### PR TITLE
Initialize repo with pre-commit and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pre-commit install
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+      - name: Run tests
+        run: pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+ENV/
+.venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pre-commit
+pytest

--- a/src/example.py
+++ b/src/example.py
@@ -1,0 +1,6 @@
+def hello(name: str) -> str:
+    return f"Hello, {name}!"
+
+
+if __name__ == "__main__":
+    print(hello("World"))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+TEST_DIR = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(TEST_DIR, ".."))
+sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,5 @@
+from src.example import hello
+
+
+def test_hello():
+    assert hello("Codex") == "Hello, Codex!"


### PR DESCRIPTION
## Summary
- add pre-commit configuration using black, flake8 and isort
- add a simple example module and unit test
- configure GitHub Actions workflow running pre-commit and pytest

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e50e2f7f0832aaf096bc89021eb0d