### PR TITLE
Add agent catalog and scaffolding

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,19 @@
+# Agent Catalog
+
+## 1. Overview
+This document lists the core agents defined in the blueprint.
+
+## 2. Directory Layout
+Each agent has a folder under `agents/` containing a `config.yml` and `prompt.tpl.md`.
+
+## 3. Core Agents
+
+| Agent | Role | Trigger | Config Path |
+|-----------------|---------------------------------------------------------|------------------------------------------|-------------------------------|
+| Supervisor | High-level strategist: builds and synthesizes graph | On user query + post-verification | `agents/Supervisor/` |
+| Planner | Optimization-based plan generator | After Supervisor LTM lookup | `agents/Planner/` |
+| WebResearcher | Academic-grade web/internet researcher | On each research sub-task node | `agents/WebResearcher/` |
+| CodeResearcher | Code analysis & sandbox execution | When `code_analysis_required` flag set | `agents/CodeResearcher/` |
+| Evaluator | Fact-checker & self-correction loop manager | After each generation or synthesis step | `agents/Evaluator/` |
+| MemoryManager | Episodic, semantic, procedural LTM operations | Post-delivery consolidation | `agents/MemoryManager/` |
+| CitationAgent | Precise source-claim matching & citation insertion | CI post-test / final report | `agents/CitationAgent/` |

--- a/agents/CitationAgent/config.yml
+++ b/agents/CitationAgent/config.yml
@@ -1,0 +1,4 @@
+agent_name: "CitationAgent"
+role: "Precise source-claim matching & citation insertion"
+max_retries: 3
+rbac: []

--- a/agents/CitationAgent/prompt.tpl.md
+++ b/agents/CitationAgent/prompt.tpl.md
@@ -1,0 +1,3 @@
+# CitationAgent Prompt
+
+Core directive: Insert precise citations by matching sources to claims.

--- a/agents/CodeResearcher/config.yml
+++ b/agents/CodeResearcher/config.yml
@@ -1,0 +1,4 @@
+agent_name: "CodeResearcher"
+role: "Code analysis & sandbox execution"
+max_retries: 3
+rbac: []

--- a/agents/CodeResearcher/prompt.tpl.md
+++ b/agents/CodeResearcher/prompt.tpl.md
@@ -1,0 +1,3 @@
+# CodeResearcher Prompt
+
+Core directive: Analyze code and execute safely in a sandbox when required.

--- a/agents/Evaluator/config.yml
+++ b/agents/Evaluator/config.yml
@@ -1,0 +1,4 @@
+agent_name: "Evaluator"
+role: "Fact-checker & self-correction loop manager"
+max_retries: 3
+rbac: []

--- a/agents/Evaluator/prompt.tpl.md
+++ b/agents/Evaluator/prompt.tpl.md
@@ -1,0 +1,3 @@
+# Evaluator Prompt
+
+Core directive: Fact-check outputs and manage the self-correction loop.

--- a/agents/MemoryManager/config.yml
+++ b/agents/MemoryManager/config.yml
@@ -1,0 +1,4 @@
+agent_name: "MemoryManager"
+role: "Episodic, semantic, procedural LTM operations"
+max_retries: 3
+rbac: []

--- a/agents/MemoryManager/prompt.tpl.md
+++ b/agents/MemoryManager/prompt.tpl.md
@@ -1,0 +1,3 @@
+# MemoryManager Prompt
+
+Core directive: Handle episodic, semantic, and procedural long-term memory.

--- a/agents/Planner/config.yml
+++ b/agents/Planner/config.yml
@@ -1,0 +1,4 @@
+agent_name: "Planner"
+role: "Optimization-based plan generator"
+max_retries: 3
+rbac: []

--- a/agents/Planner/prompt.tpl.md
+++ b/agents/Planner/prompt.tpl.md
@@ -1,0 +1,3 @@
+# Planner Prompt
+
+Core directive: Generate optimized plans after Supervisor memory lookup.

--- a/agents/Supervisor/config.yml
+++ b/agents/Supervisor/config.yml
@@ -1,0 +1,4 @@
+agent_name: "Supervisor"
+role: "High-level strategist: builds and synthesizes graph"
+max_retries: 3
+rbac: []

--- a/agents/Supervisor/prompt.tpl.md
+++ b/agents/Supervisor/prompt.tpl.md
@@ -1,0 +1,3 @@
+# Supervisor Prompt
+
+Core directive: Build and synthesize the research graph based on user queries.

--- a/agents/WebResearcher/config.yml
+++ b/agents/WebResearcher/config.yml
@@ -1,0 +1,4 @@
+agent_name: "WebResearcher"
+role: "Academic-grade web/internet researcher"
+max_retries: 3
+rbac: []

--- a/agents/WebResearcher/prompt.tpl.md
+++ b/agents/WebResearcher/prompt.tpl.md
@@ -1,0 +1,3 @@
+# WebResearcher Prompt
+
+Core directive: Perform academic-grade web research for each sub-task.


### PR DESCRIPTION
## Summary
- create main agent catalog with 7 core agents
- scaffold directories for Supervisor, Planner, WebResearcher, CodeResearcher, Evaluator, MemoryManager, and CitationAgent
- add config.yml and prompt templates for each agent

## Testing
- `pre-commit run --files agents.md agents/Supervisor/config.yml agents/Supervisor/prompt.tpl.md agents/Planner/config.yml agents/Planner/prompt.tpl.md agents/WebResearcher/config.yml agents/WebResearcher/prompt.tpl.md agents/CodeResearcher/config.yml agents/CodeResearcher/prompt.tpl.md agents/Evaluator/config.yml agents/Evaluator/prompt.tpl.md agents/MemoryManager/config.yml agents/MemoryManager/prompt.tpl.md agents/CitationAgent/config.yml agents/CitationAgent/prompt.tpl.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e54050148832a9f015c4bd8eacd59