### PR TITLE
Implement codex task queue generator

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -1,0 +1,7 @@
+- acceptance_criteria:
+  - something done
+  id: CODEX-EXAMPLE-01
+  priority: low
+  steps:
+  - do something
+  title: Example task

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,7 @@ jobs:
         run: pre-commit run --all-files
       - name: Run tests
         run: pytest -v
+      - name: Check codex queue
+        run: |
+          python scripts/codex_task_runner.py --preview > /tmp/queue.yml
+          diff -u .codex/queue.yml /tmp/queue.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+Thank you for helping improve this project! The repository uses a generated task queue located at `.codex/queue.yml`. Tasks are defined in `codex_tasks.md` using fenced code blocks tagged `codex-task`.
+
+Example block:
+
+```codex-task
+id: CODEX-EXAMPLE-02
+title: "Write docs"
+priority: medium
+steps:
+  - draft text
+acceptance_criteria:
+  - docs committed
+```
+
+To regenerate the queue file after editing `codex_tasks.md` run:
+
+```bash
+python scripts/codex_task_runner.py
+```
+
+Useful flags:
+
+- `--from <ID>` — only rebuild tasks with IDs greater than or equal to `ID`.
+- `--preview` — print the resulting YAML to stdout instead of writing to `.codex/queue.yml`.
+
+The CI pipeline verifies that the queue file matches the tasks. Ensure you run the script before opening a pull request.

--- a/codex_tasks.md
+++ b/codex_tasks.md
@@ -1,3 +1,19 @@
+# Codex Task Blocks
+
+Tasks in this file can be automatically ingested into `.codex/queue.yml`. Each task is defined in a fenced code block tagged `codex-task` and contains YAML fields.
+
+Example:
+
+```codex-task
+id: CODEX-EXAMPLE-01
+title: Example task
+priority: low
+steps:
+  - do something
+acceptance_criteria:
+  - something done
+```
+
 ## P1-01: Set up mono-repo for agentic system
 
 **Goal:** This task involves the creation of a new Git mono-repository to house all source code and related artifacts for the multi-agent system.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pre-commit
 pytest
+pyyaml

--- a/scripts/codex_task_runner.py
+++ b/scripts/codex_task_runner.py
@@ -1,0 +1,88 @@
+import argparse
+import os
+import re
+import sys
+from typing import Any, Dict, List
+
+import yaml
+
+BLOCK_RE = re.compile(r"```codex-task\n(.*?)\n```", re.DOTALL)
+REQUIRED_FIELDS = {"id", "title", "priority", "steps", "acceptance_criteria"}
+
+
+def parse_tasks(md_text: str) -> List[Dict[str, Any]]:
+    tasks = []
+    seen_ids = set()
+    for match in BLOCK_RE.findall(md_text):
+        try:
+            data = yaml.safe_load(match)
+        except Exception as e:
+            excerpt = "\n".join(match.splitlines()[:5])
+            print(f"YAML parse error in block:\n{excerpt}\n{e}", file=sys.stderr)
+            continue
+        if not isinstance(data, dict):
+            print(f"Invalid block (not a mapping): {match[:30]}", file=sys.stderr)
+            continue
+        missing = [f for f in REQUIRED_FIELDS if f not in data]
+        if missing:
+            print(f"Missing fields {missing} in task {data.get('id')}", file=sys.stderr)
+            continue
+        if data["id"] in seen_ids:
+            print(f"Duplicate ID {data['id']} found; skipping", file=sys.stderr)
+            continue
+        seen_ids.add(data["id"])
+        tasks.append(data)
+    return tasks
+
+
+def load_queue(path: str) -> List[Dict[str, Any]]:
+    if os.path.exists(path):
+        with open(path) as f:
+            data = yaml.safe_load(f) or []
+            if not isinstance(data, list):
+                print(f"Queue at {path} is not a list", file=sys.stderr)
+                return []
+            return data
+    return []
+
+
+def save_queue(path: str, tasks: List[Dict[str, Any]]):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        yaml.safe_dump(tasks, f)
+
+
+def merge_tasks(existing: List[Dict[str, Any]], new_tasks: List[Dict[str, Any]], from_id: str | None) -> List[Dict[str, Any]]:
+    id_to_index = {t["id"]: i for i, t in enumerate(existing)}
+    for t in new_tasks:
+        if from_id and t["id"] < from_id:
+            continue
+        if t["id"] in id_to_index:
+            print(f"Duplicate ID {t['id']} already in queue; skipping", file=sys.stderr)
+            continue
+        existing.append(t)
+    return existing
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate .codex/queue.yml from codex_tasks.md")
+    parser.add_argument("--from", dest="from_id", help="only process tasks with id >= given")
+    parser.add_argument("--preview", action="store_true", help="print output instead of writing")
+    args = parser.parse_args()
+
+    with open("codex_tasks.md") as f:
+        md_text = f.read()
+    tasks = parse_tasks(md_text)
+
+    queue_path = os.path.join(".codex", "queue.yml")
+    existing = load_queue(queue_path)
+    merged = merge_tasks(existing, tasks, args.from_id)
+
+    if args.preview:
+        yaml.safe_dump(merged, sys.stdout)
+    else:
+        save_queue(queue_path, merged)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document codex-task fenced blocks in `codex_tasks.md`
- add a Python script that parses these blocks and builds `.codex/queue.yml`
- check queue consistency in CI
- provide contributor instructions for regenerating the queue

## Testing
- `pre-commit run --all-files`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_684e5bf45258832abb89882fb0f16a90