### PR TITLE
Improve issue_logger reliability

### DIFF
--- a/tests/test_codex_issue_logger.py
+++ b/tests/test_codex_issue_logger.py
@@ -1,11 +1,14 @@
+import json
 import os
 from unittest import mock
+
+import requests
 
 from scripts import issue_logger
 
 
 def test_create_issue_success():
-    with mock.patch.object(issue_logger.requests, "post") as m:
+    with mock.patch.object(issue_logger.requests, "request") as m:
         m.return_value.status_code = 201
         m.return_value.json.return_value = {"html_url": "http://example.com/1"}
         with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "t"}):
@@ -13,7 +16,8 @@ def test_create_issue_success():
         assert url == "http://example.com/1"
         m.assert_called_once()
         args, kwargs = m.call_args
-        assert args[0] == "https://api.github.com/repos/u/r/issues"
+        assert args[0] == "post"
+        assert args[1] == "https://api.github.com/repos/u/r/issues"
         assert kwargs["headers"]["Authorization"] == "token t"
         assert kwargs["json"]["labels"] == ["l"]
 
@@ -21,7 +25,7 @@ def test_create_issue_success():
 def test_create_issue_no_token(capsys):
     if "GITHUB_TOKEN" in os.environ:
         del os.environ["GITHUB_TOKEN"]
-    with mock.patch.object(issue_logger.requests, "post") as m:
+    with mock.patch.object(issue_logger.requests, "request") as m:
         url = issue_logger.create_issue("t", "b", "u/r")
     assert url == ""
     assert not m.called
@@ -30,7 +34,7 @@ def test_create_issue_no_token(capsys):
 
 
 def test_post_comment_success():
-    with mock.patch.object(issue_logger.requests, "post") as m:
+    with mock.patch.object(issue_logger.requests, "request") as m:
         m.return_value.status_code = 201
         m.return_value.json.return_value = {"html_url": "http://example.com/c"}
         with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "t"}):
@@ -38,7 +42,8 @@ def test_post_comment_success():
     assert url == "http://example.com/c"
     m.assert_called_once()
     args, kwargs = m.call_args
-    assert args[0] == "http://example.com/1/comments"
+    assert args[0] == "post"
+    assert args[1] == "http://example.com/1/comments"
     assert kwargs["headers"]["Authorization"] == "token t"
 
 
@@ -46,22 +51,22 @@ def test_post_worklog_comment_create(tmp_path):
     wl_file = tmp_path / "pending.json"
     with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "t"}), mock.patch.object(
         issue_logger, "WORKLOG_PENDING_FILE", str(wl_file)
-    ), mock.patch.object(issue_logger.requests, "get") as g, mock.patch.object(
-        issue_logger.requests, "post"
-    ) as p:
-        g.return_value.status_code = 200
-        g.return_value.json.return_value = []
-        p.return_value.status_code = 201
-        p.return_value.json.return_value = {"html_url": "http://example.com/c"}
+    ), mock.patch.object(issue_logger.requests, "request") as req:
+        g_resp = mock.Mock(status_code=200)
+        g_resp.json.return_value = []
+        p_resp = mock.Mock(status_code=201)
+        p_resp.json.return_value = {"html_url": "http://example.com/c"}
+        req.side_effect = [g_resp, p_resp]
         url = issue_logger.post_worklog_comment(
             "http://example.com/issues/1", {"task_name": "t", "agent_id": "a"}
         )
     assert url == "http://example.com/c"
-    g.assert_called_once()
-    p.assert_called_once()
-    args, kwargs = p.call_args
-    assert args[0] == "http://example.com/issues/1/comments"
-    assert kwargs["headers"]["Authorization"] == "token t"
+    assert req.call_count == 2
+    call1, call2 = req.call_args_list
+    assert call1.args[0] == "get"
+    assert call2.args[0] == "post"
+    assert call2.args[1] == "http://example.com/issues/1/comments"
+    assert call2.kwargs["headers"]["Authorization"] == "token t"
 
 
 def test_post_worklog_comment_update():
@@ -71,37 +76,36 @@ def test_post_worklog_comment_update():
         "html_url": "http://example.com/c1",
     }
     with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "t"}), mock.patch.object(
-        issue_logger.requests, "get"
-    ) as g, mock.patch.object(issue_logger.requests, "patch") as patch_req:
-        g.return_value.status_code = 200
-        g.return_value.json.return_value = [existing]
-        patch_req.return_value.status_code = 200
-        patch_req.return_value.json.return_value = {"html_url": "http://example.com/c1"}
+        issue_logger.requests, "request"
+    ) as req:
+        g_resp = mock.Mock(status_code=200)
+        g_resp.json.return_value = [existing]
+        patch_resp = mock.Mock(status_code=200)
+        patch_resp.json.return_value = {"html_url": "http://example.com/c1"}
+        req.side_effect = [g_resp, patch_resp]
         url = issue_logger.post_worklog_comment(
             "http://example.com/issues/1", {"task_name": "t", "agent_id": "a"}
         )
     assert url == "http://example.com/c1"
-    g.assert_called_once()
-    patch_req.assert_called_once_with(
-        "http://example.com/comments/1",
-        headers={"Authorization": "token t"},
-        json=mock.ANY,
-        timeout=10,
-    )
+    assert req.call_count == 2
+    assert req.call_args_list[1].args[0] == "patch"
+    assert req.call_args_list[1].args[1] == "http://example.com/comments/1"
 
 
 def test_post_worklog_comment_pr_url():
     with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "t"}), mock.patch.object(
-        issue_logger.requests, "get"
-    ) as g, mock.patch.object(issue_logger.requests, "post") as p:
-        g.return_value.status_code = 200
-        g.return_value.json.return_value = []
-        p.return_value.status_code = 201
-        p.return_value.json.return_value = {"html_url": "http://example.com/c"}
+        issue_logger.requests, "request"
+    ) as req:
+        g_resp = mock.Mock(status_code=200)
+        g_resp.json.return_value = []
+        p_resp = mock.Mock(status_code=201)
+        p_resp.json.return_value = {"html_url": "http://example.com/c"}
+        req.side_effect = [g_resp, p_resp]
         issue_logger.post_worklog_comment(
             "http://example.com/pulls/2", {"task_name": "t", "agent_id": "a"}
         )
-    g.assert_called_once_with(
+    req.assert_any_call(
+        "get",
         "http://example.com/issues/2/comments",
         headers={"Authorization": "token t"},
         timeout=10,
@@ -117,3 +121,32 @@ def test_post_worklog_comment_no_token(tmp_path):
             "http://example.com/issues/1", {"task_name": "t"}
         )
     assert wl_file.exists()
+
+
+def test_request_with_retry_recovers(monkeypatch):
+    calls = []
+
+    def fake_request(method, url, timeout=10, **kwargs):
+        if not calls:
+            calls.append(True)
+            raise requests.RequestException("boom")
+        resp = mock.Mock(status_code=200)
+        return resp
+
+    monkeypatch.setattr(issue_logger.requests, "request", fake_request)
+    monkeypatch.setattr(issue_logger.time, "sleep", lambda s: None)
+
+    resp = issue_logger._request_with_retry("get", "http://x", retries=2)
+    assert resp.status_code == 200
+
+
+def test_store_pending_worklog_atomic(tmp_path):
+    wl_file = tmp_path / "pending.json"
+    with mock.patch.object(issue_logger, "WORKLOG_PENDING_FILE", str(wl_file)):
+        issue_logger._store_pending_worklog("t1", {"a": 1})
+        issue_logger._store_pending_worklog("t2", {"b": 2})
+    with open(wl_file) as f:
+        data = json.load(f)
+    assert len(data) == 2
+    assert data[0]["target"] == "t1"
+    assert data[1]["target"] == "t2"


### PR DESCRIPTION
## Summary
- add `_request_with_retry` helper and use it for GitHub calls
- write pending worklog file atomically with locking
- update tests for new retry logic and atomic writes

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7d19c450832ab074a77b0a46ac7c