### PR TITLE
Fix PYTHONPATH for validate_queue

### DIFF
--- a/scripts/validate_queue.py
+++ b/scripts/validate_queue.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 import tempfile
@@ -19,9 +20,16 @@ def main() -> int:
         )
         return 1
 
+    root = Path(__file__).resolve().parent.parent
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(root), env.get("PYTHONPATH", "")])
+
     with tempfile.NamedTemporaryFile("w+", delete=False) as tmp:
         subprocess.run(
-            [sys.executable, str(runner), "--preview"], check=True, stdout=tmp
+            [sys.executable, str(runner), "--preview"],
+            check=True,
+            stdout=tmp,
+            env=env,
         )
         tmp_path = tmp.name
 


### PR DESCRIPTION
## Summary
- ensure validate_queue.py sets PYTHONPATH when invoking codex_task_runner
- run formatting and tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `python scripts/validate_queue.py`

------
https://chatgpt.com/codex/tasks/task_e_684e808dcf24832aae4a66c0265c1b43