### PR TITLE
Add Supervisor agent skeleton

### DIFF
--- a/agents/supervisor.py
+++ b/agents/supervisor.py
@@ -1,0 +1,53 @@
+"""
+Supervisor Agent Implementation.
+This agent acts as the primary coordinator for research tasks.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class State:
+    """Simple representation of the system state."""
+
+    initial_query: str
+    plan: Optional[Dict[str, Any]] = None
+    context: List[Any] = field(default_factory=list)
+    messages: List[str] = field(default_factory=list)
+    evaluation: Optional[Dict[str, Any]] = None
+
+
+class SupervisorAgent:
+    def __init__(self, ltm_service, orchestration_engine, agent_registry=None):
+        """Initialize supervisor with memory and orchestration capabilities."""
+
+        self.ltm_service = ltm_service
+        self.orchestration_engine = orchestration_engine
+        self.agent_registry = agent_registry
+
+    def _decompose_query(self, query: str) -> List[Dict[str, Any]]:
+        """Very naive query decomposition for demonstration purposes."""
+
+        parts = [q.strip() for q in query.replace("versus", "vs").split("vs")]
+        if len(parts) <= 1:
+            return [{"topic": query}]
+        return [{"topic": p} for p in parts]
+
+    def plan_research_task(self, query: str) -> Dict[str, Any]:
+        """Decompose research query into executable subgraphs."""
+
+        past = []
+        if self.ltm_service:
+            past = self.ltm_service.retrieve(query)
+
+        tasks = self._decompose_query(query)
+
+        plan = {
+            "query": query,
+            "context": past,
+            "tasks": tasks,
+            "evaluation": {"metric": "quality"},
+        }
+
+        return plan


### PR DESCRIPTION
## Summary
- add initial SupervisorAgent implementation with simple state
- include a naive query decomposition and memory retrieval

## Testing
- `pre-commit run --files agents/supervisor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e8fd74978832ab09897385858a81d