### PR TITLE
Add minimal CI workflow

### DIFF
--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -1,0 +1,29 @@
+name: Minimal Automation
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          bash scripts/agent-setup.sh
+
+      - name: Run linters and formatters
+        run: pre-commit run --all-files
+
+      - name: Run test suite
+        run: pytest -v


### PR DESCRIPTION
## Summary
- add Minimal Automation workflow using Python 3.11

## Testing
- `pre-commit run --all-files`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_684e907f45d8832ab7acbaa58c729905