### PR TITLE
Implement automatic token auth for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -27,6 +31,10 @@ jobs:
 
   codex-sanity:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@v3

--- a/services/monitoring/system_monitor.py
+++ b/services/monitoring/system_monitor.py
@@ -12,7 +12,9 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter
 class SystemMonitor:
     """Collect system metrics and traces using OpenTelemetry."""
 
-    def __init__(self, metrics_collector: MetricReader, trace_exporter: SpanExporter) -> None:
+    def __init__(
+        self, metrics_collector: MetricReader, trace_exporter: SpanExporter
+    ) -> None:
         """Initialize monitoring with OpenTelemetry integration."""
         meter_provider = MeterProvider(metric_readers=[metrics_collector])
         metrics.set_meter_provider(meter_provider)
@@ -47,7 +49,9 @@ class SystemMonitor:
     def track_agent_performance(self, agent_id: str, task_metrics: Dict) -> None:
         """Record agent performance data for analysis."""
         attributes = {"agent_id": agent_id}
-        with self._tracer.start_as_current_span("agent_performance", attributes=attributes) as span:
+        with self._tracer.start_as_current_span(
+            "agent_performance", attributes=attributes
+        ) as span:
             time = task_metrics.get("task_completion_time")
             if time is not None:
                 self._task_time.record(time, attributes)
@@ -72,4 +76,3 @@ class SystemMonitor:
             if collab is not None:
                 self._collab_effectiveness.record(collab, attributes)
                 span.set_attribute("collaboration_effectiveness", collab)
-

--- a/tests/test_system_monitor.py
+++ b/tests/test_system_monitor.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from services.monitoring.system_monitor import SystemMonitor
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
-from opentelemetry.sdk.trace.export import SpanExportResult, SpanExporter
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+from services.monitoring.system_monitor import SystemMonitor
 
 
 class InMemorySpanExporter(SpanExporter):
@@ -48,4 +49,3 @@ def test_track_agent_performance_records_metrics_and_span():
     span = span_exporter.spans[0]
     assert span.attributes["agent_id"] == "agent1"
     assert span.attributes["task_completion_time"] == 2.0
-


### PR DESCRIPTION
## Summary
- ensure OpenTelemetry monitor formatting passes linters
- add job-level permissions for CI
- inject `${{ github.token }}` for automatic token auth

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9404c634832a98d4d8d36fb23f66