### PR TITLE
Implement central State object

### DIFF
--- a/engine/state.py
+++ b/engine/state.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class State(BaseModel):
+    """Central state passed between orchestration nodes."""
+
+    data: Dict[str, Any] = Field(default_factory=dict)
+    messages: List[Dict[str, Any]] = Field(default_factory=list)
+    status: str | None = None
+
+    def update(self, other: Dict[str, Any]) -> None:
+        """Merge arbitrary key-value pairs into ``data``."""
+        self.data.update(other)
+
+    def add_message(self, message: Dict[str, Any]) -> None:
+        """Append a message to the history."""
+        self.messages.append(message)
+
+    def to_json(self) -> str:  # pragma: no cover - thin wrapper
+        return self.model_dump_json()
+
+    @classmethod
+    def from_json(cls, payload: str) -> "State":  # pragma: no cover - thin wrapper
+        return cls.model_validate_json(payload)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pre-commit
 pytest
+pydantic
 pyyaml
 requests
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,31 @@
+from engine.orchestration_engine import OrchestrationEngine
+from engine.state import State
+
+
+def test_state_serialization_roundtrip():
+    state = State(data={"count": 1}, messages=[{"content": "hi"}], status="ok")
+    payload = state.to_json()
+    restored = State.from_json(payload)
+    assert restored == state
+
+
+def test_state_propagates_between_nodes():
+    engine = OrchestrationEngine()
+
+    def node_a(state: State) -> State:
+        state.update({"count": state.data.get("count", 0) + 1})
+        state.add_message({"content": "from_a"})
+        return state
+
+    def node_b(state: State) -> State:
+        state.update({"seen": state.data["count"]})
+        return state
+
+    engine.add_node("a", node_a)
+    engine.add_node("b", node_b)
+    engine.add_edge("a", "b")
+
+    final_state = engine.run(State())
+    assert final_state.data["count"] == 1
+    assert final_state.data["seen"] == 1
+    assert final_state.messages[-1]["content"] == "from_a"


### PR DESCRIPTION
## Summary
- add a `State` dataclass for passing data between nodes
- rework `OrchestrationEngine` to use the new state object and remove langgraph deps
- add pydantic to requirements
- test state propagation and serialization

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea34d5d98832ab4a60f839a1465b1