### PR TITLE
Add tracing schema and instrumentation

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,3 @@
 [settings]
 profile = black
-line_length = 120
+line_length = 88

--- a/codex_tasks.md
+++ b/codex_tasks.md
@@ -56,6 +56,14 @@ steps: []
 acceptance_criteria: []
 ```
 
+```codex-task
+id: P1-05
+title: Define core agent action tracing schema
+status: done
+steps: []
+acceptance_criteria: []
+```
+
 ## P1-03: Implement CD Pipeline for automated deployments
 
 **Goal:** Implement a CD pipeline that automates the deployment of all system services.
@@ -1027,6 +1035,13 @@ acceptance_criteria: []
 ```codex-task
 id: P5-01
 title: Implement System Monitoring service
+steps: []
+acceptance_criteria: []
+```
+
+```codex-task
+id: P5-02
+title: Integrate tracing schema with agents
 steps: []
 acceptance_criteria: []
 ```

--- a/docs/tracing_schema.md
+++ b/docs/tracing_schema.md
@@ -1,0 +1,27 @@
+# Agent Action Tracing Schema
+
+This document defines the standardized tracing schema used throughout the system.  All services and agents SHOULD emit spans that follow this schema so that traces are consistent and queryable.
+
+## Versioning
+
+The schema is versioned.  The current version is **1.0** and is exposed in the library `services.tracing.tracing_schema` via `SCHEMA_VERSION`.
+
+## Tool Call Span
+
+`ToolCallTrace` represents the primary span type for instrumenting tool usage.
+
+### Attributes
+
+| Attribute       | Description                          |
+| --------------- | ------------------------------------ |
+| `schema_version`| Tracing schema version identifier.   |
+| `agent_id`      | Unique identifier of the agent.      |
+| `agent_role`    | Role name of the agent.              |
+| `tool_name`     | Name of the tool invoked.            |
+| `tool_input`    | Input provided to the tool.          |
+| `tool_output`   | Output returned from the tool.       |
+| `input_tokens`  | Optional token count for the input.  |
+| `output_tokens` | Optional token count for the output. |
+| `latency_ms`    | Latency in milliseconds of the call. |
+
+Agents are encouraged to populate token counts and latency whenever possible.

--- a/services/tracing/tracing_schema.py
+++ b/services/tracing/tracing_schema.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Versioned tracing schema for agent actions."""
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from opentelemetry import trace
+
+SCHEMA_VERSION = "1.0"
+
+
+@dataclass
+class ToolCallTrace:
+    agent_id: str
+    agent_role: str
+    tool_name: str
+    tool_input: Any
+    tool_output: Any | None = None
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    latency_ms: Optional[float] = None
+
+    def record(self) -> None:
+        tracer = trace.get_tracer(__name__)
+        with tracer.start_as_current_span(
+            "tool_call",
+            attributes={
+                "schema_version": SCHEMA_VERSION,
+                "agent_id": self.agent_id,
+                "agent_role": self.agent_role,
+                "tool_name": self.tool_name,
+                "tool_input": str(self.tool_input),
+            },
+        ) as span:
+            if self.tool_output is not None:
+                span.set_attribute("tool_output", str(self.tool_output))
+            if self.input_tokens is not None:
+                span.set_attribute("input_tokens", self.input_tokens)
+            if self.output_tokens is not None:
+                span.set_attribute("output_tokens", self.output_tokens)
+            if self.latency_ms is not None:
+                span.set_attribute("latency_ms", self.latency_ms)

--- a/tests/test_tracing_schema.py
+++ b/tests/test_tracing_schema.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+
+from agents.web_researcher import WebResearcherAgent
+
+
+class InMemorySpanExporter(SpanExporter):
+    def __init__(self) -> None:
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:  # pragma: no cover - not needed
+        pass
+
+    def force_flush(
+        self, timeout_millis: int = 30_000
+    ) -> bool:  # pragma: no cover - not needed
+        return True
+
+
+def test_web_search_tool_emits_trace_span():
+    exporter = InMemorySpanExporter()
+    provider = trace.get_tracer_provider()
+    if isinstance(provider, TracerProvider):
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    def web_search(query):
+        return [{"url": "http://example.com", "title": "t"}]
+
+    registry = {
+        "web_search": web_search,
+        "summarize": lambda text: "s",
+        "pdf_extract": None,
+        "html_scraper": None,
+        "assess_source": lambda url: 1.0,
+    }
+
+    agent = WebResearcherAgent(registry)
+    agent.research_topic("q", {"agent_id": "A1"})
+
+    assert exporter.spans
+    span = exporter.spans[0]
+    assert span.attributes["agent_id"] == "A1"
+    assert span.attributes["agent_role"] == "WebResearcher"
+    assert span.attributes["tool_name"] == "web_search"
+    assert span.attributes["tool_input"] == "q"
+    assert span.attributes["tool_output"] == str(
+        [{"url": "http://example.com", "title": "t"}]
+    )


### PR DESCRIPTION
## Summary
- implement versioned `ToolCallTrace` schema
- instrument `WebResearcherAgent` with tracing
- document tracing schema
- add tests for tracing span emission
- update codex tasks
- align isort config with black

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea114e14c832aaca077c1c5d6cfb4