### PR TITLE
Implement conditional router test

### DIFF
--- a/codex_tasks.md
+++ b/codex_tasks.md
@@ -102,6 +102,21 @@ steps: []
 acceptance_criteria: []
 ```
 
+```codex-task
+id: P1-08
+title: Implement conditional edge router for dynamic workflows
+status: done
+steps: []
+acceptance_criteria: []
+```
+
+```codex-task
+id: P1-31
+title: Future orchestration engine enhancements
+steps: []
+acceptance_criteria: []
+```
+
 ## P1-05: Define core agent action tracing schema
 
 **Goal:** Define and document a standardized OpenTelemetry tracing schema that will be used across the entire system.

--- a/tests/test_orchestration_router.py
+++ b/tests/test_orchestration_router.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from engine.orchestration_engine import GraphState, create_orchestration_engine
+
+
+def test_conditional_router_executes_verifier():
+    engine = create_orchestration_engine()
+
+    def start(state: GraphState) -> GraphState:
+        state.data.setdefault("order", []).append("Start")
+        return state
+
+    def verifier(state: GraphState) -> GraphState:
+        state.data["order"].append("Verifier")
+        state.data["status"] = "approved"
+        return state
+
+    def complete(state: GraphState) -> GraphState:
+        state.data["order"].append("Complete")
+        return state
+
+    engine.add_node("Start", start)
+    engine.add_node("Verifier", verifier)
+    engine.add_node("Complete", complete)
+
+    def router(state: GraphState) -> str:
+        return (
+            "Verifier"
+            if state.data.get("status") == "requires_verification"
+            else "Complete"
+        )
+
+    engine.add_router("Start", router)
+    engine.add_edge("Verifier", "Complete")
+
+    state = GraphState(data={"status": "requires_verification"})
+
+    result = asyncio.run(engine.run_async(state))
+
+    assert result["data"]["order"] == ["Start", "Verifier", "Complete"]


### PR DESCRIPTION
## Summary
- add codex task entries for conditional router work
- test OrchestrationEngine conditional routing via status-based router

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ea3cb7010832aa40d4db371990b5c