### PR TITLE
Implement WebResearcher node

### DIFF
--- a/codex_tasks.md
+++ b/codex_tasks.md
@@ -125,6 +125,13 @@ steps: []
 acceptance_criteria: []
 ```
 
+```codex-task
+id: P1-32
+title: Extend orchestration engine state alias
+steps: []
+acceptance_criteria: []
+```
+
 ## P1-05: Define core agent action tracing schema
 
 **Goal:** Define and document a standardized OpenTelemetry tracing schema that will be used across the entire system.
@@ -246,6 +253,14 @@ acceptance_criteria: []
 - [ ] Given the 'State' object contains a sub-task for the WebResearcher to "find papers on Transformer architecture"
 - [ ] When the 'WebResearcher' node is executed
 - [ ] Then the agent calls the 'web_search' tool with a relevant query, such as "Transformer architecture academic papers"
+
+```codex-task
+id: P1-11
+title: Implement WebResearcher agent for information extraction
+status: done
+steps: []
+acceptance_criteria: []
+```
 
 ## P1-12: Implement WebResearcher's summarization capability ✅
 

--- a/engine/orchestration_engine.py
+++ b/engine/orchestration_engine.py
@@ -15,13 +15,15 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Awaitable, Callable, Dict, Iterable, Optional, Sequence
+from typing import Any, Awaitable, Callable, Dict, Iterable, Optional, Sequence
 
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.constants import CONFIG_KEY_NODE_FINISHED
-from langgraph.graph import StateGraph
 from opentelemetry import trace
-from pydantic import BaseModel, Field
+
+from engine.state import State
+
+GraphState = State
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -44,7 +46,6 @@ class Node:
                     else:
                         result = self.func(state)
                 if isinstance(result, GraphState):
-
                     return result
                 if isinstance(result, dict):
                     state.update(result)

--- a/tests/test_web_researcher.py
+++ b/tests/test_web_researcher.py
@@ -1,4 +1,5 @@
 from agents.web_researcher import WebResearcherAgent
+from engine.orchestration_engine import GraphState
 
 
 def test_research_topic_uses_tools():
@@ -41,3 +42,31 @@ def test_research_topic_uses_tools():
     assert len(result["sources"]) == 2
     assert result["confidence"] == 0.9
     assert calls["summarize"] == 2
+
+
+def test_webresearcher_node_executes_query():
+    queries: list[str] = []
+
+    def web_search(q: str):
+        queries.append(q)
+        return []
+
+    registry = {
+        "web_search": web_search,
+        "summarize": lambda text: "",
+        "pdf_extract": None,
+        "html_scraper": None,
+        "assess_source": lambda url: 1.0,
+    }
+
+    agent = WebResearcherAgent(registry)
+    state = GraphState(
+        data={"sub_task": "find papers on Transformer architecture", "agent_id": "A"}
+    )
+    result = agent(state)
+
+    assert queries, "web_search was not called"
+    q = queries[0].lower()
+    assert "transformer architecture" in q
+    assert "academic papers" in q
+    assert "research_result" in result.data


### PR DESCRIPTION
## Summary
- add GraphState alias in orchestration engine
- implement `WebResearcherAgent.__call__` for graph execution
- test WebResearcher node behavior
- document completed task and add new codex-task

## Testing
- `pre-commit run --files agents/web_researcher.py engine/orchestration_engine.py tests/test_web_researcher.py codex_tasks.md`
- `pytest -q tests/test_web_researcher.py`

------
https://chatgpt.com/codex/tasks/task_e_684ea888bc38832a8d0312da3a529d1b