### PR TITLE
Implement WebResearcher summarization

### DIFF
--- a/agents/WebResearcher/prompt.tpl.md
+++ b/agents/WebResearcher/prompt.tpl.md
@@ -1,3 +1,4 @@
 # WebResearcher Prompt
 
 Core directive: Perform academic-grade web research for each sub-task.
+After extracting information, produce a concise summary focusing only on content relevant to the given sub-task.

--- a/agents/web_researcher.py
+++ b/agents/web_researcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from typing import Any, Callable, Dict, List, Optional
 
+from engine.state import State
 from services.tracing.tracing_schema import ToolCallTrace
 
 
@@ -26,6 +27,23 @@ class WebResearcherAgent:
         self.html_scraper = self.tool_registry.get("html_scraper")
         self.summarize = self._require_tool("summarize")
         self.assess_source = self.tool_registry.get("assess_source", lambda url: 1.0)
+
+    def _summarize_for_task(self, text: str, task: str) -> str:
+        """Summarize ``text`` with focus on the current sub-task."""
+        prompt = f"Summarize the following text focusing only on information relevant to '{task}':\n{text}"
+        return self.summarize(prompt)
+
+    def summarize_to_state(
+        self, state: State, *, text_key: str = "raw_text", task_key: str = "task"
+    ) -> State:
+        """Condense ``state.data[text_key]`` and append the summary to messages."""
+        raw_text = state.data.get(text_key)
+        if not raw_text:
+            return state
+        task = state.data.get(task_key, "")
+        summary = self._summarize_for_task(raw_text, task)
+        state.add_message({"role": "WebResearcher", "content": summary})
+        return state
 
     def _require_tool(self, name: str) -> Callable[..., Any]:
         tool = self.tool_registry.get(name)
@@ -71,7 +89,7 @@ class WebResearcherAgent:
             if not content:
                 continue
 
-            summary = self.summarize(content)
+            summary = self._summarize_for_task(content, topic)
             processed.append(
                 {
                     "url": url,

--- a/codex_tasks.md
+++ b/codex_tasks.md
@@ -56,6 +56,9 @@ steps: []
 acceptance_criteria: []
 ```
 
+
+
+
 ```codex-task
 id: P1-05
 title: Define core agent action tracing schema
@@ -218,6 +221,13 @@ acceptance_criteria: []
 ```codex-task
 id: P1-09
 title: Implement Supervisor agent for query analysis
+status: done
+steps: []
+acceptance_criteria: []
+```
+```codex-task
+id: P1-12
+title: Implement WebResearcher's summarization capability
 status: done
 steps: []
 acceptance_criteria: []

--- a/tests/test_web_researcher.py
+++ b/tests/test_web_researcher.py
@@ -41,3 +41,18 @@ def test_research_topic_uses_tools():
     assert len(result["sources"]) == 2
     assert result["confidence"] == 0.9
     assert calls["summarize"] == 2
+
+
+def test_summarize_to_state_adds_message():
+    def summarize(text):
+        return "summary"
+
+    registry = {"web_search": lambda q: [], "summarize": summarize}
+    agent = WebResearcherAgent(registry)
+
+    from engine.state import State
+
+    state = State(data={"raw_text": "word " * 5000, "task": "topic"})
+    agent.summarize_to_state(state)
+
+    assert state.messages[-1]["content"] == "summary"


### PR DESCRIPTION
## Summary
- extend WebResearcher with a method to summarize raw text and store the result in state
- update the WebResearcher prompt to mention summarization focus
- register task completion in codex_tasks
- add a unit test for summary-to-state behaviour

## Testing
- `pre-commit run --all-files` *(fails: black reformatted files and flake8 missing dependencies)*
- `pytest -q` *(fails: missing packages such as requests, opentelemetry, langgraph, pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_684ea89dc8ec832aa68cabeca1e7a347