### PR TITLE
Implement Web Search tool and registry

### DIFF
--- a/engine/state.py
+++ b/engine/state.py
@@ -26,3 +26,6 @@ class State(BaseModel):
     @classmethod
     def from_json(cls, payload: str) -> "State":  # pragma: no cover - thin wrapper
         return cls.model_validate_json(payload)
+
+    def __getitem__(self, item: str):
+        return getattr(self, item)

--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Simple in-memory Tool Registry with RBAC controls."""
+
+from typing import Callable, Dict, Iterable, Optional
+
+
+class AccessDeniedError(Exception):
+    """Raised when a role tries to access an unauthorized tool."""
+
+
+class ToolRegistry:
+    def __init__(self) -> None:
+        self._tools: Dict[str, Callable[..., object]] = {}
+        self._permissions: Dict[str, set[str]] = {}
+
+    def register_tool(
+        self,
+        name: str,
+        tool: Callable[..., object],
+        *,
+        allowed_roles: Optional[Iterable[str]] = None,
+    ) -> None:
+        """Register a tool and its allowed roles."""
+        self._tools[name] = tool
+        if allowed_roles is not None:
+            self._permissions[name] = set(allowed_roles)
+        else:
+            self._permissions[name] = set()
+
+    def get_tool(self, role: str, name: str) -> Callable[..., object]:
+        """Retrieve a tool for a role if permitted."""
+        if name not in self._tools:
+            raise KeyError(name)
+        allowed = self._permissions.get(name)
+        if allowed and role not in allowed:
+            raise AccessDeniedError(f"Role '{role}' cannot access tool '{name}'")
+        return self._tools[name]

--- a/tests/test_orchestration_engine.py
+++ b/tests/test_orchestration_engine.py
@@ -1,3 +1,6 @@
+import asyncio
+import importlib
+
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -6,10 +9,7 @@ from opentelemetry.sdk.trace.export import (
     SpanExportResult,
 )
 
-import importlib
-
 from engine.orchestration_engine import GraphState, create_orchestration_engine
-import asyncio
 
 
 class InMemorySpanExporter(SpanExporter):
@@ -59,7 +59,9 @@ def test_sequential_execution_and_spans():
     assert "node:A" in span_names
     assert "node:B" in span_names
     assert any(
-        span.name == "edge" and span.attributes["from"] == "A" and span.attributes["to"] == "B"
+        span.name == "edge"
+        and span.attributes["from"] == "A"
+        and span.attributes["to"] == "B"
         for span in exporter.spans
     )
     importlib.reload(trace)

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,18 @@
+import pytest
+
+from services.tool_registry import AccessDeniedError, ToolRegistry
+
+
+def dummy_tool():
+    return "ok"
+
+
+def test_registry_authorization():
+    registry = ToolRegistry()
+    registry.register_tool("dummy", dummy_tool, allowed_roles=["WebResearcher"])
+
+    tool = registry.get_tool("WebResearcher", "dummy")
+    assert tool() == "ok"
+
+    with pytest.raises(AccessDeniedError):
+        registry.get_tool("Supervisor", "dummy")

--- a/tests/test_web_search_tool.py
+++ b/tests/test_web_search_tool.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+import tools.web_search as ws
+
+
+class DummyResponse:
+    def __init__(self, data: Any) -> None:
+        self._data = data
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> Any:
+        return self._data
+
+
+def test_web_search_parses_results(monkeypatch):
+    def fake_post(url: str, json: Any, headers: Any, timeout: int) -> DummyResponse:
+        assert json["q"] == "multi-agent systems"
+        return DummyResponse(
+            {
+                "organic": [
+                    {"link": "http://example.com", "title": "Example", "snippet": "A"}
+                ]
+            }
+        )
+
+    monkeypatch.setenv("SEARCH_API_KEY", "x")
+    monkeypatch.setattr(ws.requests, "post", fake_post)
+    results = ws.web_search("multi-agent systems")
+    assert results == [
+        {"url": "http://example.com", "title": "Example", "snippet": "A"}
+    ]

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,3 @@
+"""Tool package exposing callable wrappers for external services."""
+
+__all__ = []

--- a/tools/web_search.py
+++ b/tools/web_search.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Wrapper for an external web search API."""
+
+import os
+from typing import Dict, List, Optional
+
+import requests
+
+
+def web_search(
+    query: str, *, api_key: Optional[str] = None, top_k: int = 5
+) -> List[Dict[str, str]]:
+    """Perform a web search via a commercial API.
+
+    Parameters
+    ----------
+    query: str
+        Query string to search for.
+    api_key: str | None
+        API key for the external search service. Defaults to the ``SEARCH_API_KEY``
+        environment variable.
+    top_k: int
+        Maximum number of results to return.
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        List of search results with ``url``, ``title``, and ``snippet`` fields.
+    """
+    api_key = api_key or os.getenv("SEARCH_API_KEY")
+    if not api_key:
+        raise ValueError("Missing API key for web search")
+
+    endpoint = os.getenv("SEARCH_API_ENDPOINT", "https://api.serper.dev/search")
+    headers = {"X-API-KEY": api_key, "Content-Type": "application/json"}
+    payload = {"q": query, "num": top_k}
+    response = requests.post(endpoint, json=payload, headers=headers, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+
+    results = []
+    for item in data.get("organic", []):
+        url = item.get("link") or item.get("url")
+        title = item.get("title")
+        snippet = item.get("snippet") or item.get("snippetText")
+        if url and title:
+            results.append({"url": url, "title": title, "snippet": snippet or ""})
+    return results


### PR DESCRIPTION
## Summary
- add in-memory `ToolRegistry` with access control
- implement `web_search` wrapper for external search API
- expose tools package
- extend orchestration engine with simple execution logic
- support item access in `State` model
- add tests for tool registry and web search

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ea8d37ffc832ab76d208801ce91d2