### PR TITLE
Add LTM service API

### DIFF
--- a/services/ltm_service/__init__.py
+++ b/services/ltm_service/__init__.py
@@ -1,0 +1,11 @@
+"""Long-Term Memory service package."""
+
+from .api import LTMService, LTMServiceServer
+from .episodic_memory import EpisodicMemoryService, InMemoryStorage
+
+__all__ = [
+    "LTMService",
+    "LTMServiceServer",
+    "EpisodicMemoryService",
+    "InMemoryStorage",
+]

--- a/services/ltm_service/api.py
+++ b/services/ltm_service/api.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Dict, List
+from urllib.parse import parse_qs, urlparse
+
+from .episodic_memory import EpisodicMemoryService
+
+
+class LTMService:
+    """Coordinate access to various memory modules."""
+
+    def __init__(self, episodic_memory: EpisodicMemoryService) -> None:
+        self._modules: Dict[str, EpisodicMemoryService] = {"episodic": episodic_memory}
+
+    def consolidate(self, memory_type: str, record: Dict) -> str:
+        module = self._modules.get(memory_type)
+        if module is None:
+            raise ValueError(f"Unknown memory type: {memory_type}")
+        return module.store_experience(
+            record.get("task_context", {}),
+            record.get("execution_trace", {}),
+            record.get("outcome", {}),
+        )
+
+    def retrieve(self, memory_type: str, query: Dict, *, limit: int = 5) -> List[Dict]:
+        module = self._modules.get(memory_type)
+        if module is None:
+            raise ValueError(f"Unknown memory type: {memory_type}")
+        return module.retrieve_similar_experiences(query, limit=limit)
+
+
+class LTMServiceServer:
+    """Minimal HTTP API for the LTM service."""
+
+    def __init__(
+        self, service: LTMService, host: str = "127.0.0.1", port: int = 8081
+    ) -> None:
+        self.service = service
+        self.httpd = HTTPServer((host, port), self._handler())
+
+    def _handler(self):
+        service = self.service
+
+        class Handler(BaseHTTPRequestHandler):
+            def _json_body(self) -> Dict:
+                length = int(self.headers.get("Content-Length", 0))
+                if not length:
+                    return {}
+                data = self.rfile.read(length)
+                try:
+                    return json.loads(data)
+                except json.JSONDecodeError:
+                    return {}
+
+            def _send_json(self, status: int, payload: Dict) -> None:
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(payload).encode())
+
+            def do_POST(self) -> None:
+                parsed = urlparse(self.path)
+                if parsed.path != "/consolidate":
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                data = self._json_body()
+                record = data.get("record")
+                memory_type = data.get("memory_type", "episodic")
+                if record is None:
+                    self._send_json(400, {"error": "missing record"})
+                    return
+                try:
+                    rec_id = service.consolidate(memory_type, record)
+                except ValueError as exc:
+                    self._send_json(400, {"error": str(exc)})
+                    return
+                self._send_json(201, {"id": rec_id})
+
+            def do_GET(self) -> None:
+                parsed = urlparse(self.path)
+                if parsed.path != "/retrieve":
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                params = parse_qs(parsed.query)
+                memory_type = params.get("memory_type", ["episodic"])[0]
+                limit = int(params.get("limit", ["5"])[0])
+                data = self._json_body()
+                query = data.get("query") or data.get("task_context") or {}
+                try:
+                    results = service.retrieve(memory_type, query, limit=limit)
+                except ValueError as exc:
+                    self._send_json(400, {"error": str(exc)})
+                    return
+                self._send_json(200, {"results": results})
+
+        return Handler
+
+    def serve_forever(self) -> None:  # pragma: no cover - manual run
+        self.httpd.serve_forever()

--- a/services/tool_registry/config.yml
+++ b/services/tool_registry/config.yml
@@ -1,3 +1,6 @@
 permissions:
   WebResearcher:
     - web_search
+  MemoryManager:
+    - consolidate_memory
+    - retrieve_memory

--- a/tests/test_ltm_service_api.py
+++ b/tests/test_ltm_service_api.py
@@ -1,0 +1,58 @@
+from threading import Thread
+
+import pytest
+import requests
+
+from services.ltm_service.api import LTMService, LTMServiceServer
+from services.ltm_service.episodic_memory import EpisodicMemoryService, InMemoryStorage
+from services.tool_registry import AccessDeniedError, ToolRegistry
+from tools.ltm_client import consolidate_memory, retrieve_memory
+
+
+def _start_server() -> tuple[LTMServiceServer, str]:
+    storage = InMemoryStorage()
+    service = LTMService(EpisodicMemoryService(storage))
+    server = LTMServiceServer(service, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.httpd.server_port}"
+    return server, endpoint
+
+
+def test_consolidate_and_retrieve(monkeypatch):
+    server, endpoint = _start_server()
+    monkeypatch.setenv("LTM_SERVICE_ENDPOINT", endpoint)
+
+    record = {
+        "task_context": {"description": "Write docs"},
+        "execution_trace": {},
+        "outcome": {"success": True},
+    }
+
+    resp = requests.post(f"{endpoint}/consolidate", json={"record": record})
+    assert resp.status_code == 201
+
+    resp = requests.get(
+        f"{endpoint}/retrieve", json={"query": {"description": "Write docs"}}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["results"]
+
+    # Test via tool registry
+    registry = ToolRegistry()
+    registry.register_tool(
+        "consolidate_memory", consolidate_memory, allowed_roles=["MemoryManager"]
+    )
+    registry.register_tool(
+        "retrieve_memory", retrieve_memory, allowed_roles=["MemoryManager"]
+    )
+
+    tool = registry.get_tool("MemoryManager", "retrieve_memory")
+    consolidate_memory(record, memory_type="episodic", endpoint=endpoint)
+    results = tool(
+        {"description": "Write docs"}, memory_type="episodic", endpoint=endpoint
+    )
+    assert results
+
+    with pytest.raises(AccessDeniedError):
+        registry.get_tool("Supervisor", "retrieve_memory")

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,3 +1,8 @@
 """Tool package exposing callable wrappers for external services."""
 
-__all__ = []
+from .ltm_client import consolidate_memory, retrieve_memory
+
+__all__ = [
+    "consolidate_memory",
+    "retrieve_memory",
+]

--- a/tools/ltm_client.py
+++ b/tools/ltm_client.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional
+
+import requests
+
+
+def _endpoint(endpoint: Optional[str]) -> str:
+    return endpoint or os.getenv("LTM_SERVICE_ENDPOINT", "http://127.0.0.1:8081")
+
+
+def consolidate_memory(
+    record: Dict,
+    *,
+    memory_type: str = "episodic",
+    endpoint: Optional[str] = None,
+) -> str:
+    url = f"{_endpoint(endpoint)}/consolidate"
+    resp = requests.post(
+        url, json={"memory_type": memory_type, "record": record}, timeout=10
+    )
+    resp.raise_for_status()
+    return resp.json().get("id", "")
+
+
+def retrieve_memory(
+    query: Dict,
+    *,
+    memory_type: str = "episodic",
+    limit: int = 5,
+    endpoint: Optional[str] = None,
+) -> List[Dict]:
+    url = f"{_endpoint(endpoint)}/retrieve"
+    resp = requests.get(
+        url,
+        params={"memory_type": memory_type, "limit": str(limit)},
+        json={"query": query},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json().get("results", [])


### PR DESCRIPTION
## Summary
- implement a minimal HTTP API for the long term memory service
- expose consolidate/retrieve wrappers in tools package
- register memory tools in the Tool Registry config
- add integration tests for the new API
- clean up orchestration engine imports and constants

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eadf7e944832a97c9946a36655d3f