### PR TITLE
Improve OTel collector reliability

### DIFF
--- a/engine/orchestration_engine.py
+++ b/engine/orchestration_engine.py
@@ -22,6 +22,13 @@ from opentelemetry import trace
 from .state import State
 
 
+class InMemorySaver:
+    """Minimal in-memory checkpoint saver used until a persistent backend is implemented."""
+
+    def save(self, state: dict) -> None:  # pragma: no cover - placeholder
+        pass
+
+
 CONFIG_KEY_NODE_FINISHED = "callbacks.on_node_finished"
 
 # ``GraphState`` is currently an alias of ``State``. Future iterations may

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -5,7 +5,15 @@ receivers:
       http:
 
 processors:
+  memory_limiter:
+    limit_mib: 400
+    check_interval: 1s
   batch:
+    send_batch_size: 1024
+    timeout: 5s
+  queued_retry:
+    num_workers: 4
+    queue_size: 10000
   attributes:
     actions:
       - key: environment
@@ -22,8 +30,11 @@ exporters:
       insecure: true
 
 service:
+  telemetry:
+    metrics:
+      address: 0.0.0.0:8888
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch, attributes]
+      processors: [memory_limiter, batch, queued_retry, attributes]
       exporters: [jaeger]

--- a/tests/test_otel_collector_config.py
+++ b/tests/test_otel_collector_config.py
@@ -1,0 +1,36 @@
+import yaml
+
+
+def load_config():
+    with open("otel-collector-config.yaml", "r") as f:
+        return yaml.safe_load(f)
+
+
+def test_processors_configured():
+    config = load_config()
+    processors = config["processors"]
+    assert "memory_limiter" in processors
+    assert "batch" in processors
+    assert "queued_retry" in processors
+    assert "attributes" in processors
+    actions = processors["attributes"]["actions"]
+    env_action = next((a for a in actions if a["key"] == "environment"), None)
+    version_action = next((a for a in actions if a["key"] == "service.version"), None)
+    assert env_action == {
+        "key": "environment",
+        "value": "${ENVIRONMENT}",
+        "action": "upsert",
+    }
+    assert version_action == {
+        "key": "service.version",
+        "value": "${SERVICE_VERSION}",
+        "action": "upsert",
+    }
+
+
+def test_pipeline_uses_processors():
+    config = load_config()
+    pipeline = config["service"]["pipelines"]["traces"]
+    processors = pipeline["processors"]
+    for name in ["memory_limiter", "batch", "queued_retry", "attributes"]:
+        assert name in processors

--- a/tests/test_web_search_tool.py
+++ b/tests/test_web_search_tool.py
@@ -1,6 +1,7 @@
+import importlib
 from typing import Any
 
-import tools.web_search as ws
+ws = importlib.import_module("tools.web_search")
 
 
 class DummyResponse:

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -4,12 +4,4 @@ from .ltm_client import consolidate_memory, retrieve_memory
 from .pdf_reader import pdf_extract
 from .web_search import web_search
 
-__all__ = [
-    "consolidate_memory",
-    "retrieve_memory",
-    "web_search", 
-    "pdf_extract"
-]
-
-
-
+__all__ = ["consolidate_memory", "retrieve_memory", "web_search", "pdf_extract"]


### PR DESCRIPTION
## Summary
- add memory limiter and retry processors to `otel-collector-config.yaml`
- expose collector metrics endpoint
- verify collector settings with new tests
- fix web search tool test import
- add placeholder `InMemorySaver`

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb1b197ec832aa2d4e26fb669884a