### PR TITLE
Add DOT export test and cleanup run_async

### DIFF
--- a/engine/orchestration_engine.py
+++ b/engine/orchestration_engine.py
@@ -21,14 +21,6 @@ from opentelemetry import trace
 
 from .state import State
 
-
-class InMemorySaver:
-    """Minimal in-memory checkpoint saver used until a persistent backend is implemented."""
-
-    def save(self, state: dict) -> None:  # pragma: no cover - placeholder
-        pass
-
-
 CONFIG_KEY_NODE_FINISHED = "callbacks.on_node_finished"
 
 # ``GraphState`` is currently an alias of ``State``. Future iterations may
@@ -183,26 +175,6 @@ class OrchestrationEngine:
             else:
                 node_name = self.order.get(node_name)
         return state
-
-        if not hasattr(self, "entry") or self.entry is None:
-            self.build()
-        current = self.entry
-        while current:
-            node = self.nodes[current]
-            state = await node.run(state)
-            router_data = self.routers_map.get(current)
-            if router_data:
-                router, path_map = router_data
-                dest = router(state)
-                if path_map:
-                    dest = path_map.get(dest, dest)
-                current = dest
-            else:
-                current = self.order.get(current)
-            self._on_node_finished(node.name)
-        if isinstance(state, GraphState):
-            return state
-        return GraphState.model_validate(state.model_dump())
 
     def run(self, state: GraphState, *, thread_id: str = "default") -> GraphState:
         """Synchronous wrapper around :meth:`run_async`."""

--- a/tests/test_orchestration_engine.py
+++ b/tests/test_orchestration_engine.py
@@ -65,3 +65,26 @@ def test_sequential_execution_and_spans():
         for span in exporter.spans
     )
     importlib.reload(trace)
+
+
+def test_export_dot_outputs_valid_graph():
+    engine = create_orchestration_engine()
+
+    engine.add_node("A", lambda s: s)
+    engine.add_node("B", lambda s: s)
+    engine.add_edge("A", "B")
+
+    engine.build()
+    dot = engine.export_dot()
+
+    expected = "\n".join(
+        [
+            "digraph Orchestration {",
+            '  "A";',
+            '  "B";',
+            '  "A" -> "B";',
+            "}",
+        ]
+    )
+
+    assert dot == expected


### PR DESCRIPTION
## Summary
- remove stray InMemorySaver duplicate
- clean up `run_async` to use a single execution loop
- add regression test covering DOT export

## Testing
- `pre-commit run --files engine/orchestration_engine.py tests/test_orchestration_engine.py`
- `pytest tests/test_orchestration_engine.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb50a6a90832a898f77cd8b70d3fa