### PR TITLE
Implement immutable state history and concurrency merge

### DIFF
--- a/engine/orchestration_engine.py
+++ b/engine/orchestration_engine.py
@@ -82,10 +82,15 @@ async def parallel_subgraphs(
 
     results = await asyncio.gather(*(sg.run_async(state) for sg in subgraphs))
     merged = State(
-        data=state.data.copy(), messages=list(state.messages), status=state.status
+        data=state.data.copy(),
+        messages=list(state.messages),
+        history=list(state.history),
+        status=state.status,
     )
     for res in results:
         merged.update(res.data)
+        merged.messages.extend(res.messages)
+        merged.history.extend(res.history)
     return merged
 
 

--- a/engine/state.py
+++ b/engine/state.py
@@ -10,15 +10,18 @@ class State(BaseModel):
 
     data: Dict[str, Any] = Field(default_factory=dict)
     messages: List[Dict[str, Any]] = Field(default_factory=list)
+    history: List[Dict[str, Any]] = Field(default_factory=list)
     status: str | None = None
 
     def update(self, other: Dict[str, Any]) -> None:
-        """Merge arbitrary key-value pairs into ``data``."""
+        """Merge arbitrary key-value pairs into ``data`` and record the change."""
         self.data.update(other)
+        self.history.append({"action": "update", "data": other})
 
     def add_message(self, message: Dict[str, Any]) -> None:
-        """Append a message to the history."""
+        """Append a message and log it in ``history``."""
         self.messages.append(message)
+        self.history.append({"action": "add_message", "message": message})
 
     def to_json(self) -> str:  # pragma: no cover - thin wrapper
         return self.model_dump_json()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -9,6 +9,19 @@ def test_state_serialization_roundtrip():
     assert restored == state
 
 
+def test_state_history_and_roundtrip():
+    state = State()
+    state.update({"foo": 1})
+    state.add_message({"content": "bar"})
+    payload = state.to_json()
+    restored = State.from_json(payload)
+    assert restored == state
+    assert restored.history == [
+        {"action": "update", "data": {"foo": 1}},
+        {"action": "add_message", "message": {"content": "bar"}},
+    ]
+
+
 def test_state_propagates_between_nodes():
     engine = OrchestrationEngine()
 
@@ -29,3 +42,31 @@ def test_state_propagates_between_nodes():
     assert final_state.data["count"] == 1
     assert final_state.data["seen"] == 1
     assert final_state.messages[-1]["content"] == "from_a"
+
+
+def test_parallel_updates_preserve_history():
+    engine1 = OrchestrationEngine()
+    engine2 = OrchestrationEngine()
+
+    def node_a(state: State) -> State:
+        state.update({"a": 1})
+        state.add_message({"content": "A"})
+        return state
+
+    def node_b(state: State) -> State:
+        state.update({"b": 2})
+        state.add_message({"content": "B"})
+        return state
+
+    engine1.add_node("a", node_a)
+    engine2.add_node("b", node_b)
+
+    import asyncio
+
+    from engine.orchestration_engine import parallel_subgraphs
+
+    merged = asyncio.run(parallel_subgraphs([engine1, engine2], State()))
+
+    assert merged.data == {"a": 1, "b": 2}
+    assert any(e.get("message", {}).get("content") == "A" for e in merged.history)
+    assert any(e.get("message", {}).get("content") == "B" for e in merged.history)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -10,6 +10,5 @@ __all__ = [
     "retrieve_memory",
     "web_search",
     "html_scraper",
-    "pdf_extract"
+    "pdf_extract",
 ]
-


### PR DESCRIPTION
## Summary
- enhance `State` to track audit history
- merge message and history entries in `parallel_subgraphs`
- test append-only behavior and concurrency merging

## Testing
- `pre-commit run --files engine/state.py engine/orchestration_engine.py tests/test_state.py tools/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb630f1f8832a8689782fdaa1ebea