### PR TITLE
Add Supervisor query validation and tests

### DIFF
--- a/agents/Supervisor/prompt.tpl.md
+++ b/agents/Supervisor/prompt.tpl.md
@@ -1,3 +1,8 @@
 # Supervisor Prompt
 
-Core directive: Build and synthesize the research graph based on user queries.
+You are the Supervisor agent responsible for planning the research workflow.
+Given the user query below, output a short YAML plan describing the research
+subtopics to investigate and how results should be synthesized.
+
+Query: "{{query}}"
+

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,3 +1,5 @@
+import pytest
+
 from agents.supervisor import State, SupervisorAgent
 
 
@@ -33,3 +35,17 @@ def test_plan_contains_parallel_webresearcher_nodes():
     topics = [n.get("topic") for n in nodes if n["agent"] == "WebResearcher"]
     assert "Transformer performance" in topics
     assert "LSTM performance" in topics
+
+
+def test_invalid_query_raises_value_error():
+    agent = SupervisorAgent()
+    gs = DummyGraphState({"query": None})
+    with pytest.raises(ValueError):
+        agent(gs)
+
+
+def test_supervisor_trims_query():
+    agent = SupervisorAgent()
+    gs = DummyGraphState({"query": "  spaced query \n"})
+    result = agent(gs)
+    assert result.data["state"].initial_query == "spaced query"


### PR DESCRIPTION
## Summary
- validate query input in `SupervisorAgent.__call__`
- trim queries during analysis and parsing
- improve `_decompose_query` handling for whitespace
- expand Supervisor prompt template
- add tests for invalid and trimmed queries

## Testing
- `pre-commit run --files agents/supervisor.py tests/test_supervisor.py agents/Supervisor/prompt.tpl.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eba11fcb4832aa02316cc412724c3