### PR TITLE
Integrate LangSmith for tracing

### DIFF
--- a/engine/orchestration_engine.py
+++ b/engine/orchestration_engine.py
@@ -164,11 +164,21 @@ class OrchestrationEngine:
         if self.entry is None:
             self.build()
         self._last_node = None
+        if hasattr(self.checkpointer, "start"):
+            try:
+                self.checkpointer.start(thread_id, state)
+            except Exception:  # pragma: no cover - defensive
+                pass
 
         node_name = self.entry
         while node_name:
             node = self.nodes[node_name]
             state = await node.run(state)
+            if hasattr(self.checkpointer, "save"):
+                try:
+                    self.checkpointer.save(thread_id, node_name, state)
+                except Exception:  # pragma: no cover - defensive
+                    pass
             self._on_node_finished(node_name)
 
             if node_name in self.routers_map:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ beautifulsoup4
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-otlp
+langchain
+langgraph
+langsmith

--- a/scripts/agent-setup.sh
+++ b/scripts/agent-setup.sh
@@ -7,3 +7,7 @@ pip install -r requirements.txt
 
 # Install pre-commit hooks
 pre-commit install
+
+# Enable LangSmith tracing by default
+export LANGCHAIN_TRACING_V2="${LANGCHAIN_TRACING_V2:-true}"
+export LANGCHAIN_PROJECT="${LANGCHAIN_PROJECT:-agentic-research-engine}"

--- a/scripts/import_browsecomp_dataset.py
+++ b/scripts/import_browsecomp_dataset.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""Import the BrowseComp dataset into LangSmith."""
+from services.tracing.langsmith_integration import configure_langsmith, import_dataset
+
+
+def main() -> None:
+    configure_langsmith("agentic-research-engine")
+    import_dataset("benchmarks/browsecomp/dataset_v1.json", "BrowseComp")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/tracing/langsmith_integration.py
+++ b/services/tracing/langsmith_integration.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Utilities for integrating with LangSmith tracing and datasets."""
+
+import json
+import os
+from typing import Any
+
+from langsmith import Client
+
+
+def configure_langsmith(project_name: str) -> None:
+    """Set environment variables for LangSmith tracing."""
+    os.environ.setdefault("LANGCHAIN_TRACING_V2", "true")
+    os.environ.setdefault("LANGCHAIN_PROJECT", project_name)
+
+
+class LangSmithCheckpointer:
+    """Simple checkpointer that logs state transitions to LangSmith."""
+
+    def __init__(self, client: Client, project_name: str = "default") -> None:
+        self.client = client
+        self.project_name = project_name
+
+    def start(self, run_id: str, state: Any) -> None:  # pragma: no cover - thin wrapper
+        self.client.create_run(
+            id=run_id,
+            name="graph",
+            inputs=getattr(state, "data", {}),
+            run_type="chain",
+            project_name=self.project_name,
+        )
+
+    def save(
+        self, run_id: str, node: str, state: Any
+    ) -> None:  # pragma: no cover - thin wrapper
+        self.client.create_run(
+            id=f"{run_id}-{node}",
+            parent_run_id=run_id,
+            name=node,
+            inputs=getattr(state, "data", {}),
+            run_type="tool",
+            project_name=self.project_name,
+        )
+
+
+def import_dataset(path: str, dataset_name: str, client: Client | None = None) -> None:
+    """Import a JSON QA dataset into LangSmith if it does not exist."""
+    client = client or Client()
+    if client.has_dataset(dataset_name=dataset_name):
+        return
+    dataset = client.create_dataset(dataset_name)
+    with open(path, "r", encoding="utf-8") as f:
+        cases = json.load(f)
+    for case in cases:
+        client.create_example(
+            inputs={"question": case.get("question", "")},
+            outputs={"answer": case.get("answer", "")},
+            dataset_id=dataset.id,
+        )

--- a/tests/test_langsmith_integration.py
+++ b/tests/test_langsmith_integration.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from engine.orchestration_engine import GraphState, create_orchestration_engine
+from services.tracing.langsmith_integration import LangSmithCheckpointer, import_dataset
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.datasets = {}
+        self.examples = []
+        self.runs = []
+
+    # dataset methods
+    def has_dataset(self, dataset_name: str) -> bool:
+        return dataset_name in self.datasets
+
+    def create_dataset(self, dataset_name: str):
+        self.datasets[dataset_name] = {"id": dataset_name}
+        return type("DS", (), {"id": dataset_name})
+
+    def create_example(self, *, inputs, outputs, dataset_id):
+        self.examples.append((dataset_id, inputs, outputs))
+
+    # run methods
+    def create_run(self, name, inputs, run_type, **kwargs):
+        self.runs.append({"name": name, "inputs": inputs, "kwargs": kwargs})
+
+
+def test_import_dataset_creates_examples(tmp_path):
+    client = DummyClient()
+    import_dataset("benchmarks/browsecomp/dataset_v1.json", "TestSet", client)
+    assert "TestSet" in client.datasets
+    assert client.examples
+
+
+def test_orchestration_checkpointer_logs_runs():
+    client = DummyClient()
+    cp = LangSmithCheckpointer(client, project_name="p")
+
+    engine = create_orchestration_engine()
+    engine.checkpointer = cp
+    engine.add_node("A", lambda s: s)
+
+    asyncio.run(engine.run_async(GraphState(), thread_id="t"))
+    assert any(r["name"] == "A" for r in client.runs)


### PR DESCRIPTION
## Summary
- add LangSmith integration utilities
- hook OrchestrationEngine to use a checkpointer
- provide dataset import script for BrowseComp
- update environment setup for tracing
- add dependency requirements and tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb879f988832a98aae2f71626fba0