### PR TITLE
Add plan YAML validation for Supervisor

### DIFF
--- a/agents/Supervisor/prompt.tpl.md
+++ b/agents/Supervisor/prompt.tpl.md
@@ -1,8 +1,11 @@
 # Supervisor Prompt
 
 You are the Supervisor agent responsible for planning the research workflow.
-Given the user query below, output a short YAML plan describing the research
+Given the user query below, output a YAML plan describing the research
 subtopics to investigate and how results should be synthesized.
+The YAML **must** contain a top-level `graph` mapping with `nodes` and `edges`
+lists. Each node requires an `id` and `agent` field. Ensure the YAML parses
+correctly with no additional commentary.
 
 Query: "{{query}}"
 

--- a/agents/supervisor.py
+++ b/agents/supervisor.py
@@ -6,6 +6,8 @@ This agent acts as the primary coordinator for research tasks.
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+import yaml
+
 
 @dataclass
 class State:
@@ -76,6 +78,28 @@ class SupervisorAgent:
         }
 
         return plan
+
+    # ------------------------------------------------------------------
+    # YAML helpers
+    # ------------------------------------------------------------------
+    def format_plan_as_yaml(self, plan: Dict[str, Any]) -> str:
+        """Serialize plan dictionary to YAML string."""
+
+        return yaml.safe_dump(plan, sort_keys=False)
+
+    def parse_plan(self, plan_text: str) -> Dict[str, Any]:
+        """Parse YAML plan text and validate expected structure."""
+
+        try:
+            data = yaml.safe_load(plan_text) or {}
+        except yaml.YAMLError as exc:
+            raise ValueError("invalid plan format") from exc
+        if not isinstance(data, dict) or "graph" not in data:
+            raise ValueError("invalid plan format")
+        graph = data.get("graph", {})
+        if not isinstance(graph, dict) or "nodes" not in graph or "edges" not in graph:
+            raise ValueError("invalid graph definition")
+        return data
 
     def analyze_query(self, query: str) -> State:
         """Perform initial analysis and create the workflow state."""

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -49,3 +49,19 @@ def test_supervisor_trims_query():
     gs = DummyGraphState({"query": "  spaced query \n"})
     result = agent(gs)
     assert result.data["state"].initial_query == "spaced query"
+
+
+def test_plan_yaml_roundtrip():
+    agent = SupervisorAgent()
+    plan = agent.plan_research_task(
+        "Compare Transformer and LSTM for NLP tasks with accuracy metrics"
+    )
+    yaml_text = agent.format_plan_as_yaml(plan)
+    parsed = agent.parse_plan(yaml_text)
+    assert parsed == plan
+
+
+def test_parse_plan_invalid_yaml_raises():
+    agent = SupervisorAgent()
+    with pytest.raises(ValueError):
+        agent.parse_plan("not: [valid")


### PR DESCRIPTION
## Summary
- refine Supervisor prompt for YAML graph structure
- add YAML formatting and parsing helpers to SupervisorAgent
- test plan YAML roundtrip and error handling

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ebba0c15c832aaf0df5e1d223ca56