### PR TITLE
Implement P2-19 tool registry enhancements

### DIFF
--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Callable, Dict, Iterable, Optional
 
+import yaml
+
 
 class AccessDeniedError(Exception):
     """Raised when a role tries to access an unauthorized tool."""
@@ -36,3 +38,9 @@ class ToolRegistry:
         if allowed and role not in allowed:
             raise AccessDeniedError(f"Role '{role}' cannot access tool '{name}'")
         return self._tools[name]
+
+    def load_permissions(self, path: str) -> None:
+        """Load role permissions from a YAML config."""
+        data = yaml.safe_load(open(path)) or {}
+        perms = data.get("permissions", {})
+        self._permissions = {tool: set(roles or []) for tool, roles in perms.items()}

--- a/services/tool_registry/config.yml
+++ b/services/tool_registry/config.yml
@@ -1,9 +1,12 @@
 permissions:
-  WebResearcher:
-    - web_search
-    - pdf_extract
-    - html_scraper
-  MemoryManager:
-    - consolidate_memory
-    - retrieve_memory
+  web_search:
+    - WebResearcher
+  pdf_extract:
+    - WebResearcher
+  html_scraper:
+    - WebResearcher
+  consolidate_memory:
+    - MemoryManager
+  retrieve_memory:
+    - MemoryManager
 

--- a/services/tool_registry/registry.py
+++ b/services/tool_registry/registry.py
@@ -2,40 +2,9 @@ from __future__ import annotations
 
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Callable, Dict
 from urllib.parse import parse_qs, urlparse
 
-import yaml
-
-
-class AccessDeniedError(Exception):
-    """Raised when an agent lacks permission for a tool."""
-
-
-class ToolRegistry:
-    """Central registry mapping tools to agent permissions."""
-
-    def __init__(self, permissions_path: str | None = None) -> None:
-        self._tools: Dict[str, Callable] = {}
-        self.permissions: Dict[str, list[str]] = {}
-        if permissions_path:
-            self.load_permissions(permissions_path)
-
-    def load_permissions(self, path: str) -> None:
-        data = yaml.safe_load(open(path)) or {}
-        self.permissions = data.get("permissions", {})
-
-    def register_tool(self, name: str, func: Callable) -> None:
-        self._tools[name] = func
-
-    def get_tool(self, agent_role: str, tool_name: str) -> Callable:
-        allowed = self.permissions.get(agent_role, [])
-        if tool_name not in allowed:
-            raise AccessDeniedError(f"{agent_role} cannot access {tool_name}")
-        try:
-            return self._tools[tool_name]
-        except KeyError as exc:
-            raise KeyError(f"Tool not found: {tool_name}") from exc
+from . import AccessDeniedError, ToolRegistry
 
 
 class ToolRegistryServer:

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,6 +1,10 @@
+from threading import Thread
+
 import pytest
+import requests
 
 from services.tool_registry import AccessDeniedError, ToolRegistry
+from services.tool_registry.registry import ToolRegistryServer
 
 
 def dummy_tool():
@@ -16,3 +20,31 @@ def test_registry_authorization():
 
     with pytest.raises(AccessDeniedError):
         registry.get_tool("Supervisor", "dummy")
+
+
+def test_registry_server_permissions(tmp_path):
+    config = tmp_path / "config.yml"
+    config.write_text("permissions:\n  dummy:\n    - WebResearcher\n")
+
+    registry = ToolRegistry()
+    registry.register_tool("dummy", dummy_tool)
+    registry.load_permissions(str(config))
+    server = ToolRegistryServer(registry, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.httpd.server_port}"
+    try:
+        resp = requests.get(
+            f"{endpoint}/tool", params={"agent": "WebResearcher", "name": "dummy"}
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"tool": "dummy"}
+
+        resp = requests.get(
+            f"{endpoint}/tool", params={"agent": "Supervisor", "name": "dummy"}
+        )
+        assert resp.status_code == 403
+        assert "cannot access" in resp.json()["error"]
+    finally:
+        server.httpd.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- restructure `tool_registry/config.yml` to map tools to roles
- allow `ToolRegistry` to load permissions from YAML
- remove duplicate `ToolRegistry` implementation from registry server
- test ToolRegistry HTTP server for permission enforcement

## Testing
- `pre-commit run --files services/tool_registry/config.yml services/tool_registry/__init__.py services/tool_registry/registry.py tests/test_tool_registry.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ec00d13ac832ab03f1b1a613d9c2b