### PR TITLE
Enforce coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,12 @@ jobs:
       - name: Setup environment
         run: bash scripts/agent-setup.sh
       - name: Run tests
-        run: pytest -v
+        run: pytest --cov=./ --cov-report=xml --cov-fail-under=80 -v
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage.xml
       - name: Check codex queue
         run: python scripts/validate_queue.py
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # **agentic-research-engine: A Self-Improving Multi-Agent Research System**
 
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/actions)
-[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://codecov.io)
+[![Coverage](https://img.shields.io/badge/coverage-86%25-brightgreen)](https://codecov.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 ## **1. Vision & Mission**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pre-commit
 pytest
+pytest-cov
 pydantic
 pyyaml
 requests


### PR DESCRIPTION
## Summary
- fail tests if coverage <80% and upload artifact
- add pytest-cov dependency
- update coverage badge in README

## Testing
- `pre-commit run --all-files`
- `pytest --cov=./ --cov-report=xml --cov-fail-under=80 -q`


------
https://chatgpt.com/codex/tasks/task_e_684ec85c9f10832aad7006dc3b021799