### PR TITLE
Fix CI artifact action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run tests
         run: pytest --cov=./ --cov-report=xml --cov-fail-under=80 -v
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml


### PR DESCRIPTION
## Summary
- use `actions/upload-artifact@v4` in the CI workflow

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecb661f1c832a8a1aadd4fcf8319e