### PR TITLE
Add OCR fallback for PDF reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ The full system benchmark (P1-18), which evaluates end-to-end research capabilit
 poetry run python -m tests.run_benchmark --benchmark=browsecomp_v1
 ```
 
+### **PDF Reader Tool**
+
+The `pdf_extract` helper under `tools/` retrieves text from PDF files or URLs.
+If the pages contain only images, the function can perform OCR using
+`pytesseract`. Enable this fallback by passing ``use_ocr=True`` or setting the
+``PDF_READER_ENABLE_OCR`` environment variable to ``true``. OCR requires the
+Tesseract binary to be installed and accessible on the system.
+
 ## **7. Continuous Deployment**
 
 All services are deployed via an automated CD pipeline defined in `.github/workflows/cd.yml`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ pydantic
 pyyaml
 requests
 pdfplumber
+pytesseract
+Pillow
 beautifulsoup4
 readability-lxml
 

--- a/tools/pdf_reader.py
+++ b/tools/pdf_reader.py
@@ -8,14 +8,25 @@ from urllib.parse import urlparse
 
 import pdfplumber
 import requests
+from pdfminer.pdfparser import PDFSyntaxError
+from pdfplumber.utils.exceptions import PdfminerException
 
 
-def pdf_extract(path_or_url: str, *, timeout: int = 10, use_ocr: bool = False) -> str:
+def pdf_extract(
+    path_or_url: str, *, timeout: int = 10, use_ocr: bool | None = None
+) -> str:
     """Return the text content of a PDF from ``path_or_url``.
 
     If ``use_ocr`` is ``True`` and no text is extractable, an OCR attempt will be
-    made using ``pytesseract`` if available.
+    made using ``pytesseract`` if available. If ``use_ocr`` is ``None``, the
+    ``PDF_READER_ENABLE_OCR`` environment variable controls the fallback.
     """
+    if use_ocr is None:
+        use_ocr = os.getenv("PDF_READER_ENABLE_OCR", "false").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
     parsed = urlparse(path_or_url)
     if parsed.scheme in {"http", "https"}:
         try:
@@ -29,20 +40,25 @@ def pdf_extract(path_or_url: str, *, timeout: int = 10, use_ocr: bool = False) -
             raise FileNotFoundError(path_or_url)
         file_obj = path_or_url
 
-    with pdfplumber.open(file_obj) as pdf:
-        text_parts = []
-        for page in pdf.pages:
-            page_text = page.extract_text() or ""
-            if not page_text.strip() and use_ocr:
-                try:  # pragma: no cover - optional OCR path
-                    import pytesseract
+    try:
+        with pdfplumber.open(file_obj) as pdf:
+            text_parts = []
+            for page in pdf.pages:
+                page_text = page.extract_text() or ""
+                if not page_text.strip() and use_ocr:
+                    try:  # pragma: no cover - optional OCR path
+                        import pytesseract
 
-                    img = page.to_image(resolution=300).original
-                    page_text = pytesseract.image_to_string(img)
-                except Exception as exc:  # pragma: no cover - OCR failures
-                    raise ValueError(f"OCR extraction failed: {exc}") from exc
-            text_parts.append(page_text)
-        text = "\n".join(text_parts)
+                        img = page.to_image(resolution=300).original
+                        page_text = pytesseract.image_to_string(img)
+                    except Exception as exc:  # pragma: no cover - OCR failures
+                        raise ValueError(f"OCR extraction failed: {exc}") from exc
+                text_parts.append(page_text)
+            text = "\n".join(text_parts)
+    except (PDFSyntaxError, PdfminerException) as exc:
+        raise ValueError(f"Invalid PDF: {exc}") from exc
+    except Exception as exc:  # pragma: no cover - parsing errors
+        raise ValueError(f"Failed to parse PDF: {exc}") from exc
 
     if not text.strip():
         msg = "No extractable text found in PDF"


### PR DESCRIPTION
## Summary
- improve `pdf_extract` to handle malformed PDFs and optional OCR fallback
- add PIL-based helper for scanned PDF tests
- test OCR path, invalid PDF, and network errors
- document OCR support and add pillow/pytesseract dependencies

## Testing
- `pre-commit run --files tools/pdf_reader.py tests/test_pdf_reader_tool.py README.md requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ec9d57084832aa5d1850e674fe79a