### PR TITLE
Implement Supervisor plan schema validation

### DIFF
--- a/docs/supervisor_plan_schema.yaml
+++ b/docs/supervisor_plan_schema.yaml
@@ -1,0 +1,58 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: Supervisor Plan
+type: object
+required:
+  - query
+  - context
+  - graph
+  - evaluation
+properties:
+  query:
+    type: string
+  context:
+    type: array
+  graph:
+    type: object
+    required:
+      - nodes
+      - edges
+    properties:
+      nodes:
+        type: array
+        items:
+          type: object
+          required:
+            - id
+            - agent
+          properties:
+            id:
+              type: string
+            agent:
+              type: string
+            topic:
+              type: string
+            task:
+              type: string
+      edges:
+        type: array
+        items:
+          type: object
+          required:
+            - from
+            - to
+          properties:
+            from:
+              type: string
+            to:
+              type: string
+      parallel_groups:
+        type: array
+        items:
+          type: array
+          items:
+            type: string
+  evaluation:
+    type: object
+    properties:
+      metric:
+        type: string

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pytesseract
 Pillow
 beautifulsoup4
 readability-lxml
+jsonschema
 
 opentelemetry-api
 opentelemetry-sdk

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -65,3 +65,26 @@ def test_parse_plan_invalid_yaml_raises():
     agent = SupervisorAgent()
     with pytest.raises(ValueError):
         agent.parse_plan("not: [valid")
+
+
+def test_parse_plan_schema_violation_raises():
+    agent = SupervisorAgent()
+    bad_yaml = """
+    query: q
+    context: []
+    graph:
+      nodes:
+        - id: n1
+          agent: WebResearcher
+    evaluation:
+      metric: quality
+    """
+    with pytest.raises(ValueError):
+        agent.parse_plan(bad_yaml)
+
+
+def test_plan_research_task_produces_valid_plan():
+    agent = SupervisorAgent()
+    plan = agent.plan_research_task("What is AI?")
+    # should not raise
+    agent.validate_plan(plan)


### PR DESCRIPTION
## Summary
- add Supervisor plan schema docs
- add jsonschema dependency
- validate Supervisor plans with the schema
- test schema validation logic

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eccca0a60832a946547d54baa53b2