### PR TITLE
Provision vector database IaC

### DIFF
--- a/infra/episodic_vector_db/README.md
+++ b/infra/episodic_vector_db/README.md
@@ -1,0 +1,21 @@
+# Episodic Vector Database
+
+This directory contains Terraform configuration for deploying a Qdrant vector database to power the Episodic Memory service. The setup relies on the Helm provider so that the database can be installed in any Kubernetes cluster using a single `terraform apply`.
+
+## Prerequisites
+- A reachable Kubernetes cluster
+- `terraform` (>= 1.0)
+- Access credentials and kubeconfig path supplied via variables
+
+## Usage
+Run the following commands, supplying sensitive values via environment variables or `-var` flags:
+
+```bash
+terraform init
+terraform apply \
+  -var="kubeconfig=$KUBECONFIG" \
+  -var="namespace=ltm" \
+  -var="api_key=$(SECRET_API_KEY)"
+```
+
+The `api_key` variable is marked as sensitive so it is never written to generated manifests. The service endpoint will be output after apply as `episodic-vector-db.<namespace>.svc.cluster.local:6333`.

--- a/infra/episodic_vector_db/main.tf
+++ b/infra/episodic_vector_db/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_version = ">= 1.0.0"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig
+  }
+}
+
+resource "helm_release" "episodic_vector_db" {
+  name       = "episodic-vector-db"
+  namespace  = var.namespace
+  repository = "https://qdrant.github.io/qdrant-helm"
+  chart      = "qdrant"
+  version    = var.qdrant_version
+
+  set_sensitive {
+    name  = "apiKey"
+    value = var.api_key
+  }
+
+  values = [
+    yamlencode({
+      persistence = {
+        enabled = true
+        size    = "20Gi"
+      }
+    })
+  ]
+}
+
+output "endpoint" {
+  value = "http://episodic-vector-db.${var.namespace}.svc.cluster.local:6333"
+}

--- a/infra/episodic_vector_db/variables.tf
+++ b/infra/episodic_vector_db/variables.tf
@@ -1,0 +1,22 @@
+variable "kubeconfig" {
+  description = "Path to kubeconfig"
+  type        = string
+}
+
+variable "namespace" {
+  description = "Target namespace for the vector database"
+  type        = string
+  default     = "ltm"
+}
+
+variable "qdrant_version" {
+  description = "Helm chart version to deploy"
+  type        = string
+  default     = "0.6.2"
+}
+
+variable "api_key" {
+  description = "Admin API key for qdrant"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- add Terraform module for Qdrant vector DB
- document setup for episodic vector database

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ed07bd5e8832ab5e96784a74a60e8