### PR TITLE
Implement MemoryManager trigger

### DIFF
--- a/agents/memory_manager.py
+++ b/agents/memory_manager.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from engine.state import State
+from tools.ltm_client import consolidate_memory
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryManagerAgent:
+    """Agent responsible for consolidating task episodes into LTM."""
+
+    def __init__(self, *, endpoint: Optional[str] = None) -> None:
+        self.endpoint = endpoint
+
+    def _format_record(self, state: State) -> Dict[str, Any]:
+        return {
+            "task_context": state.data,
+            "execution_trace": {"messages": state.messages, "history": state.history},
+            "outcome": {"status": state.status},
+        }
+
+    def __call__(self, state: State) -> State:
+        record = self._format_record(state)
+        try:
+            consolidate_memory(record, endpoint=self.endpoint)
+        except Exception:  # pragma: no cover - log only
+            logger.exception("Failed to consolidate memory")
+        return state

--- a/tests/test_memory_manager_trigger.py
+++ b/tests/test_memory_manager_trigger.py
@@ -1,0 +1,33 @@
+import asyncio
+from threading import Thread
+
+from agents.memory_manager import MemoryManagerAgent
+from engine.orchestration_engine import GraphState, create_orchestration_engine
+from services.ltm_service import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.api import LTMService, LTMServiceServer
+
+
+def _start_server():
+    storage = InMemoryStorage()
+    service = LTMService(EpisodicMemoryService(storage))
+    server = LTMServiceServer(service, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.httpd.server_port}"
+    return server, endpoint
+
+
+def test_memory_manager_invoked_after_graph():
+    server, endpoint = _start_server()
+    mm = MemoryManagerAgent(endpoint=endpoint)
+
+    engine = create_orchestration_engine(memory_manager=mm)
+    engine.add_node("A", lambda s: s)
+
+    state = GraphState(data={"query": "Write docs"})
+    asyncio.run(engine.run_async(state))
+
+    # memory should be stored via the HTTP service
+    mem = server.service.retrieve("episodic", {"query": "Write docs"})
+    assert mem
+    server.httpd.shutdown()


### PR DESCRIPTION
## Summary
- add `MemoryManagerAgent` for episodic consolidation
- invoke optional callback after graph execution
- support providing a memory manager via `create_orchestration_engine`
- test that graphs trigger memory consolidation

## Testing
- `pre-commit run --files agents/memory_manager.py engine/orchestration_engine.py tests/test_memory_manager_trigger.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ed366bba4832a8ff7d187a6521ce4