### PR TITLE
Fix minimal CI workflow indentation

### DIFF
--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -11,9 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-  env:
-    GITHUB_TOKEN: ${{ github.token }}
-
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Summary
- fix `minimal-ci.yml` by indenting `env` and `steps` correctly

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed4c26b9c832abb26694931176c8d