### PR TITLE
Enhance supervisor with LTM retrieval

### DIFF
--- a/agents/Supervisor/prompt.tpl.md
+++ b/agents/Supervisor/prompt.tpl.md
@@ -1,11 +1,17 @@
 # Supervisor Prompt
 
 You are the Supervisor agent responsible for planning the research workflow.
+Step 0: Query the episodic LTM service for past tasks related to the user's request.
+Use up to {{limit}} of the most relevant memories as inspiration for the plan.
+If nothing is returned, note "No relevant past memories; generating plan from scratch.".
 Given the user query below, output a YAML plan describing the research
 subtopics to investigate and how results should be synthesized.
 The YAML **must** contain a top-level `graph` mapping with `nodes` and `edges`
 lists. Each node requires an `id` and `agent` field. Ensure the YAML parses
 correctly with no additional commentary.
+
+Using retrieved memories:
+{{memory_context}}
 
 Query: "{{query}}"
 


### PR DESCRIPTION
## Summary
- query episodic LTM before the Supervisor plans
- extend Supervisor prompt with instructions and memory context
- test LTM integration for Supervisor

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed589aac0832aa5a76bb4d27b78ee