### PR TITLE
Add LTM forgetting research and benchmark

### DIFF
--- a/benchmarks/ltm_pruning_benchmark.py
+++ b/benchmarks/ltm_pruning_benchmark.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import random
+import time
+from typing import Callable, Dict, List
+
+Record = Dict[str, float | int | bool]
+
+
+def generate_data(n: int = 200, seed: int = 42) -> List[Record]:
+    """Create synthetic memory records with timestamps, relevance, and usage flag."""
+    random.seed(seed)
+    now = 1000
+    data: List[Record] = []
+    for i in range(n):
+        timestamp = now - random.randint(0, 1000)
+        relevance = random.random()
+        used = random.random() < 0.2
+        data.append(
+            {"id": i, "timestamp": timestamp, "relevance": relevance, "used": used}
+        )
+    return data
+
+
+def recency_prune(records: List[Record], max_age: int = 300) -> List[Record]:
+    cutoff = max(r["timestamp"] for r in records) - max_age
+    return [r for r in records if r["timestamp"] >= cutoff]
+
+
+def relevance_prune(records: List[Record], threshold: float = 0.5) -> List[Record]:
+    return [r for r in records if r["relevance"] >= threshold]
+
+
+def hybrid_prune(
+    records: List[Record], max_age: int = 300, threshold: float = 0.5
+) -> List[Record]:
+    cutoff = max(r["timestamp"] for r in records) - max_age
+    return [
+        r for r in records if r["relevance"] >= threshold or r["timestamp"] >= cutoff
+    ]
+
+
+def evaluate(records: List[Record], strategy: Callable[[List[Record]], List[Record]]):
+    start = time.perf_counter()
+    pruned = strategy(records)
+    latency = time.perf_counter() - start
+    total_used = sum(1 for r in records if r["used"])
+    kept_used = sum(1 for r in pruned if r["used"])
+    recall = kept_used / total_used if total_used else 1.0
+    return len(pruned), latency, recall
+
+
+if __name__ == "__main__":
+    records = generate_data()
+    strategies = {
+        "recency": lambda rs: recency_prune(rs, max_age=300),
+        "relevance": lambda rs: relevance_prune(rs, threshold=0.5),
+        "hybrid": lambda rs: hybrid_prune(rs, max_age=300, threshold=0.5),
+    }
+    total = len(records)
+    for name, strat in strategies.items():
+        size, latency, recall = evaluate(records, strat)
+        print(
+            f"{name}: remaining {size}/{total} items, latency={latency*1000:.2f}ms, recall={recall:.2f}"
+        )

--- a/docs/LTM_P2-19A_Forgetting_Research.md
+++ b/docs/LTM_P2-19A_Forgetting_Research.md
@@ -1,0 +1,44 @@
+# Long-Term Memory Consolidation & Forgetting Research (P2-19A)
+
+This document summarizes a research spike into lifecycle management algorithms for the Long-Term Memory (LTM) service. The goal was to compare advanced forgetting strategies and recommend an approach for Phase 2 implementation.
+
+## Candidate Algorithms
+
+### 1. Selective Consolidation (Quality/Novelty)
+- Inspired by hippocampal replay and RL prioritized experience replay.
+- Memories are scored by novelty or confidence and only high-salience events are stored.
+- **Pros:** Efficient storage, good at filtering noise.
+- **Cons:** Requires reliable novelty metrics and may miss subtle but important facts.
+
+### 2. Hybrid Time-Decay + Relevance
+- Each memory's weight decays over time but can be refreshed when reused.
+- Combines recency heuristics (LRU style) with a relevance score so that rarely accessed yet important facts persist longer.
+- **Pros:** Simple to implement and tunable for different workloads.
+- **Cons:** Needs careful threshold tuning; aggressive decay can drop useful context.
+
+### 3. Value-Driven Forgetting
+- Retention is tied to future utility or reward (e.g. TD‑error or user feedback).
+- Low-value experiences are pruned to focus on memories that drive task success.
+- **Pros:** Aligns storage with agent goals and can improve performance under constraints.
+- **Cons:** Depends on accurate value estimates and introduces computational overhead.
+
+## Proof-of-Concept Benchmark
+
+A small benchmark (`benchmarks/ltm_pruning_benchmark.py`) simulates 200 memory records with timestamps, relevance scores and usage flags. Three pruning strategies were evaluated:
+
+```
+$ python benchmarks/ltm_pruning_benchmark.py
+recency: remaining 66/200 items, latency=0.03ms, recall=0.28
+relevance: remaining 102/200 items, latency=0.01ms, recall=0.53
+hybrid: remaining 135/200 items, latency=0.03ms, recall=0.66
+```
+
+- **recency** removes the oldest items beyond a fixed age threshold.
+- **relevance** keeps records with relevance >= 0.5.
+- **hybrid** retains items if they are recent or above the relevance threshold.
+
+The hybrid approach preserved the most relevant memories (66% recall on the synthetic dataset) while still reducing storage by ~32%, suggesting a balanced trade‑off between footprint and recall.
+
+## Recommendation
+
+Based on the literature review and the benchmark results, a **hybrid time‑decay with relevance scoring** is recommended for the initial forgetting mechanism. This strategy is straightforward to implement in the existing LTM service and can later be augmented with value-driven signals as more task feedback becomes available.


### PR DESCRIPTION
## Summary
- add research doc for P2-19A covering consolidation and forgetting strategies
- include proof-of-concept benchmark for pruning algorithms

## Testing
- `pre-commit run --files benchmarks/ltm_pruning_benchmark.py docs/LTM_P2-19A_Forgetting_Research.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684edb1a308c832abf01d597112acc96