### PR TITLE
Implement Evaluator critique schema and prompt

### DIFF
--- a/agents/Evaluator/prompt.tpl.md
+++ b/agents/Evaluator/prompt.tpl.md
@@ -1,3 +1,28 @@
-# Evaluator Prompt
+# Evaluator System Prompt
 
-Core directive: Fact-check outputs and manage the self-correction loop.
+You are the **Skeptical Critic**, a meticulous reviewer who challenges every claim.
+For each piece of text you evaluate you must:
+1. Score each criterion between 0 and 1.
+2. Provide a short explanation of any issues.
+3. Return only a JSON object that matches the critique schema.
+
+The critique schema:
+```json
+{
+  "overall_score": 0.0,
+  "criteria_breakdown": {"accuracy": 0.0},
+  "feedback_text": "..."
+}
+```
+
+### Good Critique Example
+```json
+{
+  "overall_score": 0.6,
+  "criteria_breakdown": {"accuracy": 0.5, "completeness": 0.7},
+  "feedback_text": "Claim about dataset size lacks support; missing limitations section."
+}
+```
+
+### Bad Critique Example
+Do NOT include prose outside the JSON object or omit required fields.

--- a/agents/critique.py
+++ b/agents/critique.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+from jsonschema import validate
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parent / "evaluator" / "config" / "critique_schema.json"
+)
+with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+    CRITIQUE_SCHEMA: Dict[str, Any] = json.load(f)
+
+
+@dataclass
+class Critique:
+    """Structured critique produced by the Evaluator agent."""
+
+    overall_score: float
+    criteria_breakdown: Dict[str, float]
+    feedback_text: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "overall_score": self.overall_score,
+            "criteria_breakdown": self.criteria_breakdown,
+            "feedback_text": self.feedback_text,
+        }
+
+    def validate(self) -> None:
+        """Validate this critique against the JSON schema."""
+
+        validate(instance=self.to_dict(), schema=CRITIQUE_SCHEMA)

--- a/agents/evaluator/config/critique_schema.json
+++ b/agents/evaluator/config/critique_schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Evaluator Critique",
+  "type": "object",
+  "required": ["overall_score", "criteria_breakdown", "feedback_text"],
+  "properties": {
+    "overall_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "criteria_breakdown": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {"type": "number", "minimum": 0, "maximum": 1}
+      },
+      "minProperties": 1
+    },
+    "feedback_text": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_critique_schema.py
+++ b/tests/test_critique_schema.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError, validate
+
+from agents.critique import CRITIQUE_SCHEMA, Critique
+
+
+def test_schema_file_fields():
+    path = Path("agents/evaluator/config/critique_schema.json")
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert set(data.get("required", [])) == {
+        "overall_score",
+        "criteria_breakdown",
+        "feedback_text",
+    }
+    props = data.get("properties", {})
+    assert props.get("overall_score", {}).get("type") == "number"
+    assert props.get("criteria_breakdown", {}).get("type") == "object"
+    assert props.get("feedback_text", {}).get("type") == "string"
+
+
+def test_critique_validation_passes():
+    crit = Critique(
+        overall_score=0.8,
+        criteria_breakdown={"accuracy": 0.9},
+        feedback_text="ok",
+    )
+    crit.validate()
+
+
+def test_critique_validation_fails():
+    bad = {"overall_score": 2}
+    with pytest.raises(ValidationError):
+        validate(instance=bad, schema=CRITIQUE_SCHEMA)


### PR DESCRIPTION
## Summary
- design new Evaluator system prompt with skeptic persona
- define JSON schema for critiques
- implement `Critique` dataclass and integrate with Evaluator
- add tests validating schema and dataclass

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ede353a3c832ab40e0d5a95ed00ed