### PR TITLE
Implement source quality assessment

### DIFF
--- a/agents/evaluator/config/source_quality.yml
+++ b/agents/evaluator/config/source_quality.yml
@@ -1,0 +1,6 @@
+allowlist:
+  - jstor.org
+  - nature.com
+blocklist:
+  - clickbait.com
+  - contentfarm.biz

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -25,3 +25,19 @@ def test_verify_factual_accuracy_accepts_supported():
     sources = ["Dogs bark loudly."]
     result = agent.verify_factual_accuracy(summary, sources)
     assert result["unsupported_facts"] == []
+
+
+def test_assess_source_quality_penalizes_blocklist():
+    agent = EvaluatorAgent()
+    output = {"sources": ["http://clickbait.com/article"]}
+    results = agent.evaluate_research_output(output, {"source_quality": {}})
+    score = results["source_quality"]["scores"]["http://clickbait.com/article"]
+    assert score < 0
+
+
+def test_assess_source_quality_rewards_allowlist():
+    agent = EvaluatorAgent()
+    output = {"sources": ["https://jstor.org/paper"]}
+    results = agent.evaluate_research_output(output, {"source_quality": {}})
+    score = results["source_quality"]["scores"]["https://jstor.org/paper"]
+    assert score > 0


### PR DESCRIPTION
## Summary
- add domain allowlist/blocklist for Evaluator
- compute a source_quality score in Evaluator based on domains
- test source quality assessment

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee2941794832aa9a4abbff51ab0d6