### PR TITLE
Implement CoSC feedback loop

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from .routing import RoutingError, make_status_router
+from .routing import RoutingError, make_cosc_router, make_status_router
 
-__all__ = ["RoutingError", "make_status_router"]
+__all__ = ["RoutingError", "make_status_router", "make_cosc_router"]

--- a/engine/routing.py
+++ b/engine/routing.py
@@ -36,3 +36,49 @@ def make_status_router(mapping: Dict[str, str]) -> Callable[[State], str]:
             raise RoutingError(f"Unknown status: {status}") from exc
 
     return router
+
+
+def make_cosc_router(
+    *,
+    retry_node: str,
+    pass_node: str,
+    max_retries: int,
+    score_threshold: float = 1.0,
+    fail_node: str | None = None,
+) -> Callable[[State], str]:
+    """Create a router implementing the Chain of Self-Correction logic.
+
+    Parameters
+    ----------
+    retry_node:
+        Node to route to when evaluation fails and retries remain.
+    pass_node:
+        Node to route to when evaluation passes.
+    max_retries:
+        Maximum number of allowed retries.
+    score_threshold:
+        Minimum overall score considered a pass.
+    fail_node:
+        Optional node to route to when retries are exhausted and evaluation
+        still fails. If ``None`` the router will proceed to ``pass_node``.
+    """
+
+    def router(state: State) -> str:
+        score = 1.0
+        if isinstance(state.evaluator_feedback, dict):
+            score = float(state.evaluator_feedback.get("overall_score", score))
+        elif state.evaluator_feedback is not None:
+            try:
+                score = float(state.evaluator_feedback)
+            except (TypeError, ValueError):
+                score = 0.0
+
+        if score < score_threshold:
+            if state.retry_count < max_retries:
+                state.retry_count += 1
+                return retry_node
+            if fail_node is not None:
+                return fail_node
+        return pass_node
+
+    return router

--- a/engine/state.py
+++ b/engine/state.py
@@ -13,6 +13,8 @@ class State(BaseModel):
     messages: List[Dict[str, Any]] = Field(default_factory=list)
     history: List[Dict[str, Any]] = Field(default_factory=list)
     status: str | None = None
+    evaluator_feedback: Dict[str, Any] | None = None
+    retry_count: int = 0
 
     def update(self, other: Dict[str, Any]) -> None:
         """Merge arbitrary key-value pairs into ``data`` and record the change."""


### PR DESCRIPTION
## Summary
- add evaluator feedback and retry counter to `State`
- implement `make_cosc_router` for self-correction routing
- export the new router via `engine.__init__`
- test routing back for retries and loop termination

## Testing
- `pre-commit run --files engine/state.py engine/routing.py engine/__init__.py tests/test_orchestration_router.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee2ce5e68832ab858a21bba9539d4