### PR TITLE
Add fact-check API tool

### DIFF
--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -9,6 +9,7 @@ import yaml
 
 from tools import (
     consolidate_memory,
+    fact_check_claim,
     html_scraper,
     pdf_extract,
     retrieve_memory,
@@ -65,6 +66,7 @@ DEFAULT_TOOLS: Dict[str, Callable[..., object]] = {
     "consolidate_memory": consolidate_memory,
     "retrieve_memory": retrieve_memory,
     "summarize": summarize_text,
+    "fact_check": fact_check_claim,
 }
 
 

--- a/services/tool_registry/config.yml
+++ b/services/tool_registry/config.yml
@@ -9,4 +9,6 @@ permissions:
     - MemoryManager
   retrieve_memory:
     - MemoryManager
+  fact_check:
+    - Evaluator
 

--- a/tests/test_fact_check_tool.py
+++ b/tests/test_fact_check_tool.py
@@ -1,0 +1,59 @@
+import importlib
+from typing import Any
+
+import pytest
+
+fc = importlib.import_module("tools.fact_check")
+
+
+class DummyResponse:
+    def __init__(self, data: Any) -> None:
+        self._data = data
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> Any:
+        return self._data
+
+
+def test_fact_check_parses_response(monkeypatch):
+    data = {
+        "claims": [
+            {
+                "text": "Earth is flat",
+                "claimReview": [
+                    {
+                        "url": "http://example.com",
+                        "reviewRating": {"text": "False"},
+                    }
+                ],
+            }
+        ]
+    }
+
+    def fake_get(url: str, params: Any, timeout: int) -> DummyResponse:
+        assert params["query"] == "Earth is flat"
+        return DummyResponse(data)
+
+    monkeypatch.setenv("FACT_CHECK_API_KEY", "x")
+    monkeypatch.setattr(fc.requests, "get", fake_get)
+    result = fc.fact_check_claim("Earth is flat")
+    assert result["rating"] == "False"
+    assert "http://example.com" in result["source_links"]
+
+
+def test_fact_check_retries_and_errors(monkeypatch):
+    calls = []
+
+    def fake_get(url: str, params: Any, timeout: int) -> DummyResponse:
+        calls.append(1)
+        raise fc.requests.RequestException("boom")
+
+    monkeypatch.setenv("FACT_CHECK_API_KEY", "x")
+    monkeypatch.setattr(fc.requests, "get", fake_get)
+    monkeypatch.setattr(fc.time, "sleep", lambda s: None)
+    with pytest.raises(ValueError):
+        fc.fact_check_claim("test", retries=2)
+    assert len(calls) == 3

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,6 +1,7 @@
 """Tool package exposing callable wrappers for external services."""
 
 from . import web_search
+from .fact_check import fact_check_claim
 from .html_scraper import html_scraper
 from .ltm_client import consolidate_memory, retrieve_memory
 from .pdf_reader import pdf_extract
@@ -13,4 +14,5 @@ __all__ = [
     "html_scraper",
     "pdf_extract",
     "summarize_text",
+    "fact_check_claim",
 ]

--- a/tools/fact_check.py
+++ b/tools/fact_check.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Wrapper for a fact-checking API."""
+
+import os
+import time
+from typing import Dict, List, Optional
+
+import requests
+
+
+def fact_check_claim(
+    claim: str,
+    *,
+    api_key: Optional[str] = None,
+    language: str = "en",
+    retries: int = 2,
+    backoff: float = 1.0,
+) -> Dict[str, object]:
+    """Validate a claim using a third-party fact-checking API.
+
+    Parameters
+    ----------
+    claim: str
+        Text of the claim to verify.
+    api_key: str | None
+        API key for the external service. Defaults to the ``FACT_CHECK_API_KEY``
+        environment variable.
+    language: str
+        Language code for the claim review results. Defaults to ``"en"``.
+    retries: int
+        Number of retry attempts on failure. Defaults to ``2``.
+    backoff: float
+        Base seconds to wait between retries. Each retry waits ``backoff`` * 2**attempt.
+
+    Returns
+    -------
+    Dict[str, object]
+        ``{"claim": claim, "rating": str, "source_links": List[str]}``.
+    """
+    if not isinstance(claim, str) or not claim.strip():
+        raise ValueError("Claim text cannot be empty")
+
+    api_key = api_key or os.getenv("FACT_CHECK_API_KEY")
+    if not api_key:
+        raise ValueError("Missing API key for fact checking")
+
+    endpoint = os.getenv(
+        "FACT_CHECK_API_ENDPOINT",
+        "https://factchecktools.googleapis.com/v1alpha1/claims:search",
+    )
+    params = {"query": claim, "languageCode": language, "key": api_key}
+
+    data: Dict[str, object] | None = None
+    for attempt in range(retries + 1):
+        try:
+            resp = requests.get(endpoint, params=params, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            break
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            if attempt >= retries:
+                raise ValueError(f"Fact check API request failed: {exc}") from exc
+            time.sleep(backoff * 2**attempt)
+
+    claims = data.get("claims", []) if isinstance(data, dict) else []
+    rating = "unverified"
+    links: List[str] = []
+    if claims:
+        review = None
+        if isinstance(claims[0], dict):
+            reviews = claims[0].get("claimReview", [])
+            if reviews and isinstance(reviews[0], dict):
+                review = reviews[0]
+        if review:
+            rating = (
+                review.get("text")
+                or (review.get("reviewRating", {}) or {}).get("text")
+                or rating
+            )
+            url = review.get("url")
+            if url:
+                links.append(url)
+
+    return {"claim": claim, "rating": rating, "source_links": links}


### PR DESCRIPTION
## Summary
- wrap Google Fact Check Tools API in new `fact_check_claim` function
- expose new tool from `tools` package and register with Tool Registry
- allow Evaluator to use the tool via registry permissions
- add tests for API wrapper

## Testing
- `pre-commit run --files services/tool_registry/__init__.py services/tool_registry/config.yml tools/__init__.py tools/fact_check.py tests/test_fact_check_tool.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee4ec53d0832a97465beb211cd831