### PR TITLE
Implement judge evaluation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 ENV/
 .venv/
+**/results.db

--- a/pipelines/judge/pipeline.py
+++ b/pipelines/judge/pipeline.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Callable, Dict, List
+
+from jsonschema import validate
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+
+class JudgePipeline:
+    """LLM-as-a-Judge evaluation pipeline."""
+
+    def __init__(
+        self,
+        llm: Callable[[str], str],
+        db_path: str = "results.db",
+        rubric_path: str
+        | Path = Path(__file__).resolve().parent / "rubric_schema.json",
+        alert_fn: Callable[[Exception], None] | None = None,
+    ) -> None:
+        self.llm = llm
+        self.db_path = db_path
+        self.alert_fn = alert_fn
+        self.rubric = json.loads(Path(rubric_path).read_text(encoding="utf-8"))
+        self._ensure_db()
+
+    def _ensure_db(self) -> None:
+        self.conn = sqlite3.connect(self.db_path)
+        with self.conn:
+            self.conn.execute(
+                (
+                    "CREATE TABLE IF NOT EXISTS evaluations "
+                    "(id INTEGER PRIMARY KEY AUTOINCREMENT, report TEXT, result TEXT)"
+                )
+            )
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def _build_prompt(self, report: str, sources: List[str]) -> str:
+        rubric = json.dumps(self.rubric, indent=2)
+        joined = "\n".join(sources)
+        return (
+            "You are an impartial judge evaluating a research report.\n"
+            "Report:\n" + report + "\n"
+            "Sources:\n" + joined + "\n"
+            "Using the rubric JSON schema:\n" + rubric + "\n"
+            "Respond ONLY with valid JSON matching that schema."
+        )
+
+    @retry(
+        stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=4)
+    )
+    def _call_llm(self, prompt: str) -> str:
+        return self.llm(prompt)
+
+    def evaluate(self, report: str, sources: List[str]) -> Dict:
+        prompt = self._build_prompt(report, sources)
+        try:
+            response = self._call_llm(prompt)
+        except Exception as e:  # persistent failure
+            if self.alert_fn:
+                self.alert_fn(e)
+            raise
+        data = json.loads(str(response))
+        validate(instance=data, schema=self.rubric)
+        with self.conn:
+            self.conn.execute(
+                "INSERT INTO evaluations (report, result) VALUES (?, ?)",
+                (report, json.dumps(data)),
+            )
+        return data

--- a/pipelines/judge/rubric_schema.json
+++ b/pipelines/judge/rubric_schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Report Evaluation Rubric",
+  "type": "object",
+  "properties": {
+    "factual_accuracy": {
+      "type": "object",
+      "properties": {
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "explanation": {"type": "string"}
+      },
+      "required": ["score"],
+      "additionalProperties": false
+    },
+    "completeness": {
+      "type": "object",
+      "properties": {
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "explanation": {"type": "string"}
+      },
+      "required": ["score"],
+      "additionalProperties": false
+    },
+    "source_quality": {
+      "type": "object",
+      "properties": {
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "explanation": {"type": "string"}
+      },
+      "required": ["score"],
+      "additionalProperties": false
+    },
+    "coherence": {
+      "type": "object",
+      "properties": {
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "explanation": {"type": "string"}
+      },
+      "required": ["score"],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "factual_accuracy",
+    "completeness",
+    "source_quality",
+    "coherence"
+  ],
+  "additionalProperties": false
+}

--- a/tests/test_judge_pipeline.py
+++ b/tests/test_judge_pipeline.py
@@ -1,0 +1,49 @@
+from pipelines.judge.pipeline import JudgePipeline
+
+
+def test_pipeline_evaluates_and_persists(tmp_path):
+    calls = []
+
+    def fake_llm(prompt: str) -> str:
+        calls.append(prompt)
+        return (
+            '{"factual_accuracy": {"score": 1.0}, "completeness": {"score": 0.9},'
+            ' "source_quality": {"score": 0.8}, "coherence": {"score": 0.95}}'
+        )
+
+    db_file = tmp_path / "results.db"
+    pipeline = JudgePipeline(fake_llm, db_path=str(db_file))
+    report = "Sample report"
+    sources = ["Source 1"]
+    result = pipeline.evaluate(report, sources)
+    pipeline.close()
+
+    assert result["coherence"]["score"] == 0.95
+    # Verify persistence
+    import sqlite3
+
+    conn = sqlite3.connect(db_file)
+    rows = conn.execute("SELECT count(*) FROM evaluations").fetchone()[0]
+    assert rows == 1
+    conn.close()
+    assert calls, "LLM should have been called"
+
+
+def test_pipeline_retries_on_failure(tmp_path):
+    attempts = []
+
+    def flaky_llm(prompt: str) -> str:
+        attempts.append(1)
+        if len(attempts) < 2:
+            raise RuntimeError("temp error")
+        return (
+            '{"factual_accuracy": {"score": 0.9}, "completeness": {"score": 1.0},'
+            ' "source_quality": {"score": 1.0}, "coherence": {"score": 1.0}}'
+        )
+
+    db_file = tmp_path / "results.db"
+    pipeline = JudgePipeline(flaky_llm, db_path=str(db_file))
+    out = pipeline.evaluate("R", ["S"])
+    pipeline.close()
+    assert out["factual_accuracy"]["score"] == 0.9
+    assert len(attempts) == 2


### PR DESCRIPTION
## Summary
- create JSON schema for evaluation rubric
- implement LLM-as-a-Judge pipeline with retry and persistence
- ignore any results databases
- test pipeline behaviour including retry logic

## Testing
- `pre-commit run --files pipelines/judge/pipeline.py tests/test_judge_pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee525de3c832a88d14e2041e8a89a