### PR TITLE
Add JSON schema for judge rubric

### DIFF
--- a/docs/judge_rubric_examples.md
+++ b/docs/judge_rubric_examples.md
@@ -1,0 +1,25 @@
+# Judge Rubric Examples
+
+This document illustrates valid objects that conform to `schemas/judge_rubric.json`.
+
+## Example 1: Scores Only
+```json
+{
+  "schema_version": "1.0",
+  "factual_accuracy": {"score": 1.0},
+  "completeness": {"score": 0.9},
+  "source_quality": {"score": 1.0},
+  "coherence": {"score": 0.8}
+}
+```
+
+## Example 2: Scores with Justifications
+```json
+{
+  "schema_version": "1.0",
+  "factual_accuracy": {"score": 0.8, "justification": "Minor factual slips"},
+  "completeness": {"score": 1.0, "justification": "All points addressed"},
+  "source_quality": {"score": 0.9, "justification": "Some sources are blog posts"},
+  "coherence": {"score": 1.0, "justification": "Clear and logical flow"}
+}
+```

--- a/pipelines/judge/pipeline.py
+++ b/pipelines/judge/pipeline.py
@@ -17,7 +17,7 @@ class JudgePipeline:
         llm: Callable[[str], str],
         db_path: str = "results.db",
         rubric_path: str
-        | Path = Path(__file__).resolve().parent / "rubric_schema.json",
+        | Path = Path(__file__).resolve().parents[2] / "schemas" / "judge_rubric.json",
         alert_fn: Callable[[Exception], None] | None = None,
     ) -> None:
         self.llm = llm

--- a/schemas/judge_rubric.json
+++ b/schemas/judge_rubric.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/schemas/judge_rubric.json",
+  "title": "LLM-as-a-Judge Evaluation Rubric",
+  "description": "Structured rubric used to score research reports",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0"],
+      "description": "Schema version identifier"
+    },
+    "factual_accuracy": {
+      "type": "object",
+      "description": "Correctness of statements with respect to provided sources",
+      "properties": {
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "justification": {"type": "string"}
+      },
+      "required": ["score"],
+      "additionalProperties": false
+    },
+    "completeness": {
+      "type": "object",
+      "description": "Coverage of all key points and absence of omissions",
+      "properties": {
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "justification": {"type": "string"}
+      },
+      "required": ["score"],
+      "additionalProperties": false
+    },
+    "source_quality": {
+      "type": "object",
+      "description": "Reliability and relevance of cited sources",
+      "properties": {
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "justification": {"type": "string"}
+      },
+      "required": ["score"],
+      "additionalProperties": false
+    },
+    "coherence": {
+      "type": "object",
+      "description": "Logical flow and clarity of the writing",
+      "properties": {
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "justification": {"type": "string"}
+      },
+      "required": ["score"],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "factual_accuracy",
+    "completeness",
+    "source_quality",
+    "coherence"
+  ],
+  "additionalProperties": false
+}

--- a/tests/test_judge_rubric_schema.py
+++ b/tests/test_judge_rubric_schema.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator, validate
+
+
+def load_schema():
+    path = Path("schemas/judge_rubric.json")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_schema_is_valid():
+    schema = load_schema()
+    Draft7Validator.check_schema(schema)
+    props = schema.get("properties", {})
+    assert set(
+        [
+            "schema_version",
+            "factual_accuracy",
+            "completeness",
+            "source_quality",
+            "coherence",
+        ]
+    ).issubset(props)
+
+
+def test_sample_validates():
+    schema = load_schema()
+    sample = {
+        "schema_version": "1.0",
+        "factual_accuracy": {"score": 1.0},
+        "completeness": {"score": 0.9},
+        "source_quality": {"score": 0.8},
+        "coherence": {"score": 1.0},
+    }
+    validate(instance=sample, schema=schema)


### PR DESCRIPTION
## Summary
- create `judge_rubric.json` schema
- use schema in `JudgePipeline`
- document sample rubric JSON
- test schema validity and add examples

## Testing
- `pre-commit run --files schemas/judge_rubric.json tests/test_judge_rubric_schema.py pipelines/judge/pipeline.py docs/judge_rubric_examples.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee653e16c832a97c1da7596924935