### PR TITLE
Implement HITL breakpoint and review queue

### DIFF
--- a/docs/hitl_breakpoint.md
+++ b/docs/hitl_breakpoint.md
@@ -1,0 +1,11 @@
+# Human-in-the-Loop Breakpoint
+
+A `human_in_the_loop_breakpoint` node pauses graph execution and pushes the
+current state to a review queue. Reviewers can inspect the state via a simple
+HTTP API and approve or reject the task.
+
+## API Endpoints
+
+- `GET /tasks` – list paused tasks with their serialized state
+- `POST /tasks/<id>/approve` – resume execution from the stored point
+- `POST /tasks/<id>/reject` – terminate the task with status `REJECTED_BY_HUMAN`

--- a/services/hitl_review/__init__.py
+++ b/services/hitl_review/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+"""Simple human-in-the-loop review queue service."""
+
+from .api import HITLReviewServer
+from .queue import InMemoryReviewQueue
+
+__all__ = ["InMemoryReviewQueue", "HITLReviewServer"]

--- a/services/hitl_review/api.py
+++ b/services/hitl_review/api.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse
+
+from engine.orchestration_engine import OrchestrationEngine
+
+from .queue import InMemoryReviewQueue
+
+
+class HITLReviewServer:
+    """Minimal HTTP API for reviewing paused tasks."""
+
+    def __init__(
+        self,
+        queue: InMemoryReviewQueue,
+        engine: OrchestrationEngine,
+        host: str = "127.0.0.1",
+        port: int = 0,
+    ) -> None:
+        self.queue = queue
+        self.engine = engine
+        self.httpd = HTTPServer((host, port), self._handler())
+
+    def _handler(self):
+        queue = self.queue
+        engine = self.engine
+
+        class Handler(BaseHTTPRequestHandler):
+            def _send_json(self, status: int, payload: dict) -> None:
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(payload).encode())
+
+            def do_GET(self) -> None:
+                if self.path != "/tasks":
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                payload = {
+                    run_id: state.model_dump()
+                    for run_id, (state, _) in queue._queue.items()
+                }
+                self._send_json(200, payload)
+
+            def do_POST(self) -> None:
+                parsed = urlparse(self.path)
+                parts = parsed.path.strip("/").split("/")
+                if len(parts) != 3 or parts[0] != "tasks":
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                run_id, action = parts[1], parts[2]
+                if action == "approve":
+                    try:
+                        state, next_node = queue.pop(run_id)
+                    except KeyError:
+                        self._send_json(404, {"error": "not found"})
+                        return
+                    state.status = None
+                    final_state = asyncio.run(
+                        engine.run_async(state, thread_id=run_id, start_at=next_node)
+                    )
+                    self._send_json(200, {"result": final_state.model_dump()})
+                elif action == "reject":
+                    try:
+                        state, _ = queue.pop(run_id)
+                    except KeyError:
+                        self._send_json(404, {"error": "not found"})
+                        return
+                    state.status = "REJECTED_BY_HUMAN"
+                    self._send_json(200, state.model_dump())
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+        return Handler
+
+    def serve_forever(self) -> None:  # pragma: no cover - manual run
+        self.httpd.serve_forever()

--- a/services/hitl_review/queue.py
+++ b/services/hitl_review/queue.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from engine.state import State
+
+
+class InMemoryReviewQueue:
+    """Store paused tasks awaiting human review."""
+
+    def __init__(self) -> None:
+        self._queue: Dict[str, Tuple[State, str | None]] = {}
+
+    def enqueue(self, run_id: str, state: State, next_node: str | None) -> None:
+        self._queue[run_id] = (state, next_node)
+
+    def pop(self, run_id: str) -> Tuple[State, str | None]:
+        return self._queue.pop(run_id)
+
+    def get(self, run_id: str) -> Tuple[State, str | None]:
+        return self._queue[run_id]
+
+    def pending(self) -> list[str]:
+        return list(self._queue.keys())

--- a/tests/test_hitl_breakpoint.py
+++ b/tests/test_hitl_breakpoint.py
@@ -1,0 +1,74 @@
+import asyncio
+from threading import Thread
+
+import requests
+
+from engine.orchestration_engine import (
+    GraphState,
+    NodeType,
+    create_orchestration_engine,
+)
+from services.hitl_review import HITLReviewServer, InMemoryReviewQueue
+
+
+def _build_engine(queue: InMemoryReviewQueue):
+    engine = create_orchestration_engine()
+    engine.review_queue = queue
+
+    def node_a(state: GraphState) -> GraphState:
+        state.update({"a": 1})
+        return state
+
+    def node_b(state: GraphState) -> GraphState:
+        state.update({"b": 2})
+        return state
+
+    engine.add_node("A", node_a)
+    engine.add_node(
+        "Break",
+        lambda s: s,
+        node_type=NodeType.HUMAN_IN_THE_LOOP_BREAKPOINT,
+    )
+    engine.add_node("B", node_b)
+    engine.add_edge("A", "Break")
+    engine.add_edge("Break", "B")
+    return engine
+
+
+def _start_server(engine, queue):
+    server = HITLReviewServer(queue, engine, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, f"http://127.0.0.1:{server.httpd.server_port}"
+
+
+def test_breakpoint_pauses_and_resumes():
+    queue = InMemoryReviewQueue()
+    engine = _build_engine(queue)
+    state = asyncio.run(engine.run_async(GraphState(), thread_id="t1"))
+    assert state.status == "PAUSED"
+    assert queue.pending() == ["t1"]
+
+    resumed = asyncio.run(engine.resume_from_queue_async("t1"))
+    assert resumed.data["b"] == 2
+    assert not queue.pending()
+
+
+def test_review_server_endpoints():
+    queue = InMemoryReviewQueue()
+    engine = _build_engine(queue)
+    asyncio.run(engine.run_async(GraphState(), thread_id="t2"))
+    server, endpoint = _start_server(engine, queue)
+
+    resp = requests.get(f"{endpoint}/tasks")
+    assert resp.status_code == 200
+    assert "t2" in resp.json()
+
+    resp = requests.post(f"{endpoint}/tasks/t2/approve")
+    assert resp.status_code == 200
+    assert resp.json()["result"]["data"]["b"] == 2
+
+    asyncio.run(engine.run_async(GraphState(), thread_id="t3"))
+    resp = requests.post(f"{endpoint}/tasks/t3/reject")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "REJECTED_BY_HUMAN"


### PR DESCRIPTION
## Summary
- add `NodeType` enum and HITL handling to orchestration engine
- create in-memory human review queue and HTTP server
- provide docs for the breakpoint API
- test pause/resume and API endpoints

## Testing
- `pre-commit run --files engine/orchestration_engine.py services/hitl_review/__init__.py services/hitl_review/api.py services/hitl_review/queue.py docs/hitl_breakpoint.md tests/test_hitl_breakpoint.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eea020aac832a9b433ba00ebb99dc