### PR TITLE
Generate self correction dataset

### DIFF
--- a/data/synthetic_self_correction/self_correction_dataset.json
+++ b/data/synthetic_self_correction/self_correction_dataset.json
@@ -1,0 +1,6002 @@
+[
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on otpic XYZ.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on otpic XYZ.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synhtetic research report 1 on topic XYZ.",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 1 on topic XYZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synhtetic research rpeort 1 on topic XYZ.",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'; 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 1 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 1 on topic XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synhtetic ersearch report 1 on topic XY.Z",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'; 'ersearch' should be 'research'; 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 1 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic resaerch report 1 on topic XYZ.",
+    "critique": "Typographical errors: 'resaerch' should be 'research'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 1 on topic XZY.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Snythetic research report 1 on topic XZY.",
+    "critique": "Typographical errors: 'Snythetic' should be 'Synthetic'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Syntheitc resaerch report 1 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'; 'resaerch' should be 'research'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 1 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc report 1 on topic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 1 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 1 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 1 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 2 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic resaerch report 2 on topic XZY.",
+    "critique": "Typographical errors: 'resaerch' should be 'research'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "ySnthetic research report 2 on topic XY.Z",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'; 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Sytnhetic research report 2 on topic XYZ.",
+    "critique": "Typographical errors: 'Sytnhetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc reoprt 2 on topic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'; 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "ySnthetic research report 2 on topic XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic reserach report 2 on topic XYZ.",
+    "critique": "Typographical errors: 'reserach' should be 'research'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Sytnhetic research report 2 on topic XYZ.",
+    "critique": "Typographical errors: 'Sytnhetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 2 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Syntheitc research reprot 2 on topic XY.Z",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'; 'reprot' should be 'report'; 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on otpic XZY.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic rseearch report 2 on topic XYZ.",
+    "critique": "Typographical errors: 'rseearch' should be 'research'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 2 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 2 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Syntehtic ersearch report 2 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'; 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 2 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 2 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 2 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Snythetic research reoprt 3 on topic XYZ.",
+    "critique": "Typographical errors: 'Snythetic' should be 'Synthetic'; 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 3 on topic XYZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 3 on topci XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'; 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research reprot 3 on topic YXZ.",
+    "critique": "Typographical errors: 'reprot' should be 'report'; 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 3 on topic XYZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic resaerch report 3 on otpic XYZ.",
+    "critique": "Typographical errors: 'resaerch' should be 'research'; 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 3 on tpoic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'; 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 3 on toipc XYZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'; 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic ersearch report 3 on topic XYZ.",
+    "critique": "Typographical errors: 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 3 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research reprot 3 on topic XYZ.",
+    "critique": "Typographical errors: 'reprot' should be 'report'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on otpic XYZ.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synhtetic research report 3 on topic XYZ.",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic resaerch repotr 3 on topic XYZ.",
+    "critique": "Typographical errors: 'resaerch' should be 'research'; 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic reserach report 3 on topci XYZ.",
+    "critique": "Typographical errors: 'reserach' should be 'research'; 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 3 on topic XZY.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic reserach report 3 on otpic XYZ.",
+    "critique": "Typographical errors: 'reserach' should be 'research'; 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthteic research report 3 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthteic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "ySnthetic reseacrh report 3 on topic XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'; 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research reprot 3 on topic XYZ.",
+    "critique": "Typographical errors: 'reprot' should be 'report'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 3 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 3 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc report 3 on topic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'",
+    "corrected_version": "Synthetic research report 3 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on otpic XY.Z",
+    "critique": "Typographical errors: 'otpic' should be 'topic'; 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "ySnthetic research report 4 on topic XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 4 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 4 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc report 4 on topic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 4 on topic XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 4 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "ySnthetic research report 4 on topic XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Sytnhetic research report 4 on topic XYZ.",
+    "critique": "Typographical errors: 'Sytnhetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 4 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research reprot 4 on topic XYZ.",
+    "critique": "Typographical errors: 'reprot' should be 'report'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic rseearch report 4 on topic XYZ.",
+    "critique": "Typographical errors: 'rseearch' should be 'research'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 4 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on otpic XYZ.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 4 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 4 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 4 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 4 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthteic research report 5 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthteic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Snythetic research report 5 on topic XYZ.",
+    "critique": "Typographical errors: 'Snythetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Sytnhetic research report 5 on topic XYZ.",
+    "critique": "Typographical errors: 'Sytnhetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthteic research report 5 on tpoic XYZ.",
+    "critique": "Typographical errors: 'Synthteic' should be 'Synthetic'; 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc reoprt 5 on topci XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'; 'reoprt' should be 'report'; 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 5 on tpoic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'; 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 5 on toipc XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'; 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synhtetic research report 5 on tpoic XYZ.",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'; 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synhtetic resaerch rpeort 5 on topic XYZ.",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'; 'resaerch' should be 'research'; 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synhtetic research report 5 on topic XYZ.",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 5 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 5 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 5 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 5 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 5 on topic XYZ.",
+    "erroneous_version": "Synthetic ersearch report 5 on topic XYZ.",
+    "critique": "Typographical errors: 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 5 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 6 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic resaerch report 6 on topic XYZ.",
+    "critique": "Typographical errors: 'resaerch' should be 'research'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 6 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic rseearch report 6 on topic XYZ.",
+    "critique": "Typographical errors: 'rseearch' should be 'research'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic ersearch report 6 on topic XYZ.",
+    "critique": "Typographical errors: 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 6 on topic XYZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 6 on topic XYZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 6 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 6 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 6 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "ySnthetic rseearch rpeort 6 on topic XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'; 'rseearch' should be 'research'; 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 6 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Snythetic research report 6 on topic XYZ.",
+    "critique": "Typographical errors: 'Snythetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 6 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on otpic XY.Z",
+    "critique": "Typographical errors: 'otpic' should be 'topic'; 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 6 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 6 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 6 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research reprot 7 on topic XYZ.",
+    "critique": "Typographical errors: 'reprot' should be 'report'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 7 on topic YXZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'; 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on toipc XZY.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research reprot 7 on topic XYZ.",
+    "critique": "Typographical errors: 'reprot' should be 'report'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 7 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Snythetic reseacrh report 7 on otpic XYZ.",
+    "critique": "Typographical errors: 'Snythetic' should be 'Synthetic'; 'reseacrh' should be 'research'; 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic ersearch report 7 on topic XYZ.",
+    "critique": "Typographical errors: 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 7 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 7 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 7 on topic XY.Z",
+    "critique": "Typographical errors: 'erport' should be 'report'; 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 7 on topic XZY.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 7 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc report 7 on topic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic reserach report 7 on topic XYZ.",
+    "critique": "Typographical errors: 'reserach' should be 'research'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "ySnthetic research report 7 on topic XZY.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 7 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 7 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 7 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 8 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 8 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc report 8 on topic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 8 on toipc XYZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'; 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Syntehtic research reoprt 8 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'; 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research reprot 8 on topic XYZ.",
+    "critique": "Typographical errors: 'reprot' should be 'report'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh reprot 8 on topic XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'; 'reprot' should be 'report'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 8 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on otpic XYZ.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 8 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc report 8 on topic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 8 on topic XYZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on otpic XYZ.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic rseearch report 8 on topic XYZ.",
+    "critique": "Typographical errors: 'rseearch' should be 'research'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 8 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 8 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 8 on topic YXZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'; 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 8 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 9 on topic YXZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'; 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synhtetic research report 9 on topic XYZ.",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 9 on topic XYZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 9 on topic XY.Z",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'; 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on tpoic XZY.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synhtetic research report 9 on topic XYZ.",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Snythetic research erport 9 on topic XZY.",
+    "critique": "Typographical errors: 'Snythetic' should be 'Synthetic'; 'erport' should be 'report'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 9 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthteic reserach report 9 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthteic' should be 'Synthetic'; 'reserach' should be 'research'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic rseearch report 9 on topic XYZ.",
+    "critique": "Typographical errors: 'rseearch' should be 'research'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 9 on topic YXZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'; 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on otpic XYZ.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 9 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 9 on tpoic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'; 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 9 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic rseearch report 9 on topic XYZ.",
+    "critique": "Typographical errors: 'rseearch' should be 'research'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Sytnhetic research report 9 on topic XYZ.",
+    "critique": "Typographical errors: 'Sytnhetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 9 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 9 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 9 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic ersearch report 10 on topic XYZ.",
+    "critique": "Typographical errors: 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Snythetic research report 10 on topic XYZ.",
+    "critique": "Typographical errors: 'Snythetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthteic research report 10 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthteic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc report 10 on topic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 10 on topic XYZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 10 on topci XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'; 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 10 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 10 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 10 on topic XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic ersearch report 10 on topic XYZ.",
+    "critique": "Typographical errors: 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetci ersearch report 10 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'; 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch rpeort 10 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'; 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 10 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 10 on topic XYZ.",
+    "erroneous_version": "Synthetic reserach report 10 on tpoic XYZ.",
+    "critique": "Typographical errors: 'reserach' should be 'research'; 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 10 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 11 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "ySnthetic rseearch report 11 on topic XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'; 'rseearch' should be 'research'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 11 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 11 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 11 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 11 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 11 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 11 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthteic research report 11 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthteic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 11 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "ySnthetic research report 11 on toipc XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'; 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topci YXZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'; 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 11 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 11 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 11 on topic XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on toipc YXZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'; 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 11 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 11 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 11 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic rseearch report 12 on topic XYZ.",
+    "critique": "Typographical errors: 'rseearch' should be 'research'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Syntehtic reserach report 12 on topic XZY.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'; 'reserach' should be 'research'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research reprot 12 on topic XYZ.",
+    "critique": "Typographical errors: 'reprot' should be 'report'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 12 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 12 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 12 on topic YXZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'; 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 12 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 12 on topic XZY.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic rseearch report 12 on topic XYZ.",
+    "critique": "Typographical errors: 'rseearch' should be 'research'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 12 on topic XZY.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic reserach reprot 12 on topic XYZ.",
+    "critique": "Typographical errors: 'reserach' should be 'research'; 'reprot' should be 'report'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 12 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 12 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 12 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 12 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 12 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 13 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 13 on tpoic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'; 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Snythetic research report 13 on topic XYZ.",
+    "critique": "Typographical errors: 'Snythetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 13 on toipc XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'; 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 13 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topci XY.Z",
+    "critique": "Typographical errors: 'topci' should be 'topic'; 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "ySnthetic ersearch reprot 13 on topic XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'; 'ersearch' should be 'research'; 'reprot' should be 'report'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on tpoic YXZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'; 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 13 on topic XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 13 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 13 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 13 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 14 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 14 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 14 on otpic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'; 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic resaerch report 14 on topic XYZ.",
+    "critique": "Typographical errors: 'resaerch' should be 'research'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 14 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 14 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Syntheitc research erport 14 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'; 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 14 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synhtetic research report 14 on topic XYZ.",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 14 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 14 on topic XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic reserach report 14 on tpoic XZY.",
+    "critique": "Typographical errors: 'reserach' should be 'research'; 'tpoic' should be 'topic'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 14 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 14 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 14 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 15 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic rseearch report 15 on topic XYZ.",
+    "critique": "Typographical errors: 'rseearch' should be 'research'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic reserach report 15 on topic XYZ.",
+    "critique": "Typographical errors: 'reserach' should be 'research'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 15 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 15 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 15 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 15 on otpic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'; 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthteic research report 15 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthteic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic ersearch report 15 on topic XYZ.",
+    "critique": "Typographical errors: 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Snythetic research report 15 on topic XYZ.",
+    "critique": "Typographical errors: 'Snythetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic reserach report 15 on topic XYZ.",
+    "critique": "Typographical errors: 'reserach' should be 'research'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 15 on topci XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'; 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetci research reoprt 15 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'; 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 15 on tpoic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'; 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 15 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthteic research report 15 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthteic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic reserach report 15 on topic XYZ.",
+    "critique": "Typographical errors: 'reserach' should be 'research'",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 15 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 15 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 15 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic ersearch report 16 on topic XYZ.",
+    "critique": "Typographical errors: 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 16 on topic XY.Z",
+    "critique": "Typographical errors: 'reesarch' should be 'research'; 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synhtetic research report 16 on otpic XYZ.",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'; 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 16 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Sytnhetic research report 16 on topic XYZ.",
+    "critique": "Typographical errors: 'Sytnhetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synhtetic research report 16 on otpic XYZ.",
+    "critique": "Typographical errors: 'Synhtetic' should be 'Synthetic'; 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "ySnthetic research report 16 on topic XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 16 on topic XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic reserach report 16 on topic XYZ.",
+    "critique": "Typographical errors: 'reserach' should be 'research'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research rpeort 16 on topic XYZ.",
+    "critique": "Typographical errors: 'rpeort' should be 'report'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc report 16 on topic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 16 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 16 on toipc XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'; 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 16 on topic XZY.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 16 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 16 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 16 on otpic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'; 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 16 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 16 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 16 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 17 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 17 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 17 on topic XY.Z",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'; 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 17 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 17 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Syntehtic reseacrh report 17 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'; 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthteic research erport 17 on toipc XYZ.",
+    "critique": "Typographical errors: 'Synthteic' should be 'Synthetic'; 'erport' should be 'report'; 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Snythetic research report 17 on otpic XYZ.",
+    "critique": "Typographical errors: 'Snythetic' should be 'Synthetic'; 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 17 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on otpic XYZ.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 17 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Sytnhetic research report 17 on topic XYZ.",
+    "critique": "Typographical errors: 'Sytnhetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc report 17 on topic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 17 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 17 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 17 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on otpic XYZ.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic ersearch report 18 on topic XYZ.",
+    "critique": "Typographical errors: 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 18 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XZY.",
+    "critique": "Typographical errors: 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic ersearch report 18 on topic XYZ.",
+    "critique": "Typographical errors: 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research reprot 18 on topic YXZ.",
+    "critique": "Typographical errors: 'reprot' should be 'report'; 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 18 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 18 on topic XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 18 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 18 on tpoic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'; 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc reprot 18 on topic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'; 'reprot' should be 'report'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "ySnthetic research report 18 on topic XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 18 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "ySnthetic research report 18 on topci XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'; 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic resaerch report 18 on topic XYZ.",
+    "critique": "Typographical errors: 'resaerch' should be 'research'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic researhc report 18 on tpoic XYZ.",
+    "critique": "Typographical errors: 'researhc' should be 'research'; 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 18 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 18 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 18 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on toipc XY.Z",
+    "critique": "Typographical errors: 'toipc' should be 'topic'; 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic reesarch report 19 on topic XYZ.",
+    "critique": "Typographical errors: 'reesarch' should be 'research'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic ersearch report 19 on topic XYZ.",
+    "critique": "Typographical errors: 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 19 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Syntheitc ersearch report 19 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'; 'ersearch' should be 'research'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research erport 19 on topic XYZ.",
+    "critique": "Typographical errors: 'erport' should be 'report'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on toipc XZY.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 19 on topic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on otpic XYZ.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 19 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 19 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on otpic XZY.",
+    "critique": "Typographical errors: 'otpic' should be 'topic'; 'XZY.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 19 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic rseearch report 19 on topic XYZ.",
+    "critique": "Typographical errors: 'rseearch' should be 'research'",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 19 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 19 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 19 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic resaerch report 20 on topic XYZ.",
+    "critique": "Typographical errors: 'resaerch' should be 'research'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic YXZ.",
+    "critique": "Typographical errors: 'YXZ.' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 20 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XY.Z",
+    "critique": "Typographical errors: 'XY.Z' should be 'XYZ.'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Syntheitc research report 20 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntheitc' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research repotr 20 on topic XYZ.",
+    "critique": "Typographical errors: 'repotr' should be 'report'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "ySnthetic research report 20 on topic XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on toipc XYZ.",
+    "critique": "Typographical errors: 'toipc' should be 'topic'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 20 on topic XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research reoprt 20 on tpoic XYZ.",
+    "critique": "Typographical errors: 'reoprt' should be 'report'; 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "ySnthetic research report 20 on topic XYZ.",
+    "critique": "Typographical errors: 'ySnthetic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Syntehtic research report 20 on topic XYZ.",
+    "critique": "Typographical errors: 'Syntehtic' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on tpoic XYZ.",
+    "critique": "Typographical errors: 'tpoic' should be 'topic'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic reseacrh report 20 on topic XYZ.",
+    "critique": "Typographical errors: 'reseacrh' should be 'research'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topci XYZ.",
+    "critique": "Typographical errors: 'topci' should be 'topic'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetci researhc report 20 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'; 'researhc' should be 'research'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetci research report 20 on topic XYZ.",
+    "critique": "Typographical errors: 'Synthetci' should be 'Synthetic'",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  },
+  {
+    "original_text": "Synthetic research report 20 on topic XYZ.",
+    "erroneous_version": "Synthetic research report 20 on topic XYZ.",
+    "critique": "No issues detected",
+    "corrected_version": "Synthetic research report 20 on topic XYZ."
+  }
+]

--- a/scripts/generate_self_correction_dataset.py
+++ b/scripts/generate_self_correction_dataset.py
@@ -1,0 +1,56 @@
+import json
+import random
+from pathlib import Path
+
+SOURCE_PATH = Path("data/golden_judge_dataset/golden_dataset.json")
+OUT_PATH = Path("data/synthetic_self_correction/self_correction_dataset.json")
+
+
+def inject_typos(text: str, rate: float = 0.1) -> str:
+    words = text.split()
+    for i in range(len(words)):
+        if random.random() < rate and len(words[i]) > 3:
+            chars = list(words[i])
+            j = random.randrange(len(chars) - 1)
+            chars[j], chars[j + 1] = chars[j + 1], chars[j]
+            words[i] = "".join(chars)
+    return " ".join(words)
+
+
+def critique(original: str, erroneous: str) -> str:
+    issues = []
+    for o, e in zip(original.split(), erroneous.split()):
+        if o != e:
+            issues.append(f"'{e}' should be '{o}'")
+    if not issues:
+        return "No issues detected"
+    return "Typographical errors: " + "; ".join(issues)
+
+
+def generate_examples() -> list[dict]:
+    src = json.loads(SOURCE_PATH.read_text())
+    reports = [entry["report"] for entry in src]
+    examples = []
+    for text in reports:
+        for _ in range(50):
+            erroneous = inject_typos(text)
+            examples.append(
+                {
+                    "original_text": text,
+                    "erroneous_version": erroneous,
+                    "critique": critique(text, erroneous),
+                    "corrected_version": text,
+                }
+            )
+    return examples
+
+
+def main() -> None:
+    examples = generate_examples()
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(examples, indent=2))
+    print(f"Wrote {OUT_PATH} with {len(examples)} examples")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_synthetic_examples.py
+++ b/scripts/generate_synthetic_examples.py
@@ -1,13 +1,24 @@
 import json
 import random
 from pathlib import Path
+
 from googletrans import Translator
 
 translator = Translator()
 
 SAMPLES = [
-    "Long-Term Memory Consolidation & Forgetting Research (P2-19A)\n\nThis document summarizes a research spike into lifecycle management algorithms for the Long-Term Memory (LTM) service. The goal was to compare advanced forgetting strategies and recommend an approach for Phase 2 implementation.",
-    "Graph Compilation Strategies Research\n\nA short research spike evaluated dynamic graph execution versus ahead-of-time compilation for the orchestration engine."
+    (
+        "Long-Term Memory Consolidation & Forgetting Research (P2-19A)\n\n"
+        "This document summarizes a research spike into lifecycle management"
+        " algorithms for the Long-Term Memory (LTM) service. The goal was to"
+        " compare advanced forgetting strategies and recommend an approach for"
+        " Phase 2 implementation."
+    ),
+    (
+        "Graph Compilation Strategies Research\n\n"
+        "A short research spike evaluated dynamic graph execution versus"
+        " ahead-of-time compilation for the orchestration engine."
+    ),
 ]
 
 
@@ -36,11 +47,13 @@ def main():
     for text in SAMPLES:
         bt = back_translate(text)
         typo = inject_typos(text)
-        data.append({
-            "original": text,
-            "back_translation": bt,
-            "typo_perturbation": typo,
-        })
+        data.append(
+            {
+                "original": text,
+                "back_translation": bt,
+                "typo_perturbation": typo,
+            }
+        )
     out_path = Path("data/synthetic_self_correction/sample_pairs.json")
     out_path.write_text(json.dumps(data, indent=2))
     print(f"Wrote {out_path}")


### PR DESCRIPTION
## Summary
- implement dataset generation script `generate_self_correction_dataset.py`
- update sample generation script for line length
- generate initial dataset `self_correction_dataset.json` with 1000 examples

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684eee694cc0832aa9823191f25251c4