### PR TITLE
Add adversarial edge case dataset

### DIFF
--- a/data/adversarial_examples/edge_cases.json
+++ b/data/adversarial_examples/edge_cases.json
@@ -1,0 +1,302 @@
+[
+  {
+    "category": "percentage_misinterpretation",
+    "prompt": "The success rate was 10%.",
+    "flawed_output": "The success rate was 11%.",
+    "critique": "The correct percentage is 10%, not 11%."
+  },
+  {
+    "category": "percentage_misinterpretation",
+    "prompt": "The success rate was 5%.",
+    "flawed_output": "The success rate was 6%.",
+    "critique": "The correct percentage is 5%, not 6%."
+  },
+  {
+    "category": "date_confusion",
+    "prompt": "The event occurred on 11/02/2018.",
+    "flawed_output": "The event occurred on 02/11/2018.",
+    "critique": "The date 02/11/2018 misinterprets the format; it should be 11/02/2018."
+  },
+  {
+    "category": "date_confusion",
+    "prompt": "The event occurred on 07/08/2019.",
+    "flawed_output": "The event occurred on 08/07/2019.",
+    "critique": "The date 08/07/2019 misinterprets the format; it should be 07/08/2019."
+  },
+  {
+    "category": "percentage_misinterpretation",
+    "prompt": "The success rate was 80%.",
+    "flawed_output": "The success rate was 84%.",
+    "critique": "The correct percentage is 80%, not 84%."
+  },
+  {
+    "category": "date_confusion",
+    "prompt": "The event occurred on 07/08/2019.",
+    "flawed_output": "The event occurred on 08/07/2019.",
+    "critique": "The date 08/07/2019 misinterprets the format; it should be 07/08/2019."
+  },
+  {
+    "category": "unit_swap",
+    "prompt": "The measurement was 10 meters.",
+    "flawed_output": "The measurement was 10 feet.",
+    "critique": "Confuses units: the correct value is 10 meters."
+  },
+  {
+    "category": "logical_fallacy",
+    "prompt": "All cats are mammals.",
+    "flawed_output": "Fido is a mammal, therefore Fido is a cat.",
+    "critique": "The conclusion does not logically follow from the premise."
+  },
+  {
+    "category": "unit_swap",
+    "prompt": "The measurement was 10 meters.",
+    "flawed_output": "The measurement was 10 feet.",
+    "critique": "Confuses units: the correct value is 10 meters."
+  },
+  {
+    "category": "date_confusion",
+    "prompt": "The event occurred on 01/04/2020.",
+    "flawed_output": "The event occurred on 04/01/2020.",
+    "critique": "The date 04/01/2020 misinterprets the format; it should be 01/04/2020."
+  },
+  {
+    "category": "historical_year_error",
+    "prompt": "The moon landing happened in 1969.",
+    "flawed_output": "The moon landing happened in 1996.",
+    "critique": "Incorrect year stated."
+  },
+  {
+    "category": "date_confusion",
+    "prompt": "The event occurred on 03/06/2022.",
+    "flawed_output": "The event occurred on 06/03/2022.",
+    "critique": "The date 06/03/2022 misinterprets the format; it should be 03/06/2022."
+  },
+  {
+    "category": "unit_swap",
+    "prompt": "The measurement was 20 kilometers.",
+    "flawed_output": "The measurement was 20 miles.",
+    "critique": "Confuses units: the correct value is 20 kilometers."
+  },
+  {
+    "category": "logical_fallacy",
+    "prompt": "If it rains, the ground gets wet.",
+    "flawed_output": "The ground is wet, so it rained.",
+    "critique": "The conclusion does not logically follow from the premise."
+  },
+  {
+    "category": "percentage_misinterpretation",
+    "prompt": "The success rate was 10%.",
+    "flawed_output": "The success rate was 19%.",
+    "critique": "The correct percentage is 10%, not 19%."
+  },
+  {
+    "category": "logical_fallacy",
+    "prompt": "All cats are mammals.",
+    "flawed_output": "Fido is a mammal, therefore Fido is a cat.",
+    "critique": "The conclusion does not logically follow from the premise."
+  },
+  {
+    "category": "historical_year_error",
+    "prompt": "The Berlin Wall fell in 1989.",
+    "flawed_output": "The Berlin Wall fell in 1998.",
+    "critique": "Incorrect year stated."
+  },
+  {
+    "category": "percentage_misinterpretation",
+    "prompt": "The success rate was 25%.",
+    "flawed_output": "The success rate was 28%.",
+    "critique": "The correct percentage is 25%, not 28%."
+  },
+  {
+    "category": "percentage_misinterpretation",
+    "prompt": "The success rate was 90%.",
+    "flawed_output": "The success rate was 91%.",
+    "critique": "The correct percentage is 90%, not 91%."
+  },
+  {
+    "category": "date_confusion",
+    "prompt": "The event occurred on 12/05/2021.",
+    "flawed_output": "The event occurred on 05/12/2021.",
+    "critique": "The date 05/12/2021 misinterprets the format; it should be 12/05/2021."
+  },
+  {
+    "category": "logical_fallacy",
+    "prompt": "If it rains, the ground gets wet.",
+    "flawed_output": "The ground is wet, so it rained.",
+    "critique": "The conclusion does not logically follow from the premise."
+  },
+  {
+    "category": "historical_year_error",
+    "prompt": "The first iPhone launched in 2007.",
+    "flawed_output": "The first iPhone launched in 2017.",
+    "critique": "Incorrect year stated."
+  },
+  {
+    "category": "unit_swap",
+    "prompt": "The measurement was 100 Celsius.",
+    "flawed_output": "The measurement was 100 Fahrenheit.",
+    "critique": "Confuses units: the correct value is 100 Celsius."
+  },
+  {
+    "category": "percentage_misinterpretation",
+    "prompt": "The success rate was 30%.",
+    "flawed_output": "The success rate was 34%.",
+    "critique": "The correct percentage is 30%, not 34%."
+  },
+  {
+    "category": "logical_fallacy",
+    "prompt": "If I study, I'll pass the exam.",
+    "flawed_output": "I passed the exam, so I must have studied.",
+    "critique": "The conclusion does not logically follow from the premise."
+  },
+  {
+    "category": "unit_swap",
+    "prompt": "The measurement was 5 kilograms.",
+    "flawed_output": "The measurement was 5 pounds.",
+    "critique": "Confuses units: the correct value is 5 kilograms."
+  },
+  {
+    "category": "percentage_misinterpretation",
+    "prompt": "The success rate was 25%.",
+    "flawed_output": "The success rate was 34%.",
+    "critique": "The correct percentage is 25%, not 34%."
+  },
+  {
+    "category": "logical_fallacy",
+    "prompt": "If the alarm is set, the door locks.",
+    "flawed_output": "The door is locked, so the alarm is set.",
+    "critique": "The conclusion does not logically follow from the premise."
+  },
+  {
+    "category": "historical_year_error",
+    "prompt": "The Declaration of Independence was signed in 1776.",
+    "flawed_output": "The Declaration of Independence was signed in 1767.",
+    "critique": "Incorrect year stated."
+  },
+  {
+    "category": "unit_swap",
+    "prompt": "The measurement was 20 kilometers.",
+    "flawed_output": "The measurement was 20 miles.",
+    "critique": "Confuses units: the correct value is 20 kilometers."
+  },
+  {
+    "category": "logical_fallacy",
+    "prompt": "If I study, I'll pass the exam.",
+    "flawed_output": "I passed the exam, so I must have studied.",
+    "critique": "The conclusion does not logically follow from the premise."
+  },
+  {
+    "category": "logical_fallacy",
+    "prompt": "If the alarm is set, the door locks.",
+    "flawed_output": "The door is locked, so the alarm is set.",
+    "critique": "The conclusion does not logically follow from the premise."
+  },
+  {
+    "category": "historical_year_error",
+    "prompt": "The moon landing happened in 1969.",
+    "flawed_output": "The moon landing happened in 1996.",
+    "critique": "Incorrect year stated."
+  },
+  {
+    "category": "historical_year_error",
+    "prompt": "The Berlin Wall fell in 1989.",
+    "flawed_output": "The Berlin Wall fell in 1998.",
+    "critique": "Incorrect year stated."
+  },
+  {
+    "category": "logical_fallacy",
+    "prompt": "If it rains, the ground gets wet.",
+    "flawed_output": "The ground is wet, so it rained.",
+    "critique": "The conclusion does not logically follow from the premise."
+  },
+  {
+    "category": "date_confusion",
+    "prompt": "The event occurred on 01/04/2020.",
+    "flawed_output": "The event occurred on 04/01/2020.",
+    "critique": "The date 04/01/2020 misinterprets the format; it should be 01/04/2020."
+  },
+  {
+    "category": "logical_fallacy",
+    "prompt": "All cats are mammals.",
+    "flawed_output": "Fido is a mammal, therefore Fido is a cat.",
+    "critique": "The conclusion does not logically follow from the premise."
+  },
+  {
+    "category": "historical_year_error",
+    "prompt": "The Berlin Wall fell in 1989.",
+    "flawed_output": "The Berlin Wall fell in 1998.",
+    "critique": "Incorrect year stated."
+  },
+  {
+    "category": "percentage_misinterpretation",
+    "prompt": "The success rate was 10%.",
+    "flawed_output": "The success rate was 17%.",
+    "critique": "The correct percentage is 10%, not 17%."
+  },
+  {
+    "category": "historical_year_error",
+    "prompt": "The Declaration of Independence was signed in 1776.",
+    "flawed_output": "The Declaration of Independence was signed in 1767.",
+    "critique": "Incorrect year stated."
+  },
+  {
+    "category": "date_confusion",
+    "prompt": "The event occurred on 07/08/2019.",
+    "flawed_output": "The event occurred on 08/07/2019.",
+    "critique": "The date 08/07/2019 misinterprets the format; it should be 07/08/2019."
+  },
+  {
+    "category": "unit_swap",
+    "prompt": "The measurement was 5 kilograms.",
+    "flawed_output": "The measurement was 5 pounds.",
+    "critique": "Confuses units: the correct value is 5 kilograms."
+  },
+  {
+    "category": "historical_year_error",
+    "prompt": "The moon landing happened in 1969.",
+    "flawed_output": "The moon landing happened in 1996.",
+    "critique": "Incorrect year stated."
+  },
+  {
+    "category": "date_confusion",
+    "prompt": "The event occurred on 11/02/2018.",
+    "flawed_output": "The event occurred on 02/11/2018.",
+    "critique": "The date 02/11/2018 misinterprets the format; it should be 11/02/2018."
+  },
+  {
+    "category": "unit_swap",
+    "prompt": "The measurement was 20 kilometers.",
+    "flawed_output": "The measurement was 20 miles.",
+    "critique": "Confuses units: the correct value is 20 kilometers."
+  },
+  {
+    "category": "historical_year_error",
+    "prompt": "The first iPhone launched in 2007.",
+    "flawed_output": "The first iPhone launched in 2017.",
+    "critique": "Incorrect year stated."
+  },
+  {
+    "category": "unit_swap",
+    "prompt": "The measurement was 20 kilometers.",
+    "flawed_output": "The measurement was 20 miles.",
+    "critique": "Confuses units: the correct value is 20 kilometers."
+  },
+  {
+    "category": "date_confusion",
+    "prompt": "The event occurred on 12/05/2021.",
+    "flawed_output": "The event occurred on 05/12/2021.",
+    "critique": "The date 05/12/2021 misinterprets the format; it should be 12/05/2021."
+  },
+  {
+    "category": "unit_swap",
+    "prompt": "The measurement was 10 meters.",
+    "flawed_output": "The measurement was 10 feet.",
+    "critique": "Confuses units: the correct value is 10 meters."
+  },
+  {
+    "category": "percentage_misinterpretation",
+    "prompt": "The success rate was 10%.",
+    "flawed_output": "The success rate was 14%.",
+    "critique": "The correct percentage is 10%, not 14%."
+  }
+]

--- a/docs/adversarial_dataset.md
+++ b/docs/adversarial_dataset.md
@@ -1,0 +1,12 @@
+# Adversarial Edge-Case Dataset
+
+This folder stores a curated set of adversarial examples targeting known weaknesses of the Evaluator agent. All files live under `data/adversarial_examples/`.
+
+## Curation Process
+1. Identified common failure modes such as percentage misreads, date format confusion, unit swaps, logical fallacies, and historical year mistakes.
+2. Wrote the script `scripts/generate_adversarial_examples.py` to automatically produce examples exhibiting these errors alongside short critiques.
+3. Generated 50 total records (10 per category) with a fixed random seed for reproducibility.
+
+## File Overview
+- `edge_cases.json` – JSON list of adversarial examples used to harden the Evaluator.
+- `generate_adversarial_examples.py` – Script that creates the dataset.

--- a/scripts/generate_adversarial_examples.py
+++ b/scripts/generate_adversarial_examples.py
@@ -1,0 +1,145 @@
+import json
+import random
+from pathlib import Path
+
+CATEGORIES = [
+    "percentage_misinterpretation",
+    "date_confusion",
+    "unit_swap",
+    "logical_fallacy",
+    "historical_year_error",
+]
+
+
+def percentage_examples(n: int) -> list[dict]:
+    base = [5, 10, 20, 25, 30, 40, 60, 75, 80, 90]
+    examples = []
+    for _ in range(n):
+        correct = random.choice(base)
+        mis = (correct + random.randint(1, 9)) % 100
+        examples.append(
+            {
+                "category": "percentage_misinterpretation",
+                "prompt": f"The success rate was {correct}%.",
+                "flawed_output": f"The success rate was {mis}%.",
+                "critique": f"The correct percentage is {correct}%, not {mis}%.",
+            }
+        )
+    return examples
+
+
+def date_examples(n: int) -> list[dict]:
+    dates = [
+        ("03/06/2022", "06/03/2022"),
+        ("12/05/2021", "05/12/2021"),
+        ("01/04/2020", "04/01/2020"),
+        ("07/08/2019", "08/07/2019"),
+        ("11/02/2018", "02/11/2018"),
+    ]
+    examples = []
+    for _ in range(n):
+        correct, wrong = random.choice(dates)
+        examples.append(
+            {
+                "category": "date_confusion",
+                "prompt": f"The event occurred on {correct}.",
+                "flawed_output": f"The event occurred on {wrong}.",
+                "critique": f"The date {wrong} misinterprets the format; it should be {correct}.",
+            }
+        )
+    return examples
+
+
+def unit_examples(n: int) -> list[dict]:
+    pairs = [
+        ("10 meters", "10 feet"),
+        ("5 kilograms", "5 pounds"),
+        ("20 kilometers", "20 miles"),
+        ("100 Celsius", "100 Fahrenheit"),
+        ("2 liters", "2 gallons"),
+    ]
+    examples = []
+    for _ in range(n):
+        metric, imperial = random.choice(pairs)
+        examples.append(
+            {
+                "category": "unit_swap",
+                "prompt": f"The measurement was {metric}.",
+                "flawed_output": f"The measurement was {imperial}.",
+                "critique": f"Confuses units: the correct value is {metric}.",
+            }
+        )
+    return examples
+
+
+def fallacy_examples(n: int) -> list[dict]:
+    statements = [
+        ("If it rains, the ground gets wet.", "The ground is wet, so it rained."),
+        ("All birds can fly.", "Penguins are birds, so penguins can fly."),
+        (
+            "If the alarm is set, the door locks.",
+            "The door is locked, so the alarm is set.",
+        ),
+        ("If I study, I'll pass the exam.", "I passed the exam, so I must have studied."),
+        ("All cats are mammals.", "Fido is a mammal, therefore Fido is a cat."),
+    ]
+    examples = []
+    for _ in range(n):
+        premise, wrong = random.choice(statements)
+        examples.append(
+            {
+                "category": "logical_fallacy",
+                "prompt": premise,
+                "flawed_output": wrong,
+                "critique": "The conclusion does not logically follow from the premise.",
+            }
+        )
+    return examples
+
+
+def year_examples(n: int) -> list[dict]:
+    facts = [
+        ("The moon landing happened in 1969.", "The moon landing happened in 1996."),
+        ("The Berlin Wall fell in 1989.", "The Berlin Wall fell in 1998."),
+        (
+            "The Declaration of Independence was signed in 1776.",
+            "The Declaration of Independence was signed in 1767.",
+        ),
+        ("World War II ended in 1945.", "World War II ended in 1954."),
+        ("The first iPhone launched in 2007.", "The first iPhone launched in 2017."),
+    ]
+    examples = []
+    for _ in range(n):
+        correct, wrong = random.choice(facts)
+        examples.append(
+            {
+                "category": "historical_year_error",
+                "prompt": correct,
+                "flawed_output": wrong,
+                "critique": "Incorrect year stated.",
+            }
+        )
+    return examples
+
+
+def generate_dataset(count_per_category: int = 10) -> list[dict]:
+    random.seed(42)
+    data = []
+    data.extend(percentage_examples(count_per_category))
+    data.extend(date_examples(count_per_category))
+    data.extend(unit_examples(count_per_category))
+    data.extend(fallacy_examples(count_per_category))
+    data.extend(year_examples(count_per_category))
+    random.shuffle(data)
+    return data
+
+
+def main() -> None:
+    dataset = generate_dataset()
+    out_path = Path("data/adversarial_examples/edge_cases.json")
+    out_path.write_text(json.dumps(dataset, indent=2))
+    print(f"Wrote {out_path} with {len(dataset)} records")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate adversarial edge cases dataset covering percentages, dates, unit swaps, logical fallacies and historical years
- add script to create the dataset
- document dataset in new markdown file

## Testing
- `pre-commit run --all-files` *(fails: E501 in scripts/generate_synthetic_examples.py)*
- `pytest -q` *(fails: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684ef12069a8832aaf67367e1ee0f709