### PR TITLE
Add Phase 1 UAT gap analysis

### DIFF
--- a/codex_tasks.md
+++ b/codex_tasks.md
@@ -31,6 +31,15 @@ acceptance_criteria:
 - [ ] When the developer attempts to create a commit
 - [ ] Then the pre-commit hook fails and prevents the commit
 
+```codex-task
+id: P1-01
+title: Set up mono-repo for agentic system
+status: in_progress
+notes: Branch protection not verifiable from repo; pre-commit configured
+steps: []
+acceptance_criteria: []
+```
+
 ## P1-02: Implement CI pipeline for automated builds and tests ✅
 
 **Goal:** Implement a CI pipeline using a standard platform (e.
@@ -388,6 +397,15 @@ acceptance_criteria: []
 - [ ] When the CI pipeline runs
 - [ ] Then the code coverage check fails and the pipeline is marked as "failed"
 
+```codex-task
+id: P1-19
+title: Create basic unit test framework and coverage goals
+status: in_progress
+notes: Tests exist but coverage threshold not enforced in CI
+steps: []
+acceptance_criteria: []
+```
+
 ## P2-01: Implement LTM Service API for memory operations
 
 **Goal:** Implement the public-facing API for the Long-Term Memory (LTM) service.
@@ -403,6 +421,15 @@ acceptance_criteria: []
 - [ ] Given a memory record has been previously stored
 - [ ] When a GET request is sent to the /retrieve endpoint with a relevant query
 - [ ] Then the service returns the corresponding memory record
+
+```codex-task
+id: P2-01
+title: Implement LTM Service API for memory operations
+status: in_progress
+notes: Endpoint works but `memory_type` validation and RBAC checks are missing
+steps: []
+acceptance_criteria: []
+```
 
 ## P2-02: Integrate vector database for Episodic Memory
 

--- a/docs/phase1_uat_gap_analysis.md
+++ b/docs/phase1_uat_gap_analysis.md
@@ -1,0 +1,51 @@
+# Phase 1 UAT Gap Analysis
+
+This report compares the repository implementation against the Phase 1 change requests defined in [BLUEPRINT.md](../BLUEPRINT.md). Each requirement is mapped to the relevant modules with a status indicator:
+
+- ✓ implemented
+- ⚠ partial
+- ✗ missing
+
+## Blueprint Coverage Matrix
+
+| CR | Title | Modules / Files | Status |
+|----|-------|-----------------|-------|
+| P1-01 | Mono-repo setup & pre-commit hooks | `.pre-commit-config.yaml`, repo structure | ⚠ Partial |
+| P1-02 | CI pipeline | `.github/workflows/ci.yml` | ✓ |
+| P1-03 | CD pipeline | `.github/workflows/cd.yml` | ✓ |
+| P1-04 | OpenTelemetry collector | `otel-collector-config.yaml` | ✓ |
+| P1-05 | Tracing schema | `docs/tracing_schema.md` | ✓ |
+| P1-06 | Orchestration engine | `engine/orchestration_engine.py` | ✓ |
+| P1-07 | State object | `engine/state.py` | ✓ |
+| P1-08 | Conditional routing | `engine/routing.py` | ✓ |
+| P1-09 | Supervisor agent | `agents/supervisor.py`, `agents/Supervisor/` | ✓ |
+| P1-10 | Supervisor planning logic | `agents/supervisor.py` | ✓ |
+| P1-11 | WebResearcher agent | `agents/web_researcher.py`, `agents/WebResearcher/` | ✓ |
+| P1-12 | WebResearcher summarization | `agents/web_researcher.py` | ✓ |
+| P1-13 | Tool Registry service | `services/tool_registry/` | ✓ |
+| P1-14 | Web Search tool | `tools/web_search.py` | ✓ |
+| P1-15 | PDF Reader tool | `tools/pdf_extract.py` | ✓ |
+| P1-16 | HTML Scraper tool | `tools/html_scraper.py` | ✓ |
+| P1-17 | BrowseComp dataset | `benchmarks/browsecomp_v1.json` | ✓ |
+| P1-18 | Integration-test harness | `tests/test_browsecomp_harness.py` | ✓ |
+| P1-19 | Unit test framework & coverage | `.github/workflows/ci.yml`, `tests/` | ⚠ Partial |
+| P1-20 | Graph compilation research | `docs/graph_compilation_research.md` | ✓ |
+
+## Identified Gaps
+
+1. **Branch protection & policy enforcement (P1‑01 – High)**
+   - Pre-commit hooks are configured, but branch protection cannot be confirmed from the repository. Documentation should outline required settings.
+2. **Coverage enforcement (P1‑19 – Medium)**
+   - Unit tests exist, but the CI workflow does not enforce a minimum coverage threshold.
+3. **LTM API validation and RBAC (P2‑01 – High)**
+   - The LTM service lacks strict validation for the `memory_type` field and endpoint-level access control.
+
+## Recommended Remediation
+
+- Document branch protection rules and ensure they are enforced in repository settings.
+- Add a coverage check (e.g., `pytest --cov` with a minimum threshold) to the CI workflow.
+- Enhance the LTM API with input validation and integrate RBAC checks.
+
+## Review Session
+
+A review walkthrough should cover these findings and confirm remediation plans ahead of Phase 1 UAT.

--- a/docs/uat_review_agenda.md
+++ b/docs/uat_review_agenda.md
@@ -1,0 +1,9 @@
+# Phase 1 UAT Review Session
+
+The following agenda is proposed for the walkthrough with the engineering team.
+
+1. **Overview of Gap Analysis findings** – review the coverage matrix and noted gaps.
+2. **Open items** – discuss remediation steps for branch protection and coverage enforcement.
+3. **LTM API improvements** – confirm scope and timeline for validation and RBAC.
+4. **Test harness status** – verify benchmark harness results and metrics.
+5. **Next steps** – agree on owners and due dates before Phase 1 UAT.


### PR DESCRIPTION
## Summary
- mark P1-01, P1-19 and P2-01 status in `codex_tasks.md`
- document implementation coverage in `docs/phase1_uat_gap_analysis.md`
- add `docs/uat_review_agenda.md` for the upcoming review session

## Testing
- `pre-commit run --files codex_tasks.md docs/phase1_uat_gap_analysis.md docs/uat_review_agenda.md`
- `pytest -q` *(fails: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684ef19100fc832aa286b375358a7be9