### PR TITLE
Add teacher LLM dataset generator

### DIFF
--- a/docs/teacher_data_pipeline.md
+++ b/docs/teacher_data_pipeline.md
@@ -1,0 +1,12 @@
+# Teacher LLM Data Generation Pipeline
+
+This document describes the pipeline used to create synthetic self-correction examples for the Evaluator agent.
+
+The pipeline prompts a powerful "teacher" model with a short topic. The model must reply with a JSON object containing:
+
+- `original_problem`
+- `flawed_output`
+- `detailed_critique`
+- `corrected_solution`
+
+Results are stored under `data/teacher_dataset/`.

--- a/pipelines/teacher/__init__.py
+++ b/pipelines/teacher/__init__.py
@@ -1,0 +1,3 @@
+from .pipeline import TeacherDataPipeline
+
+__all__ = ["TeacherDataPipeline"]

--- a/pipelines/teacher/pipeline.py
+++ b/pipelines/teacher/pipeline.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, Dict, List
+
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+
+class TeacherDataPipeline:
+    """Generate synthetic self-correction examples using a teacher LLM."""
+
+    def __init__(self, llm: Callable[[str], str], out_dir: str | Path = "data/teacher_dataset") -> None:
+        self.llm = llm
+        self.out_dir = Path(out_dir)
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+
+    def _build_prompt(self, topic: str) -> str:
+        return (
+            "You are a knowledgeable instructor. "
+            "Given the following topic, act like a typical student who makes a reasoning mistake. "
+            "Provide a JSON object with fields: original_problem, flawed_output, detailed_critique, corrected_solution. "
+            "Topic: "
+            + topic
+        )
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=4))
+    def _call_llm(self, prompt: str) -> str:
+        return self.llm(prompt)
+
+    def generate_example(self, topic: str) -> Dict[str, str]:
+        prompt = self._build_prompt(topic)
+        response = self._call_llm(prompt)
+        data = json.loads(str(response))
+        required = ["original_problem", "flawed_output", "detailed_critique", "corrected_solution"]
+        if not all(key in data for key in required):
+            raise ValueError("Missing required fields in LLM response")
+        return data
+
+    def run(self, topics: List[str], out_file: str | Path | None = None) -> List[Dict[str, str]]:
+        results = []
+        for topic in topics:
+            try:
+                results.append(self.generate_example(topic))
+            except Exception:
+                continue
+        if out_file:
+            Path(out_file).write_text(json.dumps(results, indent=2), encoding="utf-8")
+        return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ langchain
 langgraph
 langsmith
 googletrans==4.0.0rc1
+openai

--- a/scripts/generate_synthetic_examples.py
+++ b/scripts/generate_synthetic_examples.py
@@ -1,13 +1,24 @@
 import json
 import random
 from pathlib import Path
+
 from googletrans import Translator
 
 translator = Translator()
 
 SAMPLES = [
-    "Long-Term Memory Consolidation & Forgetting Research (P2-19A)\n\nThis document summarizes a research spike into lifecycle management algorithms for the Long-Term Memory (LTM) service. The goal was to compare advanced forgetting strategies and recommend an approach for Phase 2 implementation.",
-    "Graph Compilation Strategies Research\n\nA short research spike evaluated dynamic graph execution versus ahead-of-time compilation for the orchestration engine."
+    (
+        "Long-Term Memory Consolidation & Forgetting Research (P2-19A)"
+        "\n\nThis document summarizes a research spike into lifecycle management"
+        " algorithms for the Long-Term Memory (LTM) service. The goal was to"
+        " compare advanced forgetting strategies and recommend an approach for"
+        " Phase 2 implementation."
+    ),
+    (
+        "Graph Compilation Strategies Research"
+        "\n\nA short research spike evaluated dynamic graph execution versus"
+        " ahead-of-time compilation for the orchestration engine."
+    ),
 ]
 
 
@@ -36,11 +47,13 @@ def main():
     for text in SAMPLES:
         bt = back_translate(text)
         typo = inject_typos(text)
-        data.append({
-            "original": text,
-            "back_translation": bt,
-            "typo_perturbation": typo,
-        })
+        data.append(
+            {
+                "original": text,
+                "back_translation": bt,
+                "typo_perturbation": typo,
+            }
+        )
     out_path = Path("data/synthetic_self_correction/sample_pairs.json")
     out_path.write_text(json.dumps(data, indent=2))
     print(f"Wrote {out_path}")

--- a/scripts/teacher_data_generator.py
+++ b/scripts/teacher_data_generator.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+import os
+
+import openai
+
+from pipelines.teacher import TeacherDataPipeline
+
+
+def openai_llm(prompt: str) -> str:
+    response = openai.ChatCompletion.create(
+        model=os.getenv("TEACHER_MODEL", "gpt-4"),
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message["content"]
+
+
+def main():
+    topics_path = Path("data/topics.txt")
+    topics = topics_path.read_text(encoding="utf-8").splitlines()
+    pipeline = TeacherDataPipeline(openai_llm)
+    results = pipeline.run(topics)
+    out_file = Path("data/teacher_dataset/generated.json")
+    out_file.write_text(json.dumps(results, indent=2), encoding="utf-8")
+    print(f"Wrote {len(results)} examples to {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_teacher_pipeline.py
+++ b/tests/test_teacher_pipeline.py
@@ -1,0 +1,41 @@
+import json
+
+from pipelines.teacher import TeacherDataPipeline
+
+
+def test_generate_example_valid():
+    def fake_llm(prompt: str) -> str:
+        return json.dumps({
+            "original_problem": "Q",
+            "flawed_output": "A",
+            "detailed_critique": "factual error",
+            "corrected_solution": "C",
+        })
+
+    pipeline = TeacherDataPipeline(fake_llm)
+    result = pipeline.generate_example("topic")
+    assert result["flawed_output"] == "A"
+
+
+def test_pipeline_diverse_error_types():
+    critiques = [
+        "factual mistake in reasoning",
+        "logical fallacy explanation",
+        "omission of key detail",
+    ]
+
+    def fake_llm(_prompt: str) -> str:
+        text = critiques.pop(0)
+        return json.dumps({
+            "original_problem": "P",
+            "flawed_output": "F",
+            "detailed_critique": text,
+            "corrected_solution": "C",
+        })
+
+    pipeline = TeacherDataPipeline(fake_llm)
+    results = pipeline.run(["t1", "t2", "t3"])
+    detail_texts = [r["detailed_critique"] for r in results]
+    assert any("factual" in d for d in detail_texts)
+    assert any("logical" in d for d in detail_texts)
+    assert any("omission" in d for d in detail_texts)


### PR DESCRIPTION
## Summary
- implement `TeacherDataPipeline` for generating self-correction examples
- add CLI script that calls OpenAI API to create the dataset
- document the new pipeline
- include tests for pipeline behavior
- format existing synthetic example script
- add `openai` to requirements

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684eef9e4d04832aaf817488121e98b2