### PR TITLE
Add coverage gates to CI

### DIFF
--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -34,5 +34,11 @@ jobs:
       - name: Run linters and formatters
         run: pre-commit run --all-files
 
-      - name: Run test suite
-        run: pytest -v
+      - name: Run test suite with coverage
+        run: pytest --cov=./ --cov-report=xml --cov-fail-under=80 -v
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Contributions are welcome and encouraged! Please follow these steps to contribut
 
 All pull requests will be automatically validated by the CI pipeline (P1-02), which includes running linters, unit tests, and checking for code coverage. A review from at least one core team member is required for a PR to be merged.
 Branch protection rules on `main` enforce these checks so direct pushes are rejected.
+For instructions on running the pipeline locally and the required 80% coverage threshold, see [docs/ci.md](docs/ci.md).
 
 ## **10. License**
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,19 @@
+# Continuous Integration Guidelines
+
+This project uses GitHub Actions to run tests and code quality checks on every pull request.
+The main workflow is defined in `.github/workflows/ci.yml` and ensures that all
+linters pass and the full test suite runs with coverage enabled.
+
+## Coverage Gates
+
+All test jobs invoke `pytest` with the `pytest-cov` plugin. The workflow fails if
+overall coverage drops below **80%**. Coverage results are stored in `coverage.xml`
+and uploaded as a workflow artifact. Developers should run the following before
+pushing changes:
+
+```bash
+pytest --cov=./ --cov-report=xml --cov-fail-under=80
+```
+
+This mirrors the CI behaviour so local failures can be detected early.
+


### PR DESCRIPTION
## Summary
- enforce coverage checks in the minimal CI workflow
- document coverage requirement in docs/ci.md
- reference CI guide from README

## Testing
- `pre-commit run --files .github/workflows/minimal-ci.yml docs/ci.md README.md`
- `pytest --cov=./ --cov-report=term --cov-fail-under=80 -v` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684efab956c8832a860e9d3d4b903929