### PR TITLE
Enhance integration test harness

### DIFF
--- a/.github/workflows/integration-benchmarks.yml
+++ b/.github/workflows/integration-benchmarks.yml
@@ -25,4 +25,5 @@ jobs:
         env:
           HARNESS_TIMEOUT: '60'
           HARNESS_RETRIES: '1'
+          HARNESS_RETRY_DELAY: '0.5'
         run: python tests/benchmarks/integration_harness.py

--- a/docs/integration_tests.md
+++ b/docs/integration_tests.md
@@ -1,0 +1,23 @@
+# Integration Test Harness
+
+This document describes how to run the BrowseComp integration tests and configure the harness.
+
+## Running the Harness
+
+Run the harness directly:
+
+```bash
+python tests/benchmarks/integration_harness.py
+```
+
+The harness will iterate over the dataset and report pass rates and timing statistics.
+
+## Configuration
+
+Several options can be configured via environment variables:
+
+- `HARNESS_TIMEOUT` – per-question timeout in seconds (default `30`)
+- `HARNESS_RETRIES` – number of retry attempts for each question on failure (default `0`)
+- `HARNESS_RETRY_DELAY` – delay in seconds between retries (default `0.1`)
+
+These variables allow the integration tests to handle flaky external calls and long-running tasks.


### PR DESCRIPTION
## Summary
- improve BrowseComp integration harness with retry logic and logging
- document new environment variables for integration tests
- support retry delay configuration in CI workflow
- test harness retry behaviour

## Testing
- `pre-commit run --files tests/benchmarks/integration_harness.py tests/test_browsecomp_harness.py docs/integration_tests.md .github/workflows/integration-benchmarks.yml`
- `pytest tests/test_browsecomp_harness.py::test_harness_retries_on_failure -q`

------
https://chatgpt.com/codex/tasks/task_e_684efd883494832aaaa444b7bb4c44aa