### PR TITLE
Add Supervisor plan schema validation

### DIFF
--- a/agents/supervisor.py
+++ b/agents/supervisor.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
-from jsonschema import ValidationError, validate
+from pykwalify.core import Core
 
 from tools.ltm_client import retrieve_memory
 
@@ -26,7 +26,7 @@ class State:
 
 class SupervisorAgent:
     SCHEMA_PATH = (
-        Path(__file__).resolve().parent.parent / "docs" / "supervisor_plan_schema.yaml"
+        Path(__file__).resolve().parent.parent / "schemas" / "supervisor_plan.yaml"
     )
 
     def __init__(
@@ -113,14 +113,14 @@ class SupervisorAgent:
     # Validation helpers
     # ------------------------------------------------------------------
     def validate_plan(self, plan: Dict[str, Any]) -> None:
-        """Validate a plan dictionary against the JSON schema."""
+        """Validate a plan dictionary against the YAML schema."""
 
         if not self.plan_schema:
             return
         try:
-            validate(instance=plan, schema=self.plan_schema)
-        except ValidationError as exc:
-            raise ValueError(f"plan validation error: {exc.message}") from exc
+            Core(source_data=plan, schema_data=self.plan_schema).validate()
+        except Exception as exc:
+            raise ValueError(f"plan validation error: {exc}") from exc
 
     # ------------------------------------------------------------------
     # YAML helpers

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Pillow
 beautifulsoup4
 readability-lxml
 jsonschema
+pykwalify
 
 opentelemetry-api
 opentelemetry-sdk

--- a/schemas/supervisor_plan.yaml
+++ b/schemas/supervisor_plan.yaml
@@ -1,0 +1,57 @@
+type: map
+mapping:
+  query:
+    type: str
+    required: yes
+  context:
+    type: seq
+    required: yes
+  graph:
+    type: map
+    required: yes
+    mapping:
+      nodes:
+        type: seq
+        required: yes
+        sequence:
+          - type: map
+            required: yes
+            mapping:
+              id:
+                type: str
+                required: yes
+              agent:
+                type: str
+                required: yes
+              topic:
+                type: str
+                required: no
+              task:
+                type: str
+                required: no
+      edges:
+        type: seq
+        required: yes
+        sequence:
+          - type: map
+            required: yes
+            mapping:
+              from:
+                type: str
+                required: yes
+              to:
+                type: str
+                required: yes
+      parallel_groups:
+        type: seq
+        sequence:
+          - type: seq
+            sequence:
+              - type: str
+  evaluation:
+    type: map
+    required: yes
+    mapping:
+      metric:
+        type: str
+

--- a/tests/fixtures/invalid_supervisor_plan.yaml
+++ b/tests/fixtures/invalid_supervisor_plan.yaml
@@ -1,0 +1,6 @@
+query: q
+graph:
+  nodes:
+    - id: n1
+      agent: WebResearcher
+

--- a/tests/fixtures/valid_supervisor_plan.yaml
+++ b/tests/fixtures/valid_supervisor_plan.yaml
@@ -1,0 +1,16 @@
+query: sample
+context: []
+graph:
+  nodes:
+    - id: research_0
+      agent: WebResearcher
+      topic: sample
+    - id: synthesis
+      agent: Supervisor
+      task: synthesize
+  edges:
+    - from: research_0
+      to: synthesis
+evaluation:
+  metric: quality
+

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from threading import Thread
 
 import pytest
@@ -127,3 +128,19 @@ def test_plan_handles_no_memories():
     plan = agent.plan_research_task("missing")
     assert plan["context"] == []
     server.httpd.shutdown()
+
+
+def test_valid_plan_fixture_passes_schema():
+    agent = SupervisorAgent()
+    path = Path("tests/fixtures/valid_supervisor_plan.yaml")
+    yaml_text = path.read_text(encoding="utf-8")
+    plan = agent.parse_plan(yaml_text)
+    assert plan["query"] == "sample"
+
+
+def test_invalid_plan_fixture_fails_schema():
+    agent = SupervisorAgent()
+    path = Path("tests/fixtures/invalid_supervisor_plan.yaml")
+    yaml_text = path.read_text(encoding="utf-8")
+    with pytest.raises(ValueError):
+        agent.parse_plan(yaml_text)


### PR DESCRIPTION
## Summary
- define YAML schema for Supervisor plans
- validate plan dictionaries with pykwalify
- add fixtures for valid and invalid plans
- add tests covering plan validation
- add `pykwalify` to requirements

## Testing
- `pre-commit run --files agents/supervisor.py requirements.txt tests/test_supervisor.py schemas/supervisor_plan.yaml tests/fixtures/valid_supervisor_plan.yaml tests/fixtures/invalid_supervisor_plan.yaml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'googletrans')*

------
https://chatgpt.com/codex/tasks/task_e_684efd697d58832a89807fd18cadec70