### PR TITLE
Add security review report

### DIFF
--- a/docs/security_report_P2-Review-02.md
+++ b/docs/security_report_P2-Review-02.md
@@ -1,0 +1,46 @@
+# Security Review Report: P2-Review-02
+
+This document summarizes the results of a lightweight security review of the repository. The review followed the steps outlined in the Codex task P2-Review-02.
+
+## Dependency Vulnerability Scan
+
+`pip-audit` was attempted on `requirements.txt` but failed to complete within the execution environment. The generated report (`pip_audit_report.txt`) is empty. No vulnerability breakdown is available.
+
+## Input Handling Review
+
+We manually inspected the Supervisor agent and tool wrappers for handling of user inputs:
+
+- `agents/supervisor.py` validates that the query is a non-empty string before processing.
+- `tools/pdf_reader.py` sanitizes URLs using `urlparse` and checks for OCR fallback, but relies on user provided paths/URLs without further validation.
+- `tools/html_scraper.py` and `tools/web_search.py` validate response status codes and check for empty inputs.
+
+No explicit injection vulnerabilities were discovered, although tighter input validation (e.g., allowed URL schemes) is recommended.
+
+## Secret Management
+
+Searches for hard‑coded credentials found no API keys or passwords in the codebase. The tooling expects credentials from environment variables (e.g., `SEARCH_API_KEY`, `FACT_CHECK_API_KEY`).
+
+## RBAC Enforcement Testing
+
+`tests/test_tool_registry.py::test_registry_authorization` was executed. The test confirms that only authorized roles can access registered tools.
+
+## Security Scorecard
+
+| Category | Count |
+| --- | --- |
+| Critical vulnerabilities | N/A (scan failed) |
+| High vulnerabilities | N/A |
+| Medium vulnerabilities | N/A |
+| Low vulnerabilities | N/A |
+| Input handling issues | 0 critical issues found |
+| Secrets exposures | 0 found |
+| RBAC lapses | 0 found (based on test) |
+
+## Change Requests
+
+1. **Integrate automated dependency scanning** – add a CI job running `pip-audit` (or Snyk) to detect known vulnerabilities early. *Urgency: High*
+2. **Validate file and URL inputs** – implement whitelisting of URL schemes and path sanitization in `pdf_extract` and `html_scraper` to reduce injection risks. *Urgency: Medium*
+3. **Document secrets management** – provide guidance in the README for storing API keys in a secret manager rather than environment variables when deployed. *Urgency: Medium*
+4. **Expand RBAC logging** – record failed authorization attempts in `ToolRegistryServer` for auditability. *Urgency: Low*
+5. **Monitor third‑party package updates** – create a monthly process to update dependencies and re-run the audit. *Urgency: Low*
+


### PR DESCRIPTION
## Summary
- add report summarizing security audit findings
- include empty `pip_audit_report.txt` showing scan failed

## Testing
- `pre-commit run --files docs/security_report_P2-Review-02.md pip_audit_report.txt`
- `pytest tests/test_tool_registry.py::test_registry_authorization -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0023dc60832ab6515ca6a9cd533e