### PR TITLE
Add OpenAPI docs for LTM service

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,17 @@
+# LTM Service API
+
+The Long-Term Memory (LTM) service exposes an OpenAPI specification to help developers integrate with the service.
+
+## Viewing the documentation
+
+Run the FastAPI app and navigate to `http://localhost:8081/docs` to access the interactive Swagger UI. The raw specification is available at `http://localhost:8081/docs/openapi.json`.
+
+## Regenerating the spec
+
+After modifying the API, run the following command from the repository root to regenerate `docs/openapi.yaml`:
+
+```bash
+python -m services.ltm_service.generate_spec
+```
+
+This will output the current OpenAPI schema to `docs/openapi.yaml` so it can be committed to version control.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,175 @@
+components:
+  schemas:
+    ConsolidateRequest:
+      properties:
+        memory_type:
+          default: episodic
+          description: Type of memory module
+          examples:
+          - episodic
+          title: Memory Type
+          type: string
+        record:
+          additionalProperties: true
+          description: Record to store
+          title: Record
+          type: object
+      required:
+      - record
+      title: ConsolidateRequest
+      type: object
+    ConsolidateResponse:
+      properties:
+        id:
+          description: Stored record identifier
+          title: Id
+          type: string
+      required:
+      - id
+      title: ConsolidateResponse
+      type: object
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          title: Detail
+          type: array
+      title: HTTPValidationError
+      type: object
+    RetrieveBody:
+      properties:
+        query:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          description: Query to match
+          title: Query
+        task_context:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          description: Deprecated alternative query field
+          title: Task Context
+      title: RetrieveBody
+      type: object
+    RetrieveResponse:
+      properties:
+        results:
+          description: Matching records
+          items:
+            additionalProperties: true
+            type: object
+          title: Results
+          type: array
+      required:
+      - results
+      title: RetrieveResponse
+      type: object
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          title: Location
+          type: array
+        msg:
+          title: Message
+          type: string
+        type:
+          title: Error Type
+          type: string
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+      type: object
+info:
+  title: LTM Service API
+  version: 1.0.0
+openapi: 3.1.0
+paths:
+  /consolidate:
+    post:
+      operationId: consolidate_consolidate_post
+      parameters:
+      - in: header
+        name: x-role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConsolidateRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConsolidateResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Store an experience
+  /retrieve:
+    get:
+      operationId: retrieve_retrieve_get
+      parameters:
+      - in: query
+        name: memory_type
+        required: false
+        schema:
+          default: episodic
+          title: Memory Type
+          type: string
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 5
+          maximum: 50
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: header
+        name: x-role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RetrieveBody'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetrieveResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Retrieve similar experiences

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ beautifulsoup4
 readability-lxml
 jsonschema
 pykwalify
+fastapi
+uvicorn
 
 opentelemetry-api
 opentelemetry-sdk

--- a/services/ltm_service/__init__.py
+++ b/services/ltm_service/__init__.py
@@ -3,11 +3,13 @@
 from .api import LTMService, LTMServiceServer
 from .embedding_client import EmbeddingClient, SimpleEmbeddingClient
 from .episodic_memory import EpisodicMemoryService, InMemoryStorage
+from .openapi_app import create_app
 from .vector_store import InMemoryVectorStore, VectorStore
 
 __all__ = [
     "LTMService",
     "LTMServiceServer",
+    "create_app",
     "EpisodicMemoryService",
     "InMemoryStorage",
     "EmbeddingClient",

--- a/services/ltm_service/generate_spec.py
+++ b/services/ltm_service/generate_spec.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Utility for regenerating the OpenAPI specification."""
+
+import importlib.util
+import pathlib
+import yaml
+
+spec = importlib.util.spec_from_file_location('openapi_app', pathlib.Path(__file__).with_name('openapi_app.py'))
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+class Dummy:
+    def consolidate(self, memory_type, record):
+        return '1'
+    def retrieve(self, memory_type, query, limit=5):
+        return []
+
+app = module.create_app(Dummy())
+path = pathlib.Path(__file__).resolve().parents[2] / 'docs' / 'openapi.yaml'
+path.write_text(yaml.dump(app.openapi()))
+print(f"Wrote {path}")

--- a/services/ltm_service/openapi_app.py
+++ b/services/ltm_service/openapi_app.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from fastapi import Body, FastAPI, Header, HTTPException, Query
+from pydantic import BaseModel, Field
+
+try:  # Avoid heavy imports when generating docs
+    from .api import ALLOWED_MEMORY_TYPES, ROLE_PERMISSIONS, LTMService
+except Exception:  # pragma: no cover - fallback for spec generation
+    ALLOWED_MEMORY_TYPES = {"episodic", "semantic", "procedural"}
+    ROLE_PERMISSIONS = {
+        ("POST", "/consolidate"): {"editor"},
+        ("GET", "/retrieve"): {"viewer", "editor"},
+    }
+
+    class LTMService:  # type: ignore
+        ...
+
+
+def _check_role(method: str, path: str, role: str) -> bool:
+    allowed = ROLE_PERMISSIONS.get((method, path), set())
+    return role in allowed
+
+
+class ConsolidateRequest(BaseModel):
+    record: Dict = Field(..., description="Record to store")
+    memory_type: str = Field(
+        "episodic",
+        description="Type of memory module",
+        examples=["episodic"],
+    )
+
+
+ConsolidateRequest.model_rebuild()
+
+
+class ConsolidateResponse(BaseModel):
+    id: str = Field(..., description="Stored record identifier")
+
+
+class RetrieveBody(BaseModel):
+    query: Optional[Dict] = Field(None, description="Query to match")
+    task_context: Optional[Dict] = Field(
+        None, description="Deprecated alternative query field"
+    )
+
+
+RetrieveBody.model_rebuild()
+
+
+class RetrieveResponse(BaseModel):
+    results: List[Dict] = Field(..., description="Matching records")
+
+
+RetrieveResponse.model_rebuild()
+
+
+def create_app(service: LTMService) -> FastAPI:
+    app = FastAPI(
+        title="LTM Service API",
+        version="1.0.0",
+        docs_url="/docs",
+        openapi_url="/docs/openapi.json",
+    )
+
+    @app.post("/consolidate", summary="Store an experience")
+    async def consolidate(
+        req: ConsolidateRequest,
+        x_role: str | None = Header(None),
+    ) -> ConsolidateResponse:
+        role = x_role or ""
+        if not _check_role("POST", "/consolidate", role):
+            raise HTTPException(status_code=403, detail="forbidden")
+        if req.memory_type not in ALLOWED_MEMORY_TYPES:
+            raise HTTPException(status_code=400, detail="Unsupported memory type")
+        rec_id = service.consolidate(req.memory_type, req.record)
+        return ConsolidateResponse(id=rec_id)
+
+    @app.get("/retrieve", summary="Retrieve similar experiences")
+    async def retrieve(
+        memory_type: str = Query("episodic"),
+        limit: int = Query(5, ge=1, le=50),
+        req: RetrieveBody = Body(default_factory=RetrieveBody),
+        x_role: str | None = Header(None),
+    ) -> RetrieveResponse:
+        role = x_role or ""
+        if not _check_role("GET", "/retrieve", role):
+            raise HTTPException(status_code=403, detail="forbidden")
+        if memory_type not in ALLOWED_MEMORY_TYPES:
+            raise HTTPException(status_code=400, detail="Unsupported memory type")
+        query = req.query or req.task_context or {}
+        results = service.retrieve(memory_type, query, limit=limit)
+        return RetrieveResponse(results=results)
+
+    return app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    from .episodic_memory import EpisodicMemoryService, InMemoryStorage
+    import uvicorn
+
+    service = LTMService(EpisodicMemoryService(InMemoryStorage()))
+    uvicorn.run(create_app(service), host="0.0.0.0", port=8081)


### PR DESCRIPTION
## Summary
- implement FastAPI app for LTM service with annotated endpoints
- add spec generator and versioned `docs/openapi.yaml`
- update package exports and dependencies
- document how to view and regenerate the API spec

## Testing
- `pre-commit run --all-files` *(fails: black reformatted unrelated files)*
- `pytest -q` *(fails: ModuleNotFoundError: googletrans)*

------
https://chatgpt.com/codex/tasks/task_e_684f03fa5af4832a92ca69448b3b8096