### PR TITLE
Add contract tests for LTM API

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,29 @@
+# Testing Overview
+
+This project uses `pytest` for unit and integration tests. A set of contract tests ensures the LTM service HTTP API remains stable.
+
+## Running Tests
+
+Use `pytest` to execute the suite:
+
+```bash
+pytest -q
+```
+
+Run linters with `pre-commit`:
+
+```bash
+pre-commit run --all-files
+```
+
+## Contract Tests
+
+Contract tests live in `tests/test_ltm_contract.py` and load scenarios from JSON fixtures in `tests/fixtures/ltm_contract/`. Each fixture defines the request headers, body and the expected response. The helper `_assert_contract` checks that status codes and response fields match the fixture.
+
+To update fixtures when the API changes:
+
+1. Modify or add files in `tests/fixtures/ltm_contract/` with the new expected schema.
+2. Update any corresponding tests to load the new fixtures.
+3. Run the tests to verify they pass.
+
+CI will fail if any endpoint response deviates from these contracts, helping detect breaking API changes early.

--- a/tests/fixtures/ltm_contract/consolidate_invalid_memory_type.json
+++ b/tests/fixtures/ltm_contract/consolidate_invalid_memory_type.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "headers": {"X-Role": "editor"},
+    "json": {"record": {}, "memory_type": "invalid"}
+  },
+  "response": {
+    "status": 400,
+    "body": {"error": "Unsupported memory type: invalid"}
+  }
+}

--- a/tests/fixtures/ltm_contract/consolidate_invalid_role.json
+++ b/tests/fixtures/ltm_contract/consolidate_invalid_role.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "headers": {"X-Role": "viewer"},
+    "json": {"record": {}}
+  },
+  "response": {
+    "status": 403,
+    "body": {"error": "forbidden"}
+  }
+}

--- a/tests/fixtures/ltm_contract/consolidate_missing_record.json
+++ b/tests/fixtures/ltm_contract/consolidate_missing_record.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "headers": {"X-Role": "editor"},
+    "json": {}
+  },
+  "response": {
+    "status": 400,
+    "body": {"error": "missing record"}
+  }
+}

--- a/tests/fixtures/ltm_contract/consolidate_success.json
+++ b/tests/fixtures/ltm_contract/consolidate_success.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "headers": {"X-Role": "editor"},
+    "json": {
+      "record": {
+        "task_context": {"description": "Write docs"},
+        "execution_trace": {},
+        "outcome": {"success": true}
+      },
+      "memory_type": "episodic"
+    }
+  },
+  "response": {
+    "status": 201,
+    "body": {"id": "*"}
+  }
+}

--- a/tests/fixtures/ltm_contract/retrieve_invalid_memory_type.json
+++ b/tests/fixtures/ltm_contract/retrieve_invalid_memory_type.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "headers": {"X-Role": "viewer"},
+    "params": {"memory_type": "bad"},
+    "json": {"query": {}}
+  },
+  "response": {
+    "status": 400,
+    "body": {"error": "Unsupported memory type: bad"}
+  }
+}

--- a/tests/fixtures/ltm_contract/retrieve_invalid_role.json
+++ b/tests/fixtures/ltm_contract/retrieve_invalid_role.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "headers": {"X-Role": "guest"},
+    "json": {"query": {}}
+  },
+  "response": {
+    "status": 403,
+    "body": {"error": "forbidden"}
+  }
+}

--- a/tests/fixtures/ltm_contract/retrieve_success.json
+++ b/tests/fixtures/ltm_contract/retrieve_success.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "headers": {"X-Role": "viewer"},
+    "params": {"memory_type": "episodic"},
+    "json": {"query": {"description": "Write docs"}}
+  },
+  "response": {
+    "status": 200,
+    "body": {"results": "*"}
+  }
+}

--- a/tests/test_ltm_contract.py
+++ b/tests/test_ltm_contract.py
@@ -1,0 +1,115 @@
+import json
+from pathlib import Path
+from threading import Thread
+
+import pytest
+import requests
+
+from services.ltm_service import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.api import LTMService, LTMServiceServer
+
+FIXTURE_DIR = Path("tests/fixtures/ltm_contract")
+
+
+def _start_server() -> tuple[LTMServiceServer, str]:
+    storage = InMemoryStorage()
+    service = LTMService(EpisodicMemoryService(storage))
+    server = LTMServiceServer(service, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.httpd.server_port}"
+    return server, endpoint
+
+
+def _load_case(name: str) -> dict:
+    path = FIXTURE_DIR / f"{name}.json"
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _assert_contract(resp: requests.Response, expected: dict) -> None:
+    assert resp.status_code == expected["status"]
+    body = resp.json()
+    for key, value in expected.get("body", {}).items():
+        if value == "*":
+            assert key in body
+        else:
+            assert body.get(key) == value
+
+
+@pytest.fixture()
+def ltm_endpoint():
+    server, endpoint = _start_server()
+    yield endpoint
+    server.httpd.shutdown()
+
+
+def test_consolidate_success_contract(ltm_endpoint):
+    case = _load_case("consolidate_success")
+    resp = requests.post(
+        f"{ltm_endpoint}/consolidate",
+        headers=case["request"].get("headers", {}),
+        json=case["request"].get("json"),
+    )
+    _assert_contract(resp, case["response"])
+
+    # ensure retrieval works for subsequent test
+    case_retrieve = _load_case("retrieve_success")
+    resp = requests.get(
+        f"{ltm_endpoint}/retrieve",
+        headers=case_retrieve["request"].get("headers", {}),
+        params=case_retrieve["request"].get("params"),
+        json=case_retrieve["request"].get("json"),
+    )
+    _assert_contract(resp, case_retrieve["response"])
+
+
+def test_consolidate_missing_record_contract(ltm_endpoint):
+    case = _load_case("consolidate_missing_record")
+    resp = requests.post(
+        f"{ltm_endpoint}/consolidate",
+        headers=case["request"].get("headers", {}),
+        json=case["request"].get("json"),
+    )
+    _assert_contract(resp, case["response"])
+
+
+def test_consolidate_invalid_memory_type_contract(ltm_endpoint):
+    case = _load_case("consolidate_invalid_memory_type")
+    resp = requests.post(
+        f"{ltm_endpoint}/consolidate",
+        headers=case["request"].get("headers", {}),
+        json=case["request"].get("json"),
+    )
+    _assert_contract(resp, case["response"])
+
+
+def test_consolidate_invalid_role_contract(ltm_endpoint):
+    case = _load_case("consolidate_invalid_role")
+    resp = requests.post(
+        f"{ltm_endpoint}/consolidate",
+        headers=case["request"].get("headers", {}),
+        json=case["request"].get("json"),
+    )
+    _assert_contract(resp, case["response"])
+
+
+def test_retrieve_invalid_memory_type_contract(ltm_endpoint):
+    case = _load_case("retrieve_invalid_memory_type")
+    resp = requests.get(
+        f"{ltm_endpoint}/retrieve",
+        headers=case["request"].get("headers", {}),
+        params=case["request"].get("params"),
+        json=case["request"].get("json"),
+    )
+    _assert_contract(resp, case["response"])
+
+
+def test_retrieve_invalid_role_contract(ltm_endpoint):
+    case = _load_case("retrieve_invalid_role")
+    resp = requests.get(
+        f"{ltm_endpoint}/retrieve",
+        headers=case["request"].get("headers", {}),
+        json=case["request"].get("json"),
+    )
+    _assert_contract(resp, case["response"])


### PR DESCRIPTION
## Summary
- add contract tests for LTM endpoints
- store contract fixtures as JSON files
- document test workflow

## Testing
- `pre-commit run --all-files` *(fails: flake8 and isort issues)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'googletrans')*

------
https://chatgpt.com/codex/tasks/task_e_684f04112a50832a810a39875e3a6eda