### PR TITLE
Implement Supervisor plan templating

### DIFF
--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -1,0 +1,17 @@
+# Supervisor Agent
+
+This document describes how to configure the Supervisor agent.
+
+## Plan templating
+
+The Supervisor can reuse past plans retrieved from the episodic LTM service. When
+`USE_PLAN_TEMPLATES` is enabled, retrieved memories are scored against the current
+query and the highest scoring plan structure is merged into the generated plan.
+This results in similar intents producing similar plan skeletons.
+
+### Enabling
+
+Set the environment variable `USE_PLAN_TEMPLATES=1` or pass
+`use_plan_templates=True` to `SupervisorAgent` when constructing it.
+The number of memories considered is controlled by `retrieval_limit`.
+


### PR DESCRIPTION
## Summary
- add `use_plan_templates` flag to Supervisor
- reuse plan graphs from episodic memories when enabled
- rank retrieved memories by relevance score
- document Supervisor templating option
- test template behaviour

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q` *(fails: missing modules such as `googletrans`, `requests`, `jsonschema`)*

------
https://chatgpt.com/codex/tasks/task_e_684f084dee0c832a89281b79411e8077