### PR TITLE
Expand RBAC failure logging

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,24 @@
+# Security Guide
+
+This guide describes how to monitor RBAC failures in the Tool Registry.
+
+## Viewing RBAC Logs
+
+`ToolRegistryServer` logs every failed authorization attempt as a JSON record. Run the server normally and check its standard logs or your configured log aggregator.
+
+Example log entry:
+
+```json
+{"timestamp": "2024-01-01T12:00:00Z", "role": "Supervisor", "tool": "dummy", "client_ip": "127.0.0.1", "path": "/tool?agent=Supervisor&name=dummy", "error": "Role 'Supervisor' cannot access tool 'dummy'"}
+```
+
+Fields:
+
+- `timestamp` – UTC time of the request
+- `role` – agent role making the request
+- `tool` – requested tool name
+- `client_ip` – IP address of the client
+- `path` – HTTP path and query
+- `error` – reason access was denied
+
+Use `docker compose logs tool-registry` or your monitoring backend to search for these records and audit failed access attempts.


### PR DESCRIPTION
## Summary
- add JSON logging of failed authorization attempts in `ToolRegistryServer`
- test that denied tool access emits a log
- document how to view RBAC failure logs

## Testing
- `pre-commit run --files services/tool_registry/registry.py tests/test_tool_registry.py docs/security.md`
- `pytest tests/test_tool_registry.py::test_registry_server_logs_denied_access -q`
- `pytest -q` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684f08c64250832a9da87c18ed65c194