### PR TITLE
Implement input validation for PDF and HTML tools

### DIFF
--- a/tests/test_html_scraper_tool.py
+++ b/tests/test_html_scraper_tool.py
@@ -50,6 +50,16 @@ def test_html_scraper_bad_url():
         html_scraper("http://localhost:9/missing", timeout=1)
 
 
+def test_html_scraper_invalid_scheme():
+    with pytest.raises(ValueError):
+        html_scraper("javascript:alert(1)")
+
+
+def test_html_scraper_ftp_scheme():
+    with pytest.raises(ValueError):
+        html_scraper("ftp://example.com/")
+
+
 def test_html_scraper_dynamic_content(tmp_path):
     html = tmp_path / "dynamic.html"
     html.write_text(
@@ -66,3 +76,9 @@ def test_html_scraper_dynamic_content(tmp_path):
     finally:
         httpd.shutdown()
         t.join()
+
+
+def test_html_scraper_traversal(tmp_path):
+    path = tmp_path / ".." / "etc" / "passwd.html"
+    with pytest.raises(ValueError):
+        html_scraper(f"file://{path}")

--- a/tests/test_pdf_reader_tool.py
+++ b/tests/test_pdf_reader_tool.py
@@ -136,3 +136,21 @@ def test_pdf_extract_bad_url():
     with pytest.raises(ValueError) as exc:
         pdf_extract("http://localhost:9/missing.pdf", timeout=1)
     assert "Failed to download PDF" in str(exc.value)
+
+
+def test_pdf_extract_invalid_scheme():
+    with pytest.raises(ValueError) as exc:
+        pdf_extract("javascript:alert(1)")
+    assert "Invalid URL scheme" in str(exc.value)
+
+
+def test_pdf_extract_ftp_scheme():
+    with pytest.raises(ValueError):
+        pdf_extract("ftp://example.com/file.pdf")
+
+
+def test_pdf_extract_traversal(tmp_path):
+    malicious = tmp_path / ".." / "etc" / "passwd"
+    with pytest.raises(ValueError) as exc:
+        pdf_extract(str(malicious))
+    assert "directory traversal" in str(exc.value)

--- a/tools/html_scraper.py
+++ b/tools/html_scraper.py
@@ -2,26 +2,37 @@ from __future__ import annotations
 
 """Simplistic HTML scraper returning main article text."""
 
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
 import requests
 from bs4 import BeautifulSoup
 from readability import Document
 
+from .validation import validate_path_or_url
+
 
 def html_scraper(url: str, *, timeout: int = 10) -> str:
-    """Return main body text extracted from a web page URL.
+    """Return main body text extracted from a web page URL or file."""
 
-    This uses ``readability-lxml`` to isolate the main article content and
-    strips common boilerplate tags. If no meaningful text is found, an error is
-    raised.
-    """
-    try:
-        resp = requests.get(url, timeout=timeout)
-        resp.raise_for_status()
-    except requests.RequestException as exc:  # pragma: no cover - network errors
-        raise ValueError(f"Failed to fetch HTML: {exc}") from exc
+    validated = validate_path_or_url(url)
+    parsed = urlparse(url)
+
+    if parsed.scheme in {"http", "https"}:
+        try:
+            resp = requests.get(validated, timeout=timeout)
+            resp.raise_for_status()
+            html_text = resp.text
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            raise ValueError(f"Failed to fetch HTML: {exc}") from exc
+    else:
+        if not os.path.exists(validated):
+            raise FileNotFoundError(validated)
+        html_text = Path(validated).read_text(encoding="utf-8", errors="ignore")
 
     # Use readability to isolate the article HTML, falling back to full page
-    doc = Document(resp.text)
+    doc = Document(html_text)
     article_html = doc.summary(html_partial=True)
     soup = BeautifulSoup(article_html, "html.parser")
     for tag in soup(

--- a/tools/validation.py
+++ b/tools/validation.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+"""Utilities for validating user-provided file paths and URLs."""
+
+import os
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+ALLOWED_SCHEMES = {"http", "https", "file"}
+
+
+class InputValidationError(ValueError):
+    """Raised when a path or URL fails validation."""
+
+    status_code = 400
+
+
+def validate_path_or_url(target: str, allowed_schemes: set[str] | None = None) -> str:
+    """Return a sanitized path or URL if ``target`` is valid.
+
+    Parameters
+    ----------
+    target: str
+        User provided file path or URL.
+    allowed_schemes: set[str] | None
+        Permitted URL schemes. Defaults to ``ALLOWED_SCHEMES``.
+
+    Returns
+    -------
+    str
+        The original URL or a normalized filesystem path.
+
+    Raises
+    ------
+    InputValidationError
+        If the scheme is not allowed or path normalization indicates directory traversal.
+    """
+    allowed_schemes = allowed_schemes or ALLOWED_SCHEMES
+    parsed = urlparse(target)
+    scheme = parsed.scheme.lower()
+    if scheme and scheme not in allowed_schemes:
+        raise InputValidationError(f"Invalid URL scheme: {scheme} (HTTP 400)")
+
+    if scheme in {"http", "https"}:
+        return target
+
+    path = unquote(parsed.path) if scheme == "file" else target
+    normalized = os.path.normpath(path)
+    if ".." in Path(normalized).parts:
+        raise InputValidationError(
+            "Invalid path: directory traversal detected (HTTP 400)"
+        )
+    return normalized


### PR DESCRIPTION
## Summary
- add shared URL/path validation helper
- validate inputs in `pdf_extract` and `html_scraper`
- reject disallowed schemes and traversal in tests

## Testing
- `pre-commit run --files tools/pdf_reader.py tools/html_scraper.py tools/validation.py tests/test_pdf_reader_tool.py tests/test_html_scraper_tool.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'googletrans')*

------
https://chatgpt.com/codex/tasks/task_e_684f08aea1c8832abc5f2bf9257fb187