### PR TITLE
Add dependency vulnerability scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,34 @@ jobs:
       - name: Run tests
         run: pytest -q
 
+
+  security-dependencies:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Setup environment
+        run: bash scripts/agent-setup.sh
+      - name: Install pip-audit
+        run: pip install pip-audit
+      - name: Run pip-audit
+        run: |
+          mkdir -p security
+          pip-audit -r requirements.txt -f json -o security/pip_audit_report.json
+      - name: Check vulnerabilities
+        run: python scripts/check_pip_audit.py security/pip_audit_report.json
+      - name: Upload audit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-report
+          path: security/pip_audit_report.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 ENV/
 .venv/
 **/results.db
+security/

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,22 @@
+# Dependency Security Scanning
+
+The CI workflow includes a job named `security:dependencies` that checks project dependencies for known vulnerabilities using **pip-audit**.
+
+The job runs on every pull request and pushes to `main`. A report is generated at `security/pip_audit_report.json` and uploaded as a workflow artifact.
+
+## Interpreting the Report
+
+1. Download the artifact from the workflow run.
+2. Open `pip_audit_report.json` and inspect the listed vulnerabilities.
+3. The job fails when any vulnerability with a severity of **high** or **critical** is detected. Lower-severity issues are reported but do not block the build.
+4. Update affected packages to resolve vulnerabilities. Rerun the scan to verify.
+
+## Running Locally
+
+```bash
+pip install pip-audit
+pip-audit -r requirements.txt -f json -o security/pip_audit_report.json
+python scripts/check_pip_audit.py security/pip_audit_report.json
+```
+
+The script exits with a non-zero status if high or critical vulnerabilities are present.

--- a/scripts/check_pip_audit.py
+++ b/scripts/check_pip_audit.py
@@ -1,0 +1,48 @@
+import json
+import sys
+from pathlib import Path
+
+HIGH_SEVERITIES = {"high", "critical"}
+
+
+def iter_vulnerabilities(data):
+    if isinstance(data, dict):
+        if "dependencies" in data:
+            for dep in data.get("dependencies", []):
+                for vuln in dep.get("vulns", []):
+                    yield vuln
+        if "vulnerabilities" in data:
+            for vuln in data.get("vulnerabilities", []):
+                yield vuln
+
+
+def is_high(vuln):
+    sev = vuln.get("severity")
+    if not sev:
+        ratings = vuln.get("ratings", [])
+        if ratings and isinstance(ratings[0], dict):
+            sev = ratings[0].get("severity")
+    if not sev:
+        desc = vuln.get("description", "").lower()
+        for level in HIGH_SEVERITIES | {"medium", "low"}:
+            if f"severity is {level}" in desc:
+                sev = level
+                break
+    return sev and sev.lower() in HIGH_SEVERITIES
+
+
+def main(path: str = "security/pip_audit_report.json") -> int:
+    report = Path(path)
+    if not report.is_file():
+        print(f"Report not found: {report}", file=sys.stderr)
+        return 1
+    data = json.loads(report.read_text())
+    if any(is_high(v) for v in iter_vulnerabilities(data)):
+        print("High or critical vulnerabilities detected", file=sys.stderr)
+        return 1
+    print("No high or critical vulnerabilities found")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1] if len(sys.argv) > 1 else "security/pip_audit_report.json"))

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -1,0 +1,19 @@
+from scripts.check_pip_audit import is_high, iter_vulnerabilities
+
+sample_report = {
+    "dependencies": [
+        {
+            "name": "foo",
+            "version": "1.0",
+            "vulns": [
+                {"id": "CVE-123", "severity": "high"},
+                {"id": "CVE-456", "severity": "low"},
+            ],
+        }
+    ]
+}
+
+def test_detect_high_vulnerability():
+    vulns = list(iter_vulnerabilities(sample_report))
+    assert any(is_high(v) for v in vulns)
+


### PR DESCRIPTION
## Summary
- add `security-dependencies` job to CI
- add script to parse pip-audit reports and fail on high/critical vulns
- document how to run and interpret the dependency scan
- ignore generated security reports
- test script logic

## Testing
- `pre-commit run --all-files` *(fails: flake8 and isort on unrelated files)*
- `pytest -q` *(fails: ModuleNotFoundError on many dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_684f08a311d4832a81f4c8ad9979a393