### PR TITLE
Add basic Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- add Dependabot configuration for pip dependencies

## Testing
- `pre-commit run --all-files` *(fails: `pre-commit: command not found`)*
- `pytest -q` *(fails: 29 errors during collection)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684f0a96ddb8832a85715676965159a2