### PR TITLE
Improve CI failure reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,33 @@ jobs:
       - name: Setup environment
         run: bash scripts/agent-setup.sh
       - name: Run tests
-        run: pytest --cov=./ --cov-report=xml --cov-fail-under=80 -v
+        id: run-tests
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          pytest --cov=./ --cov-report=xml --cov-report=html --cov-fail-under=80 -v | tee tests.log
+          echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml
+      - name: Upload coverage html
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: htmlcov/
+      - name: Upload test log
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-log
+          path: tests.log
+      - name: Summarize failures
+        if: always()
+        run: python scripts/ci_summary.py tests.log coverage.xml
+      - name: Fail if tests failed
+        if: steps.run-tests.outputs.exitcode != '0'
+        run: exit 1
       - name: Check codex queue
         run: python scripts/validate_queue.py
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -17,3 +17,26 @@ pytest --cov=./ --cov-report=xml --cov-fail-under=80
 
 This mirrors the CI behaviour so local failures can be detected early.
 
+## Failure Summaries
+
+Each CI run ends with a concise summary block that shows the tail of the test
+log and the overall coverage percentage. Direct links to the coverage HTML
+report and full logs are included. Failing tests are annotated inline in the PR
+using the `pytest-github-actions-annotate-failures` plugin.
+
+Example:
+
+```
+## Test Failure Summary
+
+**Coverage:** 82.3%
+
+<last lines from tests.log>
+
+[Coverage HTML](https://github.com/org/repo/actions/runs/<run_id>#artifacts)
+[Full Log](https://github.com/org/repo/actions/runs/<run_id>)
+```
+
+Download the `coverage-html` artifact from the run and open `index.html` locally
+to view detailed coverage results.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pre-commit
 pytest
 pytest-cov
+pytest-github-actions-annotate-failures
 pydantic
 pyyaml
 requests

--- a/scripts/ci_summary.py
+++ b/scripts/ci_summary.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+def coverage_percent(xml_path: str) -> str:
+    path = Path(xml_path)
+    if not path.is_file():
+        return "N/A"
+    root = ET.parse(path).getroot()
+    rate = root.get("line-rate")
+    if rate is None:
+        return "N/A"
+    return f"{float(rate) * 100:.1f}%"
+
+
+def tail_lines(log_path: str, num: int = 20) -> str:
+    path = Path(log_path)
+    if not path.is_file():
+        return "log file missing"
+    return "\n".join(path.read_text().splitlines()[-num:])
+
+
+def main(log_path: str = "tests.log", cov_path: str = "coverage.xml") -> int:
+    summary_file = Path(os.environ.get("GITHUB_STEP_SUMMARY", ""))
+    cov = coverage_percent(cov_path)
+    tail = tail_lines(log_path)
+    text = [
+        "## Test Failure Summary",
+        "",
+        f"**Coverage:** {cov}",
+        "",
+        "```",
+        tail,
+        "```",
+        "",
+        f"[Coverage HTML](https://github.com/{os.environ.get('GITHUB_REPOSITORY')}/actions/runs/{os.environ.get('GITHUB_RUN_ID')}#artifacts)",
+        f"[Full Log](https://github.com/{os.environ.get('GITHUB_REPOSITORY')}/actions/runs/{os.environ.get('GITHUB_RUN_ID')})",
+    ]
+    if summary_file:
+        summary_file.write_text("\n".join(text))
+    else:
+        print("\n".join(text))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(*(sys.argv[1:3])))


### PR DESCRIPTION
## Summary
- include `pytest-github-actions-annotate-failures` plugin
- collect test logs and coverage HTML in CI
- output a concise CI summary via `ci_summary.py`
- document how to read failure summaries

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_684f0dba40dc832aba837d1f2ab5dc41