### PR TITLE
Implement tool init tracing

### DIFF
--- a/pipelines/teacher/pipeline.py
+++ b/pipelines/teacher/pipeline.py
@@ -10,7 +10,9 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 class TeacherDataPipeline:
     """Generate synthetic self-correction examples using a teacher LLM."""
 
-    def __init__(self, llm: Callable[[str], str], out_dir: str | Path = "data/teacher_dataset") -> None:
+    def __init__(
+        self, llm: Callable[[str], str], out_dir: str | Path = "data/teacher_dataset"
+    ) -> None:
         self.llm = llm
         self.out_dir = Path(out_dir)
         self.out_dir.mkdir(parents=True, exist_ok=True)
@@ -19,12 +21,14 @@ class TeacherDataPipeline:
         return (
             "You are a knowledgeable instructor. "
             "Given the following topic, act like a typical student who makes a reasoning mistake. "
-            "Provide a JSON object with fields: original_problem, flawed_output, detailed_critique, corrected_solution. "
-            "Topic: "
-            + topic
+            "Provide a JSON object with fields: "
+            "original_problem, flawed_output, detailed_critique, corrected_solution. "
+            "Topic: " + topic
         )
 
-    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=4))
+    @retry(
+        stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=4)
+    )
     def _call_llm(self, prompt: str) -> str:
         return self.llm(prompt)
 
@@ -32,12 +36,19 @@ class TeacherDataPipeline:
         prompt = self._build_prompt(topic)
         response = self._call_llm(prompt)
         data = json.loads(str(response))
-        required = ["original_problem", "flawed_output", "detailed_critique", "corrected_solution"]
+        required = [
+            "original_problem",
+            "flawed_output",
+            "detailed_critique",
+            "corrected_solution",
+        ]
         if not all(key in data for key in required):
             raise ValueError("Missing required fields in LLM response")
         return data
 
-    def run(self, topics: List[str], out_file: str | Path | None = None) -> List[Dict[str, str]]:
+    def run(
+        self, topics: List[str], out_file: str | Path | None = None
+    ) -> List[Dict[str, str]]:
         results = []
         for topic in topics:
             try:

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -2,9 +2,34 @@ from threading import Thread
 
 import pytest
 import requests
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
 
 from services.tool_registry import AccessDeniedError, ToolRegistry
 from services.tool_registry.registry import ToolRegistryServer
+from services.tracing.tracing_schema import ToolCallTrace
+
+
+class InMemorySpanExporter(SpanExporter):
+    def __init__(self) -> None:
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:  # pragma: no cover - not needed
+        pass
+
+    def force_flush(
+        self, timeout_millis: int = 30_000
+    ) -> bool:  # pragma: no cover - not needed
+        return True
 
 
 def dummy_tool():
@@ -48,3 +73,30 @@ def test_registry_server_permissions(tmp_path):
     finally:
         server.httpd.shutdown()
         thread.join()
+
+
+def test_tool_init_span_and_propagation():
+    exporter = InMemorySpanExporter()
+    trace.set_tracer_provider(TracerProvider())
+    provider = trace.get_tracer_provider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    registry = ToolRegistry()
+
+    def tool(x):
+        return x
+
+    registry.register_tool("dummy", tool)
+    wrapped = registry.get_tool("WebResearcher", "dummy")
+    out = wrapped("hi")
+    ToolCallTrace(
+        agent_id="A",
+        agent_role="WebResearcher",
+        tool_name="dummy",
+        tool_input="hi",
+        tool_output=out,
+    ).record()
+
+    names = {span.name for span in exporter.spans}
+    assert "tool.init" in names
+    assert "tool_call" in names


### PR DESCRIPTION
## Summary
- instrument `ToolRegistry` with `tool.init` spans
- propagate span context in returned tool wrappers
- add unit test for init span instrumentation
- fix flake8 issue in teacher pipeline

## Testing
- `pre-commit run --files pipelines/teacher/pipeline.py services/tool_registry/__init__.py tests/test_tool_registry.py`
- `pytest -q tests/test_tool_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_684f0d9752a4832ab0c1b8986bca4077