### PR TITLE
Add core test suite and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,14 +54,26 @@ This will apply `black`, `flake8`, and `isort` to your changes.
 ## Pre-PR Testing
 
 Before opening a pull request, verify your changes locally.
+Tests are tagged into three categories:
 
-Run the test suite:
+- **core** – fast unit tests that cover critical functionality
+- **integration** – tests that exercise service boundaries or heavy components
+- **optional** – slow or environment-specific checks
+
+Run the lightweight **core** test suite to verify basic functionality:
+
+```bash
+pytest -m "core" -q
+```
+
+You can also run `bash scripts/test_core.sh` as a shorthand. The command should complete quickly and exit with code `0`.
+
+To execute the full suite (all `core`, `integration`, and `optional` tests) run:
 
 ```bash
 pytest -q
 ```
 
-The command should exit with code `0` and display each test as `PASSED`.
 Any failures must be fixed prior to submission.
 
 Then execute the pre-commit hooks on all files:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    core: lightweight core tests for local development
+    integration: heavier integration tests
+    optional: optional or slow tests

--- a/scripts/test_core.sh
+++ b/scripts/test_core.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+pytest -m "core" "$@"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        if (
+            not item.get_closest_marker("core")
+            and not item.get_closest_marker("integration")
+            and not item.get_closest_marker("optional")
+        ):
+            item.add_marker("integration")

--- a/tests/test_codex_issue_logger.py
+++ b/tests/test_codex_issue_logger.py
@@ -4,10 +4,13 @@ import os
 import sys
 from unittest import mock
 
+import pytest
 import requests
 import yaml
 
 from scripts import issue_logger
+
+pytestmark = pytest.mark.core
 
 
 def test_create_issue_success():

--- a/tests/test_dataset_curation.py
+++ b/tests/test_dataset_curation.py
@@ -1,6 +1,10 @@
 import json
 
+import pytest
+
 from scripts import dataset_curation
+
+pytestmark = pytest.mark.core
 
 
 def test_validation_flags_and_quarantines(tmp_path):

--- a/tests/test_dynamic_group_chat.py
+++ b/tests/test_dynamic_group_chat.py
@@ -1,4 +1,8 @@
+import pytest
+
 from engine.collaboration.group_chat import DynamicGroupChat
+
+pytestmark = pytest.mark.core
 
 
 def test_message_passing():

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,4 +1,8 @@
+import pytest
+
 from agents.evaluator import EvaluatorAgent
+
+pytestmark = pytest.mark.core
 
 
 def test_verify_factual_accuracy_flags_unsupported():

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,4 +1,8 @@
+import pytest
+
 from src.example import hello
+
+pytestmark = pytest.mark.core
 
 
 def test_hello():

--- a/tests/test_html_scraper_tool.py
+++ b/tests/test_html_scraper_tool.py
@@ -7,6 +7,8 @@ import pytest
 
 from tools.html_scraper import html_scraper
 
+pytestmark = pytest.mark.core
+
 
 def _serve_dir(path: Path):
     handler = functools.partial(SimpleHTTPRequestHandler, directory=str(path))

--- a/tests/test_orchestration_engine.py
+++ b/tests/test_orchestration_engine.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib
 
+import pytest
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -10,6 +11,8 @@ from opentelemetry.sdk.trace.export import (
 )
 
 from engine.orchestration_engine import GraphState, create_orchestration_engine
+
+pytestmark = pytest.mark.core
 
 
 class InMemorySpanExporter(SpanExporter):

--- a/tests/test_pdf_reader_tool.py
+++ b/tests/test_pdf_reader_tool.py
@@ -11,6 +11,9 @@ from PIL import Image, ImageDraw, ImageFont
 
 from tools.pdf_reader import pdf_extract
 
+pytestmark = pytest.mark.core
+
+
 HELLO_PDF_B64 = (
     "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2Jq"
     "CjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9Db3VudCAxIC9LaWRzIFszIDAgUl0gPj4KZW5kb2Jq"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,5 +1,9 @@
+import pytest
+
 from engine.orchestration_engine import OrchestrationEngine
 from engine.state import State
+
+pytestmark = pytest.mark.core
 
 
 def test_state_serialization_roundtrip():

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -8,6 +8,8 @@ from agents.supervisor import State, SupervisorAgent
 from services.ltm_service import EpisodicMemoryService, InMemoryStorage
 from services.ltm_service.api import LTMService, LTMServiceServer
 
+pytestmark = pytest.mark.core
+
 
 class DummyGraphState:
     def __init__(self, data=None):

--- a/tests/test_web_researcher.py
+++ b/tests/test_web_researcher.py
@@ -3,6 +3,8 @@ import pytest
 from agents.web_researcher import WebResearcherAgent
 from engine.orchestration_engine import GraphState
 
+pytestmark = pytest.mark.core
+
 
 def test_research_topic_uses_tools():
     calls = {}


### PR DESCRIPTION
## Summary
- add pytest markers for core tests
- ensure unmarked tests default to integration
- create helper script to run core suite
- document test categories in CONTRIBUTING

## Testing
- `pre-commit run --files CONTRIBUTING.md tests/test_codex_issue_logger.py tests/test_dataset_curation.py tests/test_dynamic_group_chat.py tests/test_evaluator.py tests/test_example.py tests/test_html_scraper_tool.py tests/test_orchestration_engine.py tests/test_pdf_reader_tool.py tests/test_state.py tests/test_supervisor.py tests/test_web_researcher.py tests/conftest.py pytest.ini scripts/test_core.sh`
- `pytest -m "core" -q` *(fails: ModuleNotFoundError: No module named 'googletrans')*

------
https://chatgpt.com/codex/tasks/task_e_684f0dcc8b3c832a955ba915e2dd09b8