### PR TITLE
Add typed edge support

### DIFF
--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -1,0 +1,36 @@
+# Orchestration Engine Overview
+
+The orchestration engine executes agent workflows as a directed graph. Nodes encapsulate agent functions while edges describe how state flows between them.
+
+## Typed Edges
+
+Edges can carry optional metadata via the `edge_type` field. This allows routers to select the next node based on labels rather than hard coded destinations.
+
+Example YAML snippet:
+
+```yaml
+graph:
+  nodes:
+    - id: start
+      agent: WebResearcher
+    - id: success
+      agent: Supervisor
+    - id: failure
+      agent: Supervisor
+  edges:
+    - from: start
+      to: success
+      edge_type: success
+    - from: start
+      to: failure
+      edge_type: fail
+```
+
+Routers can inspect this metadata using `make_edge_type_router`:
+
+```python
+router = make_edge_type_router(engine, "start", state_key="path")
+engine.add_router("start", router)
+```
+
+When `state.data['path']` equals `"fail"`, the engine will traverse the edge labelled `fail`.

--- a/docs/supervisor_plan_schema.yaml
+++ b/docs/supervisor_plan_schema.yaml
@@ -45,6 +45,8 @@ properties:
               type: string
             to:
               type: string
+            edge_type:
+              type: string
       parallel_groups:
         type: array
         items:

--- a/schemas/supervisor_plan.yaml
+++ b/schemas/supervisor_plan.yaml
@@ -42,6 +42,9 @@ mapping:
               to:
                 type: str
                 required: yes
+              edge_type:
+                type: str
+                required: no
       parallel_groups:
         type: seq
         sequence:

--- a/tests/test_orchestration_engine.py
+++ b/tests/test_orchestration_engine.py
@@ -10,6 +10,7 @@ from opentelemetry.sdk.trace.export import (
 )
 
 from engine.orchestration_engine import GraphState, create_orchestration_engine
+from engine.routing import make_edge_type_router
 
 
 class InMemorySpanExporter(SpanExporter):
@@ -98,3 +99,37 @@ def test_export_dot_outputs_valid_graph():
     )
 
     assert dot == expected
+
+
+def test_typed_edges_routing_and_lookup():
+    engine = create_orchestration_engine()
+
+    def start(state: GraphState) -> GraphState:
+        return state
+
+    def node_b(state: GraphState) -> GraphState:
+        state.update({"dest": "B"})
+        return state
+
+    def node_c(state: GraphState) -> GraphState:
+        state.update({"dest": "C"})
+        return state
+
+    engine.add_node("Start", start)
+    engine.add_node("B", node_b)
+    engine.add_node("C", node_c)
+
+    engine.add_edge("Start", "B", edge_type="success")
+    engine.add_edge("Start", "C", edge_type="fail")
+
+    router = make_edge_type_router(engine, "Start", state_key="path")
+    engine.add_router("Start", router)
+
+    state = GraphState(data={"path": "fail"})
+    result = asyncio.run(engine.run_async(state))
+
+    assert result.data["dest"] == "C"
+    assert engine.get_edges("Start", "success")[0].end == "B"
+    engine.build()
+    dot = engine.export_dot()
+    assert '"Start" -> "B" [label="success"];' in dot


### PR DESCRIPTION
## Summary
- extend orchestration engine edges with optional `edge_type`
- include edge metadata in DOT export and tracing spans
- add `make_edge_type_router` for routing by edge type
- update supervisor plan schemas for typed edges
- document typed edges usage
- test typed edge routing and lookup

## Testing
- `pre-commit run --files engine/orchestration_engine.py engine/routing.py tests/test_orchestration_engine.py schemas/supervisor_plan.yaml docs/supervisor_plan_schema.yaml docs/architecture/orchestration.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'googletrans')*


------
https://chatgpt.com/codex/tasks/task_e_684f120cd6bc832a84d346493157c000