### PR TITLE
Implement TTL forgetting job

### DIFF
--- a/scripts/episodic_forgetting_job.py
+++ b/scripts/episodic_forgetting_job.py
@@ -1,0 +1,23 @@
+import os
+
+from opentelemetry import trace
+
+from services.ltm_service import EpisodicMemoryService, InMemoryStorage
+
+TTL_DAYS = float(os.getenv("LTM_TTL_DAYS", "30"))
+TTL_SECONDS = TTL_DAYS * 24 * 3600
+
+
+def main() -> None:
+    storage = InMemoryStorage()
+    service = EpisodicMemoryService(storage)
+    pruned = service.prune_stale_memories(TTL_SECONDS)
+    tracer = trace.get_tracer(__name__)
+    with tracer.start_as_current_span(
+        "forget_job", attributes={"pruned": pruned, "ttl_days": TTL_DAYS}
+    ):
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/services/ltm_service/episodic_memory.py
+++ b/services/ltm_service/episodic_memory.py
@@ -8,6 +8,7 @@ from difflib import SequenceMatcher
 from typing import Dict, Iterable, List, Tuple
 
 from langchain.text_splitter import RecursiveCharacterTextSplitter
+from opentelemetry import trace
 
 from .embedding_client import EmbeddingClient, EmbeddingError, SimpleEmbeddingClient
 from .vector_store import InMemoryVectorStore, VectorStore, WeaviateVectorStore
@@ -20,6 +21,14 @@ class StorageBackend:
         raise NotImplementedError
 
     def all(self) -> Iterable[Tuple[str, Dict]]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def delete(self, record_id: str) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def update(
+        self, record_id: str, updates: Dict
+    ) -> None:  # pragma: no cover - interface
         raise NotImplementedError
 
 
@@ -37,6 +46,13 @@ class InMemoryStorage(StorageBackend):
 
     def all(self) -> Iterable[Tuple[str, Dict]]:
         return list(self._data.items())
+
+    def delete(self, record_id: str) -> None:
+        self._data.pop(record_id, None)
+
+    def update(self, record_id: str, updates: Dict) -> None:
+        if record_id in self._data:
+            self._data[record_id].update(updates)
 
 
 class EpisodicMemoryService:
@@ -84,6 +100,7 @@ class EpisodicMemoryService:
             "task_context": task_context,
             "execution_trace": execution_trace,
             "outcome": outcome,
+            "last_accessed": time.time(),
         }
         categories = set(task_context.get("tags", []))
         cat = task_context.get("category")
@@ -128,6 +145,7 @@ class EpisodicMemoryService:
             for rec in self.vector_store.query(vector, limit):
                 stored = dict(self.storage._data.get(rec["id"], {}))
                 stored.update(rec)
+                self.storage.update(rec["id"], {"last_accessed": time.time()})
                 results.append(stored)
         else:
             results = []
@@ -136,6 +154,8 @@ class EpisodicMemoryService:
                 score = self._similarity(query_text, context_text)
                 rec = rec.copy()
                 rec["similarity"] = score
+                if rec.get("id"):
+                    self.storage.update(rec["id"], {"last_accessed": time.time()})
                 results.append(rec)
 
         for rec in results:
@@ -156,3 +176,24 @@ class EpisodicMemoryService:
             results.sort(key=lambda r: r.get("similarity", 0), reverse=True)
 
         return results[:limit]
+
+    def prune_stale_memories(self, ttl_seconds: float) -> int:
+        """Delete memories not accessed within the TTL."""
+        cutoff = time.time() - ttl_seconds
+        pruned = 0
+        tracer = trace.get_tracer(__name__)
+        for rec_id, rec in list(self.storage.all()):
+            last = rec.get("last_accessed", 0)
+            if last < cutoff:
+                self.storage.delete(rec_id)
+                if hasattr(self.vector_store, "delete"):
+                    try:
+                        self.vector_store.delete(rec_id)
+                    except Exception:  # pragma: no cover - best effort
+                        pass
+                pruned += 1
+        with tracer.start_as_current_span(
+            "ltm.prune", attributes={"pruned_count": pruned}
+        ):
+            pass
+        return pruned

--- a/services/ltm_service/vector_store.py
+++ b/services/ltm_service/vector_store.py
@@ -26,6 +26,9 @@ class VectorStore:
     ) -> List[Dict]:  # pragma: no cover - interface
         raise NotImplementedError
 
+    def delete(self, vec_id: str) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
 
 class InMemoryVectorStore(VectorStore):
     """Simple in-memory vector storage with cosine similarity search."""
@@ -61,6 +64,9 @@ class InMemoryVectorStore(VectorStore):
             rec = dict(meta)
             rec.setdefault("id", vec_id)
             yield vec_id, {"vector": vec, **rec}
+
+    def delete(self, vec_id: str) -> None:
+        self._data.pop(vec_id, None)
 
 
 class WeaviateVectorStore(VectorStore):
@@ -115,3 +121,9 @@ class WeaviateVectorStore(VectorStore):
             records.append(meta)
         records.sort(key=lambda r: r["similarity"], reverse=True)
         return records
+
+    def delete(self, vec_id: str) -> None:
+        try:
+            self._collection.data.delete(uuid=vec_id)
+        except Exception:  # pragma: no cover - best effort cleanup
+            pass

--- a/tests/test_forgetting_job.py
+++ b/tests/test_forgetting_job.py
@@ -1,0 +1,98 @@
+import sys
+import time
+import types
+
+# flake8: noqa: E402
+
+# provide minimal stub for langchain dependency
+splitter_mod = types.ModuleType("langchain.text_splitter")  # noqa: E402
+splitter_mod.RecursiveCharacterTextSplitter = lambda **_: types.SimpleNamespace(
+    split_text=lambda text: [text]
+)  # noqa: E402
+langchain_mod = types.ModuleType("langchain")  # noqa: E402
+sys.modules.setdefault("langchain", langchain_mod)  # noqa: E402
+sys.modules.setdefault("langchain.text_splitter", splitter_mod)  # noqa: E402
+
+# minimal fastapi stub to satisfy imports
+fastapi_mod = types.ModuleType("fastapi")  # noqa: E402
+fastapi_mod.FastAPI = object
+fastapi_mod.Body = object
+fastapi_mod.Header = object
+fastapi_mod.HTTPException = Exception
+fastapi_mod.Query = object
+responses_mod = types.ModuleType("fastapi.responses")  # noqa: E402
+responses_mod.RedirectResponse = object
+sys.modules.setdefault("fastapi.responses", responses_mod)  # noqa: E402
+sys.modules.setdefault("fastapi", fastapi_mod)  # noqa: E402
+
+pydantic_mod = types.ModuleType("pydantic")  # noqa: E402
+pydantic_mod.BaseModel = type(
+    "BaseModel", (), {"model_rebuild": classmethod(lambda cls: None)}
+)
+pydantic_mod.Field = lambda *args, **kwargs: None
+sys.modules.setdefault("pydantic", pydantic_mod)  # noqa: E402
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+
+from services.ltm_service.episodic_memory import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.vector_store import InMemoryVectorStore
+
+
+class InMemorySpanExporter(SpanExporter):
+    def __init__(self) -> None:
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:  # pragma: no cover - not needed
+        pass
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:  # pragma: no cover
+        return True
+
+
+def test_prune_stale_memories():
+    storage = InMemoryStorage()
+    vector_store = InMemoryVectorStore()
+    service = EpisodicMemoryService(storage, vector_store=vector_store)
+
+    old_ts = time.time() - 31 * 24 * 3600
+    recent_ts = time.time() - 5 * 24 * 3600
+
+    id_old = storage.save(
+        {
+            "task_context": {},
+            "execution_trace": {},
+            "outcome": {},
+            "last_accessed": old_ts,
+        }
+    )
+    vector_store.add([0.0], {"id": id_old})
+    id_new = storage.save(
+        {
+            "task_context": {},
+            "execution_trace": {},
+            "outcome": {},
+            "last_accessed": recent_ts,
+        }
+    )
+    vector_store.add([0.0], {"id": id_new})
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    pruned = service.prune_stale_memories(30 * 24 * 3600)
+    assert pruned == 1
+    assert id_old not in dict(storage.all())
+    assert id_new in dict(storage.all())
+    assert exporter.spans


### PR DESCRIPTION
## Summary
- add persistence interfaces for deleting and updating memory records
- add daily forgetting job utility
- track last_accessed timestamps when storing and retrieving
- prune stale memories with tracing
- integration test for pruning logic

## Testing
- `pre-commit run --files services/ltm_service/episodic_memory.py services/ltm_service/vector_store.py scripts/episodic_forgetting_job.py tests/test_forgetting_job.py`
- `pytest tests/test_forgetting_job.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684f114060a0832a94aeb44fc704c779