### PR TITLE
Consolidate supervisor state

### DIFF
--- a/agents/supervisor.py
+++ b/agents/supervisor.py
@@ -3,28 +3,16 @@ Supervisor Agent Implementation.
 This agent acts as the primary coordinator for research tasks.
 """
 
-from dataclasses import dataclass, field
+import os
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-
-from difflib import SequenceMatcher
-import os
 
 import yaml
 from pykwalify.core import Core
 
+from engine.state import State
 from tools.ltm_client import retrieve_memory
-
-
-@dataclass
-class State:
-    """Simple representation of the system state."""
-
-    initial_query: str
-    plan: Optional[Dict[str, Any]] = None
-    context: List[Any] = field(default_factory=list)
-    messages: List[str] = field(default_factory=list)
-    evaluation: Optional[Dict[str, Any]] = None
 
 
 class SupervisorAgent:
@@ -183,7 +171,15 @@ class SupervisorAgent:
 
         cleaned = query.strip()
         plan = self.plan_research_task(cleaned)
-        return State(initial_query=cleaned, plan=plan, context=plan.get("context", []))
+        state = State()
+        state.update(
+            {
+                "initial_query": cleaned,
+                "plan": plan,
+                "context": plan.get("context", []),
+            }
+        )
+        return state
 
     def __call__(self, graph_state: Any) -> Any:
         """Node entrypoint for the orchestration graph."""

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -4,7 +4,8 @@ from threading import Thread
 import pytest
 import requests
 
-from agents.supervisor import State, SupervisorAgent
+from agents.supervisor import SupervisorAgent
+from engine.state import State
 from services.ltm_service import EpisodicMemoryService, InMemoryStorage
 from services.ltm_service.api import LTMService, LTMServiceServer
 
@@ -33,7 +34,7 @@ def test_analyze_query_returns_state():
     agent = SupervisorAgent()
     state = agent.analyze_query("What is AI?")
     assert isinstance(state, State)
-    assert state.initial_query == "What is AI?"
+    assert state.data["initial_query"] == "What is AI?"
 
 
 def test_supervisor_node_updates_graph_state():
@@ -41,7 +42,7 @@ def test_supervisor_node_updates_graph_state():
     gs = DummyGraphState({"query": "Example query"})
     result = agent(gs)
     assert isinstance(result.data.get("state"), State)
-    assert result.data["state"].initial_query == "Example query"
+    assert result.data["state"].data["initial_query"] == "Example query"
 
 
 def test_plan_contains_parallel_webresearcher_nodes():
@@ -66,7 +67,7 @@ def test_supervisor_trims_query():
     agent = SupervisorAgent()
     gs = DummyGraphState({"query": "  spaced query \n"})
     result = agent(gs)
-    assert result.data["state"].initial_query == "spaced query"
+    assert result.data["state"].data["initial_query"] == "spaced query"
 
 
 def test_plan_yaml_roundtrip():


### PR DESCRIPTION
## Summary
- drop `State` dataclass from `agents/supervisor`
- update `SupervisorAgent` to use the central `engine.state.State`
- adjust supervisor unit tests to expect data in `State.data`

## Testing
- `pre-commit run --files agents/supervisor.py tests/test_supervisor.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'googletrans')*

------
https://chatgpt.com/codex/tasks/task_e_684f15c16608832a90f94f512db656a8