### PR TITLE
Add judge pipeline contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,44 @@ jobs:
       - name: Check codex queue
         run: python scripts/validate_queue.py
 
+  judge-pipeline:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Setup environment
+        run: bash scripts/agent-setup.sh
+      - name: Run judge pipeline contract tests
+        id: run-judge
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          pytest pipelines/judge/tests -v | tee judge.log
+          echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+      - name: Upload test log
+        uses: actions/upload-artifact@v4
+        with:
+          name: judge-test-log
+          path: judge.log
+      - name: Summarize failures
+        if: always()
+        run: python scripts/ci_summary.py judge.log coverage.xml
+      - name: Fail if tests failed
+        if: steps.run-judge.outputs.exitcode != '0'
+        run: exit 1
+
   codex-sanity:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/judge-pipeline.yml
+++ b/.github/workflows/judge-pipeline.yml
@@ -1,0 +1,49 @@
+name: Judge Pipeline
+
+on:
+  push:
+    paths:
+      - 'pipelines/judge/**'
+      - 'data/golden_judge_dataset/**'
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  judge-pipeline:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Setup environment
+        run: bash scripts/agent-setup.sh
+      - name: Run judge pipeline contract tests
+        id: run-judge
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          pytest pipelines/judge/tests -v | tee judge.log
+          echo "exitcode=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+      - name: Upload test log
+        uses: actions/upload-artifact@v4
+        with:
+          name: judge-test-log
+          path: judge.log
+      - name: Summarize failures
+        if: always()
+        run: python scripts/ci_summary.py judge.log coverage.xml
+      - name: Fail if tests failed
+        if: steps.run-judge.outputs.exitcode != '0'
+        run: exit 1

--- a/docs/pipelines/judge.md
+++ b/docs/pipelines/judge.md
@@ -1,0 +1,28 @@
+# Judge Pipeline Contract Tests
+
+This directory contains contract tests for the LLM-as-a-Judge evaluation pipeline.
+The tests ensure that given a known report, the pipeline produces JSON matching
+`schemas/judge_rubric.json` and persists the result.
+
+## Running the tests
+
+Execute the tests directly with `pytest`:
+
+```bash
+pytest pipelines/judge/tests -v
+```
+
+## Adding new cases
+
+1. Create a JSON fixture under `pipelines/judge/tests/fixtures/` named
+   `caseN.json` (increment `N`). Each fixture should include the `report` text and
+   a `scores` object representing the expected rubric scores.
+2. The contract test will load fixtures in sorted order and feed each set of
+   scores through a fake LLM. Extend the fixtures to cover new behaviours or edge
+   cases.
+
+## Interpreting failures
+
+A failing test prints a diff between the expected scores from the fixture and the
+actual pipeline output or the jsonschema validation error. The CI summary also
+includes the tail of the test log for quick debugging.

--- a/pipelines/judge/tests/fixtures/case1.json
+++ b/pipelines/judge/tests/fixtures/case1.json
@@ -1,0 +1,23 @@
+{
+  "id": 1,
+  "report": "Synthetic research report 1 on topic XYZ.",
+  "scores": {
+    "schema_version": "1.0",
+    "factual_accuracy": {
+      "score": 0.76,
+      "justification": "All facts cross-checked."
+    },
+    "completeness": {
+      "score": 0.82,
+      "justification": "Addresses key aspects."
+    },
+    "source_quality": {
+      "score": 0.76,
+      "justification": "Uses credible sources."
+    },
+    "coherence": {
+      "score": 0.99,
+      "justification": "Well structured."
+    }
+  }
+}

--- a/pipelines/judge/tests/fixtures/case2.json
+++ b/pipelines/judge/tests/fixtures/case2.json
@@ -1,0 +1,23 @@
+{
+  "id": 2,
+  "report": "Synthetic research report 2 on topic XYZ.",
+  "scores": {
+    "schema_version": "1.0",
+    "factual_accuracy": {
+      "score": 0.86,
+      "justification": "All facts cross-checked."
+    },
+    "completeness": {
+      "score": 0.97,
+      "justification": "Addresses key aspects."
+    },
+    "source_quality": {
+      "score": 0.89,
+      "justification": "Uses credible sources."
+    },
+    "coherence": {
+      "score": 0.83,
+      "justification": "Well structured."
+    }
+  }
+}

--- a/pipelines/judge/tests/test_judge_contract.py
+++ b/pipelines/judge/tests/test_judge_contract.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+import sqlite3
+
+from pipelines.judge.pipeline import JudgePipeline
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_cases():
+    cases = []
+    for path in sorted(FIXTURES.glob("case*.json")):
+        cases.append(json.loads(path.read_text(encoding="utf-8")))
+    return cases
+
+
+def test_judge_pipeline_contracts(tmp_path):
+    cases = _load_cases()
+    idx = {"i": 0}
+
+    def fake_llm(_prompt: str) -> str:
+        data = cases[idx["i"]]["scores"]
+        idx["i"] += 1
+        return json.dumps(data)
+
+    db_file = tmp_path / "results.db"
+    pipeline = JudgePipeline(fake_llm, db_path=str(db_file))
+    for case in cases:
+        result = pipeline.evaluate(case["report"], [])
+        assert result == case["scores"]
+    pipeline.close()
+
+    conn = sqlite3.connect(db_file)
+    rows = conn.execute("SELECT count(*) FROM evaluations").fetchone()[0]
+    conn.close()
+    assert rows == len(cases)


### PR DESCRIPTION
## Summary
- add contract tests for judge pipeline
- document judge pipeline testing
- add judge-pipeline job and scheduled workflow to CI

## Testing
- `bash scripts/agent-setup.sh` *(fails: ResolutionImpossible due to dependency conflict)*
- `pre-commit run --files pipelines/judge/tests/test_judge_contract.py docs/pipelines/judge.md .github/workflows/ci.yml .github/workflows/judge-pipeline.yml pipelines/judge/tests/fixtures/case1.json pipelines/judge/tests/fixtures/case2.json` *(fails: command not found)*
- `pytest -q` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684f17673ef4832aa5098b5d7d9b61bb