### PR TITLE
Consolidate tool access via registry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,10 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
+  - repo: local
+    hooks:
+      - id: forbid-tool-imports
+        name: forbid direct tool imports
+        entry: scripts/check_tool_imports.py
+        language: python
+        types: [python]

--- a/scripts/check_tool_imports.py
+++ b/scripts/check_tool_imports.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Fail if any code imports tools modules directly."""
+
+import pathlib
+import re
+import sys
+
+PATTERNS = [
+    re.compile(r"^\s*from\s+tools(\.|\s)"),
+    re.compile(r"^\s*import\s+tools(\.|\s)"),
+]
+
+base = pathlib.Path(".").resolve()
+failed = False
+for path in base.rglob("*.py"):
+    rel = path.relative_to(base)
+    if (
+        "tests" in rel.parts
+        or str(rel).startswith("services/tool_registry")
+        or str(rel).startswith("tools")
+    ):
+        continue
+    text = path.read_text(encoding="utf-8")
+    for pat in PATTERNS:
+        if pat.search(text, re.MULTILINE):
+            print(f"Direct tool import found in {rel}")
+            failed = True
+            break
+if failed:
+    sys.exit(1)

--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -84,6 +84,11 @@ class ToolRegistry:
 
         return wrapped
 
+    def invoke(self, role: str, name: str, *args: object, **kwargs: object) -> object:
+        """Invoke a tool via the registry enforcing RBAC."""
+        tool = self.get_tool(role, name)
+        return tool(*args, **kwargs)
+
     def load_permissions(self, path: str) -> None:
         """Load role permissions from a YAML config."""
         data = yaml.safe_load(open(path)) or {}

--- a/tests/test_memory_manager_trigger.py
+++ b/tests/test_memory_manager_trigger.py
@@ -5,6 +5,7 @@ from agents.memory_manager import MemoryManagerAgent
 from engine.orchestration_engine import GraphState, create_orchestration_engine
 from services.ltm_service import EpisodicMemoryService, InMemoryStorage
 from services.ltm_service.api import LTMService, LTMServiceServer
+from services.tool_registry import create_default_registry
 
 
 def _start_server():
@@ -19,7 +20,7 @@ def _start_server():
 
 def test_memory_manager_invoked_after_graph():
     server, endpoint = _start_server()
-    mm = MemoryManagerAgent(endpoint=endpoint)
+    mm = MemoryManagerAgent(endpoint=endpoint, tool_registry=create_default_registry())
 
     engine = create_orchestration_engine(memory_manager=mm)
     engine.add_node("A", lambda s: s)

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -41,11 +41,10 @@ def test_registry_authorization():
     registry = ToolRegistry()
     registry.register_tool("dummy", dummy_tool, allowed_roles=["WebResearcher"])
 
-    tool = registry.get_tool("WebResearcher", "dummy")
-    assert tool() == "ok"
+    assert registry.invoke("WebResearcher", "dummy") == "ok"
 
     with pytest.raises(AccessDeniedError):
-        registry.get_tool("Supervisor", "dummy")
+        registry.invoke("Supervisor", "dummy")
 
 
 def test_registry_server_permissions(tmp_path):
@@ -99,6 +98,7 @@ def test_registry_server_logs_denied_access(tmp_path, caplog):
     finally:
         server.httpd.shutdown()
         thread.join()
+
 
 def test_tool_init_span_and_propagation():
     exporter = InMemorySpanExporter()


### PR DESCRIPTION
## Summary
- add ToolRegistry.invoke to centralize RBAC enforcement
- remove direct tool usage in agents
- update agents and tests for registry invocations
- add lint rule forbidding direct tool imports
- integration tests for authorized/unauthorized calls

## Testing
- `pre-commit run --files agents/memory_manager.py agents/supervisor.py services/tool_registry/__init__.py tests/test_memory_manager_trigger.py tests/test_supervisor.py tests/test_tool_registry.py scripts/check_tool_imports.py .pre-commit-config.yaml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'googletrans')*

------
https://chatgpt.com/codex/tasks/task_e_684f17522fac832ab1e3d4ee14f3f9a8