### PR TITLE
Add GroupChatManager and tests

### DIFF
--- a/engine/collaboration/__init__.py
+++ b/engine/collaboration/__init__.py
@@ -1,0 +1,3 @@
+from .group_chat import DynamicGroupChat, GroupChatManager
+
+__all__ = ["DynamicGroupChat", "GroupChatManager"]

--- a/engine/orchestration_engine.py
+++ b/engine/orchestration_engine.py
@@ -37,6 +37,7 @@ class NodeType(str, Enum):
 
     DEFAULT = "default"
     HUMAN_IN_THE_LOOP_BREAKPOINT = "human_in_the_loop_breakpoint"
+    GROUP_CHAT_MANAGER = "group_chat_manager"
 
 
 class InMemorySaver:

--- a/tests/test_group_chat_manager.py
+++ b/tests/test_group_chat_manager.py
@@ -1,0 +1,26 @@
+import asyncio
+
+import pytest
+
+from engine.collaboration.group_chat import GroupChatManager
+from engine.state import State
+
+pytestmark = pytest.mark.core
+
+
+def test_group_chat_manager_message_passing():
+    received_by_b = []
+
+    def agent_a(messages, state):
+        assert messages == []
+        return "hello"
+
+    def agent_b(messages, state):
+        received_by_b.extend(messages)
+        return {"content": "FINISH", "type": "finish"}
+
+    manager = GroupChatManager({"A": agent_a, "B": agent_b}, max_turns=2)
+    state = asyncio.run(manager.run(State()))
+
+    assert any(m["content"] == "hello" for m in state.data["conversation"])
+    assert received_by_b and received_by_b[0]["content"] == "hello"


### PR DESCRIPTION
## Summary
- add `GROUP_CHAT_MANAGER` node type
- implement `GroupChatManager` for collaborative chats
- export new collaboration API
- test message passing via `GroupChatManager`

## Testing
- `pre-commit run --files engine/collaboration/group_chat.py engine/orchestration_engine.py engine/collaboration/__init__.py tests/test_group_chat_manager.py`
- `pytest -q tests/test_dynamic_group_chat.py tests/test_group_chat_manager.py`
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f18954954832abdfa415c9f6e0aba