### PR TITLE
Add episodic memory FastAPI scaffold

### DIFF
--- a/services/episodic_memory/__init__.py
+++ b/services/episodic_memory/__init__.py
@@ -1,0 +1,5 @@
+"""Episodic memory FastAPI service."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/services/episodic_memory/app.py
+++ b/services/episodic_memory/app.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from fastapi import Body, FastAPI
+from pydantic import BaseModel, Field
+
+from services.ltm_service import EpisodicMemoryService, InMemoryStorage
+
+
+class ConsolidateRequest(BaseModel):
+    task_context: Dict = Field(...)
+    execution_trace: Dict = Field(...)
+    outcome: Dict = Field(...)
+
+
+class ConsolidateResponse(BaseModel):
+    id: str
+
+
+class RetrieveBody(BaseModel):
+    query: Optional[Dict] = None
+    task_context: Optional[Dict] = None
+
+
+class RetrieveResponse(BaseModel):
+    results: List[Dict]
+
+
+storage = InMemoryStorage()
+service = EpisodicMemoryService(storage)
+
+app = FastAPI(title="Episodic Memory Service")
+
+
+@app.post("/consolidate", response_model=ConsolidateResponse)
+async def consolidate(req: ConsolidateRequest) -> ConsolidateResponse:
+    rec_id = service.store_experience(
+        req.task_context,
+        req.execution_trace,
+        req.outcome,
+    )
+    return ConsolidateResponse(id=rec_id)
+
+
+@app.get("/retrieve", response_model=RetrieveResponse)
+async def retrieve(
+    limit: int = 5,
+    body: RetrieveBody = Body(default_factory=RetrieveBody),
+) -> RetrieveResponse:
+    query = body.query or body.task_context or {}
+    results = service.retrieve_similar_experiences(query, limit=limit)
+    return RetrieveResponse(results=results)

--- a/services/episodic_memory/main.py
+++ b/services/episodic_memory/main.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import uvicorn
+
+from .app import app
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    uvicorn.run(app, host="0.0.0.0", port=8081)


### PR DESCRIPTION
## Summary
- add new `services/episodic_memory` package
- create FastAPI `app` exposing `/consolidate` and `/retrieve`
- add `main.py` entrypoint for running with Uvicorn

## Testing
- `pre-commit run --files services/episodic_memory/app.py services/episodic_memory/main.py services/episodic_memory/__init__.py`
- `pytest -q` *(fails: TypeError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_684f1b41a32c832ab1fd2d9a502d0790