### PR TITLE
Add Uvicorn multi-worker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV WORKER_COUNT=4
+CMD ["sh", "-c", "uvicorn services.episodic_memory.app:app --host 0.0.0.0 --port 8081 --workers ${WORKER_COUNT}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,5 +33,17 @@ services:
       - jaeger
     restart: unless-stopped
 
+  episodic-memory:
+    build: .
+    image: agentic/research-engine:latest
+    command: uvicorn services.episodic_memory.app:app --host 0.0.0.0 --port 8081 --workers ${WORKER_COUNT:-4}
+    environment:
+      WORKER_COUNT: ${WORKER_COUNT:-4}
+    ports:
+      - "8081:8081"
+    depends_on:
+      - otel-collector
+      - weaviate
+
 volumes:
   weaviate_data:

--- a/infra/helm/agent-services/templates/deployment.yaml
+++ b/infra/helm/agent-services/templates/deployment.yaml
@@ -22,5 +22,11 @@ spec:
       containers:
       - name: agent-services
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        command: ["sh", "-c"]
+        args:
+          - uvicorn services.episodic_memory.app:app --host 0.0.0.0 --port 80 --workers ${WORKER_COUNT}
         ports:
         - containerPort: 80
+        env:
+          - name: WORKER_COUNT
+            value: "{{ .Values.workerCount }}"

--- a/infra/helm/agent-services/values.yaml
+++ b/infra/helm/agent-services/values.yaml
@@ -7,3 +7,4 @@ service:
   type: ClusterIP
   port: 80
 color: blue
+workerCount: 4


### PR DESCRIPTION
## Summary
- create Dockerfile to run episodic memory service via uvicorn
- run service in docker-compose with configurable `WORKER_COUNT`
- update Helm chart with command, env var and default worker count

## Testing
- `pre-commit run --files Dockerfile docker-compose.yml infra/helm/agent-services/templates/deployment.yaml infra/helm/agent-services/values.yaml`
- `pytest -q` *(fails: ForwardRef._evaluate errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f1db0c2dc832a9e94bc9de5df3ae2