### PR TITLE
Implement hierarchical subgraph support

### DIFF
--- a/schemas/supervisor_plan.yaml
+++ b/schemas/supervisor_plan.yaml
@@ -29,6 +29,51 @@ mapping:
               task:
                 type: str
                 required: no
+              subgraph:
+                type: map
+                required: no
+                mapping:
+                  nodes:
+                    type: seq
+                    required: yes
+                    sequence:
+                      - type: map
+                        required: yes
+                        mapping:
+                          id:
+                            type: str
+                            required: yes
+                          agent:
+                            type: str
+                            required: yes
+                          topic:
+                            type: str
+                            required: no
+                          task:
+                            type: str
+                            required: no
+                  edges:
+                    type: seq
+                    required: yes
+                    sequence:
+                      - type: map
+                        required: yes
+                        mapping:
+                          from:
+                            type: str
+                            required: yes
+                          to:
+                            type: str
+                            required: yes
+                          edge_type:
+                            type: str
+                            required: no
+                  parallel_groups:
+                    type: seq
+                    sequence:
+                      - type: seq
+                        sequence:
+                          - type: str
       edges:
         type: seq
         required: yes

--- a/scripts/ci_summary.py
+++ b/scripts/ci_summary.py
@@ -1,7 +1,7 @@
 import os
 import sys
-from pathlib import Path
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 
 def coverage_percent(xml_path: str) -> str:
@@ -35,8 +35,14 @@ def main(log_path: str = "tests.log", cov_path: str = "coverage.xml") -> int:
         tail,
         "```",
         "",
-        f"[Coverage HTML](https://github.com/{os.environ.get('GITHUB_REPOSITORY')}/actions/runs/{os.environ.get('GITHUB_RUN_ID')}#artifacts)",
-        f"[Full Log](https://github.com/{os.environ.get('GITHUB_REPOSITORY')}/actions/runs/{os.environ.get('GITHUB_RUN_ID')})",
+        (
+            f"[Coverage HTML](https://github.com/{os.environ.get('GITHUB_REPOSITORY')}/"
+            f"actions/runs/{os.environ.get('GITHUB_RUN_ID')}#artifacts)"
+        ),
+        (
+            f"[Full Log](https://github.com/{os.environ.get('GITHUB_REPOSITORY')}/"
+            f"actions/runs/{os.environ.get('GITHUB_RUN_ID')})"
+        ),
     ]
     if summary_file:
         summary_file.write_text("\n".join(text))

--- a/tests/test_embedding_cache.py
+++ b/tests/test_embedding_cache.py
@@ -1,6 +1,7 @@
-import os
-
-from services.ltm_service.embedding_client import CachedEmbeddingClient, SimpleEmbeddingClient
+from services.ltm_service.embedding_client import (
+    CachedEmbeddingClient,
+    SimpleEmbeddingClient,
+)
 
 
 class CountingEmbeddingClient(SimpleEmbeddingClient):
@@ -22,7 +23,11 @@ def test_cached_embedding_client_hits():
 
 
 def test_service_cache_integration(monkeypatch):
-    from services.ltm_service.episodic_memory import EpisodicMemoryService, InMemoryStorage, InMemoryVectorStore
+    from services.ltm_service.episodic_memory import (
+        EpisodicMemoryService,
+        InMemoryStorage,
+        InMemoryVectorStore,
+    )
 
     monkeypatch.setenv("EMBED_CACHE_SIZE", "4")
     base = CountingEmbeddingClient()
@@ -35,4 +40,3 @@ def test_service_cache_integration(monkeypatch):
         service.retrieve_similar_experiences(ctx)
     # 1 call during store_experience + 1 during first retrieval
     assert base.calls <= 2
-

--- a/tests/test_hierarchical_subgraph.py
+++ b/tests/test_hierarchical_subgraph.py
@@ -1,0 +1,30 @@
+import asyncio
+
+from engine.orchestration_engine import GraphState, OrchestrationEngine
+
+
+def test_subgraph_node_executes_and_returns_state():
+    parent = OrchestrationEngine()
+    sub = OrchestrationEngine()
+
+    def sub_start(state: GraphState) -> GraphState:
+        state.update({"sub": 1})
+        return state
+
+    def sub_end(state: GraphState) -> GraphState:
+        state.update({"sub_done": True})
+        return state
+
+    sub.add_node("s1", sub_start)
+    sub.add_node("s2", sub_end)
+    sub.add_edge("s1", "s2")
+
+    parent.add_node("start", lambda s: s)
+    parent.add_subgraph("child", sub)
+    parent.add_node("finish", lambda s: s)
+    parent.add_edge("start", "child")
+    parent.add_edge("child", "finish")
+
+    result = asyncio.run(parent.run_async(GraphState()))
+    assert result.data["sub"] == 1
+    assert result.data["sub_done"] is True


### PR DESCRIPTION
## Summary
- allow Supervisor plans to describe nested subgraphs
- support `SUBGRAPH` node type in OrchestrationEngine
- add `add_subgraph` helper
- tweak CI summary formatting
- clean up unused import
- test subgraph execution

## Testing
- `pre-commit run --files engine/orchestration_engine.py schemas/supervisor_plan.yaml scripts/ci_summary.py tests/test_embedding_cache.py tests/test_hierarchical_subgraph.py`
- `pytest tests/test_hierarchical_subgraph.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'googletrans')*

------
https://chatgpt.com/codex/tasks/task_e_684f1d2fae1c832ab5bc8c3208fafbdf