### PR TITLE
Add reward model training pipeline

### DIFF
--- a/docs/pipelines/reward_model.md
+++ b/docs/pipelines/reward_model.md
@@ -1,0 +1,13 @@
+# Reward Model Training Pipeline
+
+This pipeline trains a simple reward model using the quality scores produced by the LLM-as-a-Judge evaluation step. The dataset should contain JSON records with a `trace` field (the task execution trace) and a numeric `score`.
+
+The `RewardModelTrainer` extracts lightweight features from the trace (currently just token length), fits a linear regression model, and saves the coefficients to `reward_model.json` in the specified output directory.
+
+Run the training script:
+
+```bash
+python scripts/train_reward_model.py --data-path data/evaluated_traces.json
+```
+
+The script versions models under `models/reward_model/<timestamp>/` and prints the evaluation MSE.

--- a/pipelines/reward_model/__init__.py
+++ b/pipelines/reward_model/__init__.py
@@ -1,0 +1,3 @@
+from .pipeline import RewardModelTrainer
+
+__all__ = ["RewardModelTrainer"]

--- a/pipelines/reward_model/pipeline.py
+++ b/pipelines/reward_model/pipeline.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+class RewardModelTrainer:
+    """Train a simple linear reward model on labeled trajectories."""
+
+    def __init__(self, data_path: str | Path, out_dir: str | Path) -> None:
+        self.data_path = Path(data_path)
+        self.out_dir = Path(out_dir)
+
+    def load_data(self) -> List[Dict]:
+        text = self.data_path.read_text(encoding="utf-8")
+        if not text.strip():
+            return []
+        if text.lstrip()[0] == "[":
+            return json.loads(text)
+        return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+    @staticmethod
+    def preprocess(records: List[Dict]) -> Tuple[List[int], List[float]]:
+        """Extract simple length-based features."""
+        x = [len(str(rec.get("trace", "")).split()) for rec in records]
+        y = [float(rec.get("score", 0)) for rec in records]
+        return x, y
+
+    @staticmethod
+    def train_model(x: List[int], y: List[float]) -> Dict[str, float]:
+        if not x:
+            raise ValueError("No training data")
+        n = len(x)
+        mean_x = sum(x) / n
+        mean_y = sum(y) / n
+        denom = sum((xi - mean_x) ** 2 for xi in x) or 1e-8
+        a = sum((xi - mean_x) * (yi - mean_y) for xi, yi in zip(x, y)) / denom
+        b = mean_y - a * mean_x
+        return {"a": a, "b": b}
+
+    @staticmethod
+    def evaluate_model(model: Dict[str, float], x: List[int], y: List[float]) -> float:
+        mse = sum(
+            (model["a"] * xi + model["b"] - yi) ** 2 for xi, yi in zip(x, y)
+        ) / len(y)
+        return mse
+
+    def save_model(self, model: Dict[str, float]) -> Path:
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        path = self.out_dir / "reward_model.json"
+        path.write_text(json.dumps(model, indent=2), encoding="utf-8")
+        return path
+
+    def run(self) -> float:
+        records = self.load_data()
+        x, y = self.preprocess(records)
+        model = self.train_model(x, y)
+        mse = self.evaluate_model(model, x, y)
+        self.save_model(model)
+        return mse

--- a/scripts/train_reward_model.py
+++ b/scripts/train_reward_model.py
@@ -1,0 +1,25 @@
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+from pipelines.reward_model import RewardModelTrainer
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train Reward Model")
+    parser.add_argument("--data-path", type=Path, required=True)
+    parser.add_argument("--out-root", type=Path, default=Path("models/reward_model"))
+    parser.add_argument("--version", default=None)
+    args = parser.parse_args()
+
+    version = args.version or datetime.utcnow().strftime("reward-%Y%m%d_%H%M%S")
+    out_dir = args.out_root / version
+
+    trainer = RewardModelTrainer(args.data_path, out_dir)
+    mse = trainer.run()
+    print(f"Saved model to {out_dir}")
+    print(f"Eval MSE: {mse:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_reward_model_pipeline.py
+++ b/tests/test_reward_model_pipeline.py
@@ -1,0 +1,22 @@
+import json
+
+from pipelines.reward_model import RewardModelTrainer
+
+
+def test_reward_model_training(tmp_path):
+    records = [
+        {"trace": "step1 step2", "score": 1.0},
+        {"trace": "step1 step2 step3 step4", "score": 2.0},
+        {"trace": "short", "score": 0.5},
+    ]
+    data_file = tmp_path / "traces.json"
+    data_file.write_text(json.dumps(records), encoding="utf-8")
+    out_dir = tmp_path / "model"
+
+    trainer = RewardModelTrainer(data_file, out_dir)
+    mse = trainer.run()
+    assert mse >= 0
+    model_file = out_dir / "reward_model.json"
+    assert model_file.is_file()
+    model = json.loads(model_file.read_text())
+    assert "a" in model and "b" in model


### PR DESCRIPTION
## Summary
- implement simple RewardModelTrainer and training script
- document reward model training usage
- test reward model pipeline

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ForwardRef._evaluate() missing 1 required keyword-only argument 'recursive_guard')*

------
https://chatgpt.com/codex/tasks/task_e_684f2234a190832abead222cab1c8c34