### PR TITLE
Add scratchpad field to State

### DIFF
--- a/engine/orchestration_engine.py
+++ b/engine/orchestration_engine.py
@@ -120,6 +120,7 @@ async def parallel_subgraphs(
         data=state.data.copy(),
         messages=list(state.messages),
         history=list(state.history),
+        scratchpad=state.scratchpad.copy(),
         status=state.status,
     )
     for res in results:

--- a/engine/state.py
+++ b/engine/state.py
@@ -12,6 +12,7 @@ class State(BaseModel):
     data: Dict[str, Any] = Field(default_factory=dict)
     messages: List[Dict[str, Any]] = Field(default_factory=list)
     history: List[Dict[str, Any]] = Field(default_factory=list)
+    scratchpad: Dict[str, Any] = Field(default_factory=dict)
     status: str | None = None
     evaluator_feedback: Dict[str, Any] | None = None
     retry_count: int = 0

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -6,6 +6,15 @@ from engine.state import State
 pytestmark = pytest.mark.core
 
 
+def test_state_scratchpad_roundtrip_and_default():
+    state = State()
+    assert state.scratchpad == {}
+    state.scratchpad["foo"] = "bar"
+    payload = state.to_json()
+    restored = State.from_json(payload)
+    assert restored.scratchpad == {"foo": "bar"}
+
+
 def test_state_serialization_roundtrip():
     state = State(data={"count": 1}, messages=[{"content": "hi"}], status="ok")
     payload = state.to_json()


### PR DESCRIPTION
## Summary
- support collaborative scratchpad in `engine.state.State`
- preserve `scratchpad` when merging parallel subgraphs
- test that scratchpad defaults to empty dict and persists through serialization

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard')*

------
https://chatgpt.com/codex/tasks/task_e_684f23c23544832ab573df5c04ad8303