### PR TITLE
Add FastAPI migration and deployment docs

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -13,3 +13,21 @@ A larger cache improves retrieval latency at the cost of additional memory. With
 
 Parallel vector search can further improve throughput on multi-core hosts. Adjust `VECTOR_SEARCH_WORKERS` based on available CPU cores. On an 8‑core machine, using 4 workers yielded around a 30% increase in requests per second compared to the single-worker baseline.
 
+
+## FastAPI Migration
+The legacy `HTTPServer` implementation was replaced with FastAPI for asynchronous request handling.
+Key entry points include `services/episodic_memory/app.py` and `services/ltm_service/openapi_app.py` where the FastAPI apps are defined.
+
+## Deployment Configuration
+Set the `WORKER_COUNT` environment variable to control the number of Uvicorn worker processes.
+For local development you can start the service with:
+
+```bash
+uvicorn services.episodic_memory.app:app --host 0.0.0.0 --port 8081 --workers ${WORKER_COUNT:-4}
+```
+
+The Dockerfile and Helm chart also honor this variable for container deployments.
+
+## Benchmark Results
+Load testing results are summarized in `docs/fastapi_benchmark_report.md`.
+Switching to FastAPI achieved over a 10× throughput increase versus the previous HTTP server while keeping latency under 100 ms at moderate concurrency.


### PR DESCRIPTION
## Summary
- document FastAPI migration, deployment config, and benchmark link in performance docs

## Testing
- `pre-commit run --files docs/performance.md`
- `pytest -q` *(fails: ImportError: lxml.html.clean module is now a separate project lxml_html_clean)*

------
https://chatgpt.com/codex/tasks/task_e_684f2416e0a8832a890a990cec9ddc3c