### PR TITLE
Integrate PPO optimizer with TRL

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -24,4 +24,6 @@ weaviate-client==3.26.7
 googletrans==4.0.2
 openai==1.3.5
 
+trl==0.7.10
+
 pytest-asyncio==0.23.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,6 @@ googletrans==4.0.2
 openai
 datasets
 transformers
+trl
 
 pytest-asyncio==0.23.6

--- a/services/learning/__init__.py
+++ b/services/learning/__init__.py
@@ -1,0 +1,6 @@
+"""Learning utilities and optimizers."""
+
+from .rlaif_system import RLAIFSystem
+from .ppo_policy_optimizer import PPOPolicyOptimizer
+
+__all__ = ["RLAIFSystem", "PPOPolicyOptimizer"]

--- a/services/learning/ppo_policy_optimizer.py
+++ b/services/learning/ppo_policy_optimizer.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""PPO-based policy optimizer using the TRL library."""
+
+from pathlib import Path
+from typing import Dict
+
+import logging
+
+from transformers import AutoTokenizer
+from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer
+
+logger = logging.getLogger(__name__)
+
+
+class PPOPolicyOptimizer:
+    """Wrapper around :class:`~trl.PPOTrainer` to update language model policies."""
+
+    def __init__(self, model_name: str, *, lr: float = 1e-5, log_dir: str | Path | None = None) -> None:
+        self.model_name = model_name
+        self.log_dir = Path(log_dir or "ppo_logs")
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        self.config = PPOConfig(model_name=model_name, learning_rate=lr)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
+        self.trainer = PPOTrainer(config=self.config, model=self.model, tokenizer=self.tokenizer)
+        self.step_count = 0
+
+    def update(self, trajectory: Dict, reward: float) -> float:
+        """Run a single PPO update step for ``trajectory`` with ``reward``."""
+        query = trajectory.get("prompt", "")
+        response = trajectory.get("response", "")
+        stats = self.trainer.step([query], [response], [reward])
+        self.step_count += 1
+        loss = float(stats.get("ppo/loss/total", 0.0))
+        for key, val in stats.items():
+            logger.info("%s: %s", key, val)
+        self.save()
+        return loss
+
+    def save(self, path: str | Path | None = None) -> None:
+        """Persist the current policy model to ``path``."""
+        dest = Path(path or self.log_dir / "policy")
+        dest.mkdir(parents=True, exist_ok=True)
+        self.model.save_pretrained(dest)
+        self.tokenizer.save_pretrained(dest)

--- a/tests/test_ppo_policy_optimizer.py
+++ b/tests/test_ppo_policy_optimizer.py
@@ -1,0 +1,17 @@
+import pytest
+
+from services.learning.ppo_policy_optimizer import PPOPolicyOptimizer
+
+
+def test_ppo_policy_optimizer_step(tmp_path):
+    _ = pytest.importorskip("trl")
+    from transformers import AutoTokenizer
+
+    model_name = "sshleifer/tiny-gpt2"
+    _ = AutoTokenizer.from_pretrained(model_name)
+    optimizer = PPOPolicyOptimizer(model_name, log_dir=tmp_path)
+    traj = {"prompt": "Hello", "response": " world"}
+    loss = optimizer.update(traj, 1.0)
+    assert isinstance(loss, float)
+    assert (tmp_path / "policy" / "config.json").exists()
+

--- a/tests/test_rlaif_system.py
+++ b/tests/test_rlaif_system.py
@@ -1,3 +1,5 @@
+import pytest
+
 from services.learning.rlaif_system import RLAIFSystem
 
 
@@ -24,3 +26,17 @@ def test_update_agent_policies():
     assert metrics["average_loss"] == -0.75
     # replay_buffer should contain the experiences
     assert len(rlaif.replay_buffer) == 2
+
+
+def test_rlaif_with_ppo(tmp_path):
+    _ = pytest.importorskip("trl")
+    from services.learning.ppo_policy_optimizer import PPOPolicyOptimizer
+
+    reward_model = DummyRewardModel()
+    optimizer = PPOPolicyOptimizer("sshleifer/tiny-gpt2", log_dir=tmp_path)
+    rlaif = RLAIFSystem(reward_model, optimizer)
+    batch = [{"prompt": "hi", "response": " there", "quality": 1.0}]
+    metrics = rlaif.update_agent_policies(batch)
+    assert "average_reward" in metrics
+    assert (tmp_path / "policy" / "config.json").exists()
+


### PR DESCRIPTION
## Summary
- add `trl` dependency for PPO support
- implement `PPOPolicyOptimizer` using TRL's `PPOTrainer`
- expose optimizer in `services.learning`
- add tests for PPO optimizer and RLAIF loop

## Testing
- `pre-commit run --files services/learning/ppo_policy_optimizer.py services/learning/__init__.py tests/test_ppo_policy_optimizer.py tests/test_rlaif_system.py requirements.txt constraints.txt` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_684f2461e7e8832aab2a3cb711f38e5d