### PR TITLE
Implement scratchpad access in group chat

### DIFF
--- a/tests/test_dynamic_group_chat.py
+++ b/tests/test_dynamic_group_chat.py
@@ -1,6 +1,7 @@
 import pytest
 
 from engine.collaboration.group_chat import DynamicGroupChat
+from engine.state import State
 
 pytestmark = pytest.mark.core
 
@@ -21,3 +22,13 @@ def test_shared_workspace():
     chat.facilitate_team_collaboration(["A", "B"], {})
     chat.update_workspace("A", "note", "value")
     assert workspace["note"] == "value"
+
+
+def test_scratchpad_binding_and_rw():
+    state = State()
+    chat = DynamicGroupChat({})
+    chat.bind_state(state)
+    chat.facilitate_team_collaboration(["A", "B"], {})
+    chat.write_scratchpad("foo", "bar")
+    assert chat.read_scratchpad("foo") == "bar"
+    assert state.scratchpad["foo"] == "bar"


### PR DESCRIPTION
## Summary
- expose `scratchpad` in `DynamicGroupChat`
- bind group chat to `State` so scratchpad writes mutate shared State
- add helpers to write/read the scratchpad
- exercise scratchpad sharing in new tests

## Testing
- `pre-commit run --files engine/collaboration/group_chat.py tests/test_dynamic_group_chat.py tests/test_group_chat_manager.py`
- `pytest -q tests/test_dynamic_group_chat.py tests/test_group_chat_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_684f251172a8832a88bae8e13fdb2a62