### PR TITLE
Connect RLAIF loop to Supervisor policy

### DIFF
--- a/pipelines/supervisor_policy/__init__.py
+++ b/pipelines/supervisor_policy/__init__.py
@@ -1,0 +1,3 @@
+from .pipeline import RewardModel, SupervisorPolicyTrainer
+
+__all__ = ["SupervisorPolicyTrainer", "RewardModel"]

--- a/pipelines/supervisor_policy/pipeline.py
+++ b/pipelines/supervisor_policy/pipeline.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+# ``services.learning`` imports the optional ``trl`` dependency. Import lazily
+# to avoid hard failures when the library is unavailable (tests will skip).
+def _load_learning_modules():
+    from services.learning import PPOPolicyOptimizer, RLAIFSystem
+
+    return PPOPolicyOptimizer, RLAIFSystem
+
+
+class RewardModel:
+    """Lightweight linear reward model loader."""
+
+    def __init__(self, model_path: str | Path) -> None:
+        self.model_path = Path(model_path)
+        self.weights = json.loads(self.model_path.read_text(encoding="utf-8"))
+
+    def score(self, trajectory: Dict) -> float:
+        a = float(self.weights.get("a", 0))
+        b = float(self.weights.get("b", 0))
+        length = len(str(trajectory.get("response", "")).split())
+        return a * length + b
+
+
+class SupervisorPolicyTrainer:
+    """Run RLAIF to update the Supervisor's planning policy."""
+
+    def __init__(
+        self,
+        data_path: str | Path,
+        reward_model_path: str | Path,
+        model_name: str = "sshleifer/tiny-gpt2",
+        out_dir: str | Path = "models/supervisor_policy",
+    ) -> None:
+        self.data_path = Path(data_path)
+        self.reward_model = RewardModel(reward_model_path)
+        PPOPolicyOptimizer, RLAIFSystem = _load_learning_modules()
+        self.rlaif = RLAIFSystem(
+            self.reward_model,
+            PPOPolicyOptimizer(model_name, log_dir=out_dir),
+        )
+
+    def load_data(self) -> List[Dict]:
+        text = self.data_path.read_text(encoding="utf-8")
+        if text.lstrip().startswith("["):
+            return json.loads(text)
+        return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+    def run(self, epochs: int = 1) -> Dict[str, float]:
+        records = self.load_data()
+        for _ in range(max(1, epochs)):
+            batch = [
+                {"prompt": rec.get("query", ""), "response": rec.get("plan", "")}
+                for rec in records
+            ]
+            self.rlaif.update_agent_policies(batch)
+        return self.rlaif.metrics

--- a/scripts/train_supervisor_policy.py
+++ b/scripts/train_supervisor_policy.py
@@ -1,0 +1,27 @@
+import argparse
+from pathlib import Path
+
+from pipelines.supervisor_policy import SupervisorPolicyTrainer
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train Supervisor policy via RLAIF")
+    parser.add_argument("--data-path", type=Path, required=True)
+    parser.add_argument("--reward-model", type=Path, required=True)
+    parser.add_argument("--model", default="sshleifer/tiny-gpt2")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument(
+        "--out-dir", type=Path, default=Path("models/supervisor_policy")
+    )
+    args = parser.parse_args()
+
+    trainer = SupervisorPolicyTrainer(
+        args.data_path, args.reward_model, args.model, args.out_dir
+    )
+    metrics = trainer.run(epochs=args.epochs)
+    print(f"Saved policy to {args.out_dir / 'policy'}")
+    print(f"Avg reward: {metrics.get('average_reward', 0):.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_supervisor_policy_trainer.py
+++ b/tests/test_supervisor_policy_trainer.py
@@ -1,0 +1,24 @@
+import json
+
+import pytest
+
+from pipelines.supervisor_policy import SupervisorPolicyTrainer
+
+
+def test_supervisor_policy_trainer(tmp_path):
+    _ = pytest.importorskip("trl")
+    data = [
+        {"query": "Q1", "plan": "step a"},
+        {"query": "Q2", "plan": "step b step c"},
+    ]
+    data_file = tmp_path / "traces.json"
+    data_file.write_text(json.dumps(data), encoding="utf-8")
+    reward_file = tmp_path / "reward_model.json"
+    reward_file.write_text(json.dumps({"a": 1.0, "b": 0.0}), encoding="utf-8")
+    out_dir = tmp_path / "model"
+    trainer = SupervisorPolicyTrainer(
+        data_file, reward_file, model_name="sshleifer/tiny-gpt2", out_dir=out_dir
+    )
+    metrics = trainer.run(epochs=1)
+    assert "average_reward" in metrics
+    assert (out_dir / "policy" / "config.json").exists()


### PR DESCRIPTION
## Summary
- add SupervisorPolicyTrainer to run PPO-based updates
- provide CLI script for training the Supervisor policy
- include test exercising the trainer interface

## Testing
- `pre-commit run --files pipelines/supervisor_policy/pipeline.py pipelines/supervisor_policy/__init__.py scripts/train_supervisor_policy.py tests/test_supervisor_policy_trainer.py`
- `pytest -q tests/test_supervisor_policy_trainer.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_684f26180aec832abb522d84a0f8c732