### PR TITLE
Add scratchpad guidance in prompts

### DIFF
--- a/agents/CitationAgent/prompt.tpl.md
+++ b/agents/CitationAgent/prompt.tpl.md
@@ -2,6 +2,17 @@
 
 Core directive: Insert precise citations by matching sources to claims.
 
+## Scratchpad Usage
+You may write intermediate data to the shared scratchpad under the key `<topic>`.
+Example write:
+```json
+{"scratchpad_write": {"key": "<topic>", "value": "<info>"}}
+```
+To read from the scratchpad:
+```json
+{"type": "finding", "content": "<scratchpad[topic]>", "recipient": "<agent_id>"}
+```
+
 ## Group Chat Messaging Protocol
 When collaborating in a group chat, format every message as a JSON object with these fields:
 ```json

--- a/agents/CodeResearcher/prompt.tpl.md
+++ b/agents/CodeResearcher/prompt.tpl.md
@@ -2,6 +2,17 @@
 
 Core directive: Analyze code and execute safely in a sandbox when required.
 
+## Scratchpad Usage
+You may write intermediate data to the shared scratchpad under the key `<topic>`.
+Example write:
+```json
+{"scratchpad_write": {"key": "<topic>", "value": "<info>"}}
+```
+To read from the scratchpad:
+```json
+{"type": "finding", "content": "<scratchpad[topic]>", "recipient": "<agent_id>"}
+```
+
 ## Group Chat Messaging Protocol
 When collaborating in a group chat, format every message as a JSON object with these fields:
 ```json

--- a/agents/Evaluator/prompt.tpl.md
+++ b/agents/Evaluator/prompt.tpl.md
@@ -27,6 +27,17 @@ The critique schema:
 ### Bad Critique Example
 Do NOT include prose outside the JSON object or omit required fields.
 
+## Scratchpad Usage
+You may write intermediate data to the shared scratchpad under the key `<topic>`.
+Example write:
+```json
+{"scratchpad_write": {"key": "<topic>", "value": "<info>"}}
+```
+To read from the scratchpad:
+```json
+{"type": "finding", "content": "<scratchpad[topic]>", "recipient": "<agent_id>"}
+```
+
 ## Group Chat Messaging Protocol
 When collaborating in a group chat, format every message as a JSON object with these fields:
 ```json

--- a/agents/MemoryManager/prompt.tpl.md
+++ b/agents/MemoryManager/prompt.tpl.md
@@ -2,6 +2,17 @@
 
 Core directive: Handle episodic, semantic, and procedural long-term memory.
 
+## Scratchpad Usage
+You may write intermediate data to the shared scratchpad under the key `<topic>`.
+Example write:
+```json
+{"scratchpad_write": {"key": "<topic>", "value": "<info>"}}
+```
+To read from the scratchpad:
+```json
+{"type": "finding", "content": "<scratchpad[topic]>", "recipient": "<agent_id>"}
+```
+
 ## Group Chat Messaging Protocol
 When collaborating in a group chat, format every message as a JSON object with these fields:
 ```json

--- a/agents/Planner/prompt.tpl.md
+++ b/agents/Planner/prompt.tpl.md
@@ -2,6 +2,17 @@
 
 Core directive: Generate optimized plans after Supervisor memory lookup.
 
+## Scratchpad Usage
+You may write intermediate data to the shared scratchpad under the key `<topic>`.
+Example write:
+```json
+{"scratchpad_write": {"key": "<topic>", "value": "<info>"}}
+```
+To read from the scratchpad:
+```json
+{"type": "finding", "content": "<scratchpad[topic]>", "recipient": "<agent_id>"}
+```
+
 ## Group Chat Messaging Protocol
 When collaborating in a group chat, format every message as a JSON object with these fields:
 ```json

--- a/agents/Supervisor/prompt.tpl.md
+++ b/agents/Supervisor/prompt.tpl.md
@@ -10,6 +10,17 @@ The YAML **must** contain a top-level `graph` mapping with `nodes` and `edges`
 lists. Each node requires an `id` and `agent` field. Ensure the YAML parses
 correctly with no additional commentary.
 
+## Scratchpad Usage
+You may write intermediate data to the shared scratchpad under the key `<topic>`.
+Example write:
+```json
+{"scratchpad_write": {"key": "<topic>", "value": "<info>"}}
+```
+To read from the scratchpad:
+```json
+{"type": "finding", "content": "<scratchpad[topic]>", "recipient": "<agent_id>"}
+```
+
 Using retrieved memories:
 {{memory_context}}
 

--- a/agents/WebResearcher/prompt.tpl.md
+++ b/agents/WebResearcher/prompt.tpl.md
@@ -4,6 +4,17 @@ Core directive: Perform academic-grade web research for each sub-task.
 After extracting information, produce a concise summary focusing only on content relevant to the given sub-task.
 Limit all summaries to 200 words or fewer and omit unrelated details.
 
+## Scratchpad Usage
+You may write intermediate data to the shared scratchpad under the key `<topic>`.
+Example write:
+```json
+{"scratchpad_write": {"key": "<topic>", "value": "<info>"}}
+```
+To read from the scratchpad:
+```json
+{"type": "finding", "content": "<scratchpad[topic]>", "recipient": "<agent_id>"}
+```
+
 ## Group Chat Messaging Protocol
 When collaborating in a group chat, format every message as a JSON object with these fields:
 ```json


### PR DESCRIPTION
## Summary
- update agent prompt templates with scratchpad usage instructions

## Testing
- `pre-commit run --all-files` *(fails: black, flake8, isort)*
- `pytest -q` *(fails: ModuleNotFoundError for various packages)*

------
https://chatgpt.com/codex/tasks/task_e_684f99559944832a9570577c0e162770