### PR TITLE
Fix opentelemetry version mismatch

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -14,7 +14,7 @@ jsonschema==4.24.0
 pykwalify==1.8.0
 fastapi==0.110.0
 uvicorn==0.27.0
-opentelemetry-api==1.34.1
+opentelemetry-api==1.24.0
 opentelemetry-sdk==1.24.0
 opentelemetry-exporter-otlp==1.24.0
 langchain==0.1.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ jsonschema==4.24.0
 pykwalify==1.8.0
 fastapi==0.110.0
 uvicorn==0.27.0
-opentelemetry-api==1.34.1
+opentelemetry-api==1.24.0
 opentelemetry-sdk==1.24.0
 opentelemetry-exporter-otlp==1.24.0
 langchain==0.1.15


### PR DESCRIPTION
## Summary
- align opentelemetry-api version with sdk to avoid pip conflict

## Testing
- `pre-commit run --files requirements.txt constraints.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_684f9de66984832abdae5a7bbd1c8a46