### PR TITLE
Use CPU Torch for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This is a mono-repo containing all services, agent definitions, and infrastructu
    ```
    The setup script installs from `requirements.txt` using a
    pinned `constraints.txt` file to avoid dependency resolution loops.
+   It pulls the CPU-only PyTorch wheels so you don't need CUDA
+   drivers for local testing.
    For a lean environment run `bash scripts/bootstrap_minimal.sh`. See
    [docs/onboarding.md](docs/onboarding.md) for troubleshooting tips.
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -25,4 +25,5 @@ googletrans==4.0.2
 openai==1.3.5
 trl==0.7.10
 pytest-asyncio==0.23.6
+torch==2.2.2+cpu
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,5 @@ googletrans==4.0.2
 openai==1.3.5
 trl==0.7.10
 pytest-asyncio==0.23.6
+torch==2.2.2+cpu
 

--- a/scripts/agent-setup.sh
+++ b/scripts/agent-setup.sh
@@ -3,6 +3,7 @@ set -e
 
 # Install Python dependencies
 python -m pip install --upgrade pip
+pip install torch==2.2.2+cpu --extra-index-url https://download.pytorch.org/whl/cpu
 pip install -r requirements.txt -c constraints.txt
 
 # Install pre-commit hooks


### PR DESCRIPTION
## Summary
- pin torch CPU wheels in requirements and constraints
- install CPU-only torch in agent-setup
- note CPU-only install in README

## Testing
- `pre-commit run --files README.md constraints.txt requirements.txt scripts/agent-setup.sh`
- `pytest -q` *(fails: 13 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f9fb42fa8832a98dae70945f314ae