### PR TITLE
Add sandboxed code interpreter

### DIFF
--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,27 @@
+import importlib.util
+import pathlib
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "sandbox", pathlib.Path("tools/sandbox.py")
+)
+sandbox = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sandbox)  # type: ignore
+run_python_code = sandbox.run_python_code
+
+pytestmark = pytest.mark.core
+
+
+def test_network_blocked():
+    code = "import urllib.request\nurllib.request.urlopen('http://example.com')"
+    result = run_python_code(code, timeout=2)
+    assert result["returncode"] != 0
+    assert "network access disabled" in result["stderr"]
+
+
+def test_timeout_enforced():
+    code = "while True:\n    pass"
+    result = run_python_code(code, timeout=1)
+    assert result["returncode"] != 0
+    assert "timeout" in result["stderr"]

--- a/tools/code_interpreter.py
+++ b/tools/code_interpreter.py
@@ -1,49 +1,21 @@
 from __future__ import annotations
 
-"""Simple code execution tool using a subprocess sandbox."""
+"""Simple code execution tool leveraging the sandbox module."""
 
-import subprocess
-import sys
 from typing import List
+
+from .sandbox import run_python_code
 
 
 def code_interpreter(
-    code: str, *, args: List[str] | None = None, timeout: int = 5
+    code: str,
+    *,
+    args: List[str] | None = None,
+    timeout: int = 5,
+    memory_limit_mb: int = 128,
 ) -> dict:
-    """Execute ``code`` as a Python script with optional ``args``.
+    """Execute ``code`` with optional ``args`` in an isolated sandbox."""
 
-    Parameters
-    ----------
-    code: str
-        Python code to execute.
-    args: List[str] | None
-        Command line arguments available as ``sys.argv[1:]``.
-    timeout: int
-        Maximum execution time in seconds.
-
-    Returns
-    -------
-    dict
-        Mapping with ``stdout``, ``stderr``, and ``returncode`` fields.
-    """
-    if not isinstance(code, str):
-        raise ValueError("code must be a string")
-    cmd = [sys.executable, "-"]
-    if args:
-        cmd.extend(args)
-    try:
-        proc = subprocess.run(
-            cmd,
-            input=code,
-            text=True,
-            capture_output=True,
-            timeout=timeout,
-            check=False,
-        )
-        return {
-            "stdout": proc.stdout,
-            "stderr": proc.stderr,
-            "returncode": proc.returncode,
-        }
-    except subprocess.TimeoutExpired:
-        return {"stdout": "", "stderr": "timeout expired", "returncode": -1}
+    return run_python_code(
+        code, args=args or [], timeout=timeout, memory_limit_mb=memory_limit_mb
+    )

--- a/tools/sandbox.py
+++ b/tools/sandbox.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Lightweight sandbox for executing Python code securely."""
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from typing import List
+
+_WRAPPER_TEMPLATE = """
+import resource
+import socket
+import sys
+
+# Apply resource limits
+resource.setrlimit(resource.RLIMIT_CPU, ({timeout}, {timeout}))
+resource.setrlimit(resource.RLIMIT_AS, ({memory}, {memory}))
+
+# Disable all network access
+class _BlockedSocket(socket.socket):
+    def __new__(cls, *args, **kwargs):
+        raise OSError('network access disabled')
+
+socket.socket = _BlockedSocket  # type: ignore[assignment]
+socket.create_connection = lambda *a, **k: (_ for _ in ()).throw(OSError('network access disabled'))
+
+code_file = sys.argv[1]
+args = sys.argv[2:]
+with open(code_file) as f:
+    code = f.read()
+
+sys.argv = [sys.argv[0]] + args
+exec(compile(code, '<sandbox>', 'exec'), {{'__name__': '__main__'}})
+"""
+
+
+def run_python_code(
+    code: str,
+    *,
+    args: List[str] | None = None,
+    timeout: int = 5,
+    memory_limit_mb: int = 128,
+) -> dict:
+    """Execute ``code`` inside a restricted subprocess."""
+    if not isinstance(code, str):
+        raise ValueError("code must be a string")
+
+    args = args or []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        code_path = os.path.join(tmp, "code.py")
+        wrapper_path = os.path.join(tmp, "wrapper.py")
+        with open(code_path, "w") as f:
+            f.write(code)
+        with open(wrapper_path, "w") as f:
+            script = _WRAPPER_TEMPLATE.format(
+                timeout=timeout, memory=memory_limit_mb * 1024 * 1024
+            )
+            f.write(textwrap.dedent(script))
+
+        cmd = [sys.executable, wrapper_path, code_path] + list(args)
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+            return {
+                "stdout": proc.stdout,
+                "stderr": proc.stderr,
+                "returncode": proc.returncode,
+            }
+        except subprocess.TimeoutExpired:
+            return {"stdout": "", "stderr": "timeout expired", "returncode": -1}


### PR DESCRIPTION
## Summary
- implement new `tools.sandbox` module to run code with network disabled and resource limits
- update `code_interpreter` to use sandbox
- add tests covering network blocking and timeout enforcement

## Testing
- `pre-commit run --files tools/sandbox.py tools/code_interpreter.py tests/test_sandbox.py`
- `pytest -q` *(fails: 13 errors during collection)*
- `pytest tests/test_sandbox.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa3b21b44832a889ec8a3b393e276