### PR TITLE
Implement composite reward function

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -26,4 +26,5 @@ openai==1.3.5
 trl==0.7.10
 pytest-asyncio==0.23.6
 torch==2.2.2+cpu
+sentence-transformers==2.6.1
 

--- a/pipelines/reward_model/__init__.py
+++ b/pipelines/reward_model/__init__.py
@@ -1,3 +1,13 @@
+from .composite_reward import (
+    CompositeRewardConfig,
+    CompositeRewardFunction,
+    LinearPreferenceModel,
+)
 from .pipeline import RewardModelTrainer
 
-__all__ = ["RewardModelTrainer"]
+__all__ = [
+    "RewardModelTrainer",
+    "CompositeRewardFunction",
+    "CompositeRewardConfig",
+    "LinearPreferenceModel",
+]

--- a/pipelines/reward_model/composite_reward.py
+++ b/pipelines/reward_model/composite_reward.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+from sentence_transformers import SentenceTransformer, util
+
+
+class LinearPreferenceModel:
+    """Simple linear preference model used as the base quality scorer."""
+
+    def __init__(self, weights: Dict[str, float]):
+        self.a = float(weights.get("a", 0))
+        self.b = float(weights.get("b", 0))
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "LinearPreferenceModel":
+        weights = json.loads(Path(path).read_text(encoding="utf-8"))
+        return cls(weights)
+
+    def score(self, prompt: str, output: str) -> float:  # noqa: D401
+        """Return linear score based on output length."""
+        length = len(str(output).split())
+        return self.a * length + self.b
+
+
+@dataclass
+class CompositeRewardConfig:
+    w_quality: float = 1.0
+    w_correction: float = 1.0
+    w_cost: float = 0.1
+    beta: float = 1.0
+    alpha: float = 1.0
+    tau_fail: float = 0.2
+    tau_pass: float = 0.8
+    lambda_cost: float = 0.01
+
+
+class CompositeRewardFunction:
+    """Calculate a SCoRe-inspired composite reward."""
+
+    def __init__(
+        self,
+        preference_model: LinearPreferenceModel,
+        sbert_model: str | SentenceTransformer = "paraphrase-MiniLM-L6-v2",
+        config: CompositeRewardConfig | None = None,
+    ) -> None:
+        self.preference_model = preference_model
+        self.sbert = (
+            sbert_model
+            if isinstance(sbert_model, SentenceTransformer)
+            else SentenceTransformer(sbert_model)
+        )
+        self.config = config or CompositeRewardConfig()
+        self.last_components: Dict[str, float] | None = None
+        self.logger = logging.getLogger(__name__)
+
+    def semantic_distance(self, output1: str, output2: str) -> float:
+        embeddings = self.sbert.encode([output1, output2], convert_to_tensor=True)
+        similarity = util.cos_sim(embeddings[0], embeddings[1]).item()
+        return 1 - similarity
+
+    def __call__(self, prompt: str, output1: str, output2: str) -> float:
+        pm2 = self.preference_model.score(prompt, output2)
+        pm1 = self.preference_model.score(prompt, output1)
+        r_base = pm2
+        r_progress = (
+            self.config.beta
+            if pm2 > self.config.tau_pass and pm1 < self.config.tau_fail
+            else 0.0
+        )
+        distance = self.semantic_distance(output1, output2)
+        m_semantic = max(0.0, min(1.0, self.config.alpha * distance))
+        c_eff = self.config.lambda_cost * len(output2.split())
+        reward = (
+            self.config.w_quality * r_base
+            + self.config.w_correction * (r_progress * m_semantic)
+            - self.config.w_cost * c_eff
+        )
+        self.last_components = {
+            "base_quality": r_base,
+            "progress_bonus": r_progress,
+            "semantic_multiplier": m_semantic,
+            "efficiency_cost": c_eff,
+        }
+        self.logger.debug("Reward components: %s", self.last_components)
+        return reward

--- a/pipelines/reward_model/pipeline.py
+++ b/pipelines/reward_model/pipeline.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from .composite_reward import CompositeRewardFunction, LinearPreferenceModel
+
 
 class RewardModelTrainer:
     """Train a simple linear reward model on labeled trajectories."""
@@ -48,14 +50,15 @@ class RewardModelTrainer:
 
     def save_model(self, model: Dict[str, float]) -> Path:
         self.out_dir.mkdir(parents=True, exist_ok=True)
-        path = self.out_dir / "reward_model.json"
+        path = self.out_dir / "preference_model.json"
         path.write_text(json.dumps(model, indent=2), encoding="utf-8")
         return path
 
-    def run(self) -> float:
+    def run(self) -> CompositeRewardFunction:
         records = self.load_data()
         x, y = self.preprocess(records)
         model = self.train_model(x, y)
-        mse = self.evaluate_model(model, x, y)
+        self.evaluate_model(model, x, y)
         self.save_model(model)
-        return mse
+        preference_model = LinearPreferenceModel(model)
+        return CompositeRewardFunction(preference_model)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,5 @@ openai==1.3.5
 trl==0.7.10
 pytest-asyncio==0.23.6
 torch==2.2.2+cpu
+sentence-transformers==2.6.1
 

--- a/tests/test_reward_model_pipeline.py
+++ b/tests/test_reward_model_pipeline.py
@@ -1,6 +1,11 @@
 import json
 
-from pipelines.reward_model import RewardModelTrainer
+from pipelines.reward_model import (
+    CompositeRewardConfig,
+    CompositeRewardFunction,
+    LinearPreferenceModel,
+    RewardModelTrainer,
+)
 
 
 def test_reward_model_training(tmp_path):
@@ -14,9 +19,24 @@ def test_reward_model_training(tmp_path):
     out_dir = tmp_path / "model"
 
     trainer = RewardModelTrainer(data_file, out_dir)
-    mse = trainer.run()
-    assert mse >= 0
-    model_file = out_dir / "reward_model.json"
+    reward_fn = trainer.run()
+    assert isinstance(reward_fn, CompositeRewardFunction)
+    model_file = out_dir / "preference_model.json"
     assert model_file.is_file()
     model = json.loads(model_file.read_text())
     assert "a" in model and "b" in model
+    reward = reward_fn("p", "bad", "good answer")
+    assert isinstance(reward, float)
+
+
+def test_composite_reward_meaningful_vs_trivial(tmp_path):
+    pref_path = tmp_path / "pref.json"
+    pref_path.write_text(json.dumps({"a": 0.0, "b": 0.0}), encoding="utf-8")
+    pref_model = LinearPreferenceModel.from_file(pref_path)
+    reward_fn = CompositeRewardFunction(
+        pref_model,
+        config=CompositeRewardConfig(w_cost=0.0, tau_fail=0.1, tau_pass=-0.1),
+    )
+    high = reward_fn("p", "wrong answer", "correct and different answer")
+    low = reward_fn("p", "a", "a")
+    assert high > low


### PR DESCRIPTION
## Summary
- add configurable CompositeRewardFunction using Sentence-BERT
- refactor reward model trainer to output a preference model and return a composite reward instance
- update export in pipelines.reward_model
- document and test the new reward function
- add `sentence-transformers` to requirements

## Testing
- `pre-commit run --files requirements.txt constraints.txt pipelines/reward_model/__init__.py pipelines/reward_model/pipeline.py pipelines/reward_model/composite_reward.py tests/test_reward_model_pipeline.py`
- `pytest tests/test_reward_model_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa78c74f0832ab03805376fd0b035