### PR TITLE
Adapt PPO to composite reward

### DIFF
--- a/services/learning/rlaif_system.py
+++ b/services/learning/rlaif_system.py
@@ -13,8 +13,9 @@ class RLAIFSystem:
         Parameters
         ----------
         reward_model:
-            Object with a ``score`` method returning a numeric reward for a
-            trajectory dict.
+            Either a callable accepting ``(prompt, output1, output2)`` or an
+            object with a ``score`` method that consumes a trajectory dict and
+            returns a numeric reward.
         policy_optimizer:
             Object exposing an ``update`` method that consumes a trajectory and
             reward to update the policy parameters and returns the loss.
@@ -23,6 +24,41 @@ class RLAIFSystem:
         self.policy_optimizer = policy_optimizer
         self.replay_buffer: List[Dict] = []
         self.metrics: Dict[str, float | int] = {"updates": 0}
+
+    def _compute_reward(self, experience: Dict) -> float:
+        """Return reward for a trajectory ``experience``.
+
+        If ``self.reward_model`` exposes a ``score`` method, it is called with
+        the full trajectory dictionary. Otherwise the reward model is assumed to
+        be callable with ``(prompt, output1, output2)`` representing the
+        self-correction workflow.
+        """
+
+        if hasattr(self.reward_model, "score"):
+            return float(self.reward_model.score(experience))
+
+        prompt = (
+            experience.get("original_problem")
+            or experience.get("original_text")
+            or experience.get("prompt")
+            or experience.get("query")
+            or ""
+        )
+        output1 = (
+            experience.get("flawed_output")
+            or experience.get("erroneous_version")
+            or experience.get("response")
+            or experience.get("draft")
+            or ""
+        )
+        output2 = (
+            experience.get("corrected_solution")
+            or experience.get("corrected_version")
+            or experience.get("revised_response")
+            or experience.get("response")
+            or ""
+        )
+        return float(self.reward_model(prompt, output1, output2))
 
     def update_agent_policies(self, experience_batch: List[Dict]) -> Dict[str, float]:
         """Update agent behaviors based on performance feedback.
@@ -38,7 +74,7 @@ class RLAIFSystem:
         losses: List[float] = []
 
         for exp in experience_batch:
-            reward = float(self.reward_model.score(exp))
+            reward = self._compute_reward(exp)
             loss = float(self.policy_optimizer.update(exp, reward))
             self.replay_buffer.append(exp)
             rewards.append(reward)


### PR DESCRIPTION
## Summary
- support composite reward functions in `RLAIFSystem`
- record reward model calls during tests
- test PPO integration with composite reward

## Testing
- `pre-commit run --files services/learning/rlaif_system.py tests/test_rlaif_system.py`
- `pytest -q` *(fails: ImportError: cannot import name 'top_k_top_p_filtering' from 'transformers')*


------
https://chatgpt.com/codex/tasks/task_e_684fa7e475c8832a8c4428d01b799feb