### PR TITLE
Add GitHub repo scraping utility

### DIFF
--- a/scripts/score_metrics.py
+++ b/scripts/score_metrics.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Compute simple metrics for scraped repositories."""
+import argparse
+import json
+import statistics
+from typing import Dict, List
+
+
+def compute_metrics(repos: List[Dict]) -> Dict[str, float]:
+    stars = [r.get("stargazers_count", 0) for r in repos]
+    forks = [r.get("forks_count", 0) for r in repos]
+    return {
+        "repo_count": len(repos),
+        "avg_stars": statistics.mean(stars) if stars else 0.0,
+        "avg_forks": statistics.mean(forks) if forks else 0.0,
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_file")
+    parser.add_argument("--output")
+    args = parser.parse_args(argv)
+
+    with open(args.input_file) as f:
+        repos = json.load(f)
+
+    metrics = compute_metrics(repos)
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(metrics, f, indent=2)
+    for k, v in metrics.items():
+        print(f"{k}: {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scrape_repos.py
+++ b/scripts/scrape_repos.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Scrape repository data from GitHub."""
+import argparse
+import json
+
+import requests
+
+GITHUB_API = "https://api.github.com"
+
+
+def search_repos(min_stars: int):
+    """Return repositories with at least ``min_stars`` stars."""
+    page = 1
+    repos = []
+    while True:
+        resp = requests.get(
+            f"{GITHUB_API}/search/repositories",
+            params={
+                "q": f"stars:>={min_stars}",
+                "sort": "stars",
+                "order": "desc",
+                "per_page": 100,
+                "page": page,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        repos.extend(data.get("items", []))
+        if "next" not in resp.links:
+            break
+        page += 1
+    return repos
+
+
+def fetch_repo(full_name: str):
+    """Return metadata for a single repository."""
+    resp = requests.get(f"{GITHUB_API}/repos/{full_name}", timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--min-stars", type=int, default=0)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--one-shot", action="store_true")
+    parser.add_argument("--repos", nargs="*")
+    args = parser.parse_args(argv)
+
+    if args.repos:
+        results = [fetch_repo(r) for r in args.repos]
+    else:
+        results = search_repos(args.min_stars)
+
+    with open(args.output, "w") as f:
+        json.dump(results, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_repo_scripts.py
+++ b/tests/test_repo_scripts.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from scripts import score_metrics, scrape_repos
+
+pytestmark = pytest.mark.core
+
+
+def test_search_repos_pagination():
+    resp1 = mock.Mock()
+    resp1.status_code = 200
+    resp1.json.return_value = {"items": [{"id": 1}]}
+    resp1.links = {"next": {"url": "n"}}
+    resp2 = mock.Mock()
+    resp2.status_code = 200
+    resp2.json.return_value = {"items": [{"id": 2}]}
+    resp2.links = {}
+    with mock.patch.object(
+        scrape_repos.requests, "get", side_effect=[resp1, resp2]
+    ) as m:
+        results = scrape_repos.search_repos(50)
+    assert len(results) == 2
+    assert m.call_count == 2
+
+
+def test_main_writes_output(tmp_path: Path):
+    out = tmp_path / "repos.json"
+    with mock.patch.object(scrape_repos, "fetch_repo", return_value={"id": 1}):
+        scrape_repos.main(["--repos", "u/r", "--output", str(out)])
+    data = json.loads(out.read_text())
+    assert data == [{"id": 1}]
+
+
+def test_compute_metrics():
+    repos = [
+        {"stargazers_count": 5, "forks_count": 1},
+        {"stargazers_count": 3, "forks_count": 3},
+    ]
+    metrics = score_metrics.compute_metrics(repos)
+    assert metrics == {"repo_count": 2, "avg_stars": 4.0, "avg_forks": 2.0}


### PR DESCRIPTION
## Summary
- add `scrape_repos.py` script to fetch repo metadata from GitHub
- add `score_metrics.py` script to compute simple stats
- test repo scraping and scoring helpers

## Testing
- `pre-commit run --files scripts/score_metrics.py scripts/scrape_repos.py tests/test_repo_scripts.py`
- `pytest -q tests/test_repo_scripts.py`


------
https://chatgpt.com/codex/tasks/task_e_684fcaae8bf8832a952113e42867722a