### PR TITLE
Implement sandboxed code interpreter

### DIFF
--- a/tests/test_code_interpreter_tool.py
+++ b/tests/test_code_interpreter_tool.py
@@ -1,0 +1,17 @@
+import pytest
+
+from tools.code_interpreter import code_interpreter
+
+pytestmark = pytest.mark.core
+
+
+def test_code_interpreter_print():
+    result = code_interpreter('print("hello world")')
+    assert result["stdout"] == "hello world\n"
+    assert result["stderr"] == ""
+    assert result["returncode"] == 0
+
+
+def test_code_interpreter_result_value():
+    result = code_interpreter("1 + 1")
+    assert result["result"] == 2


### PR DESCRIPTION
## Summary
- support capturing result value when running code in sandbox
- handle async translator responses in back translation pipeline
- add tests for the code interpreter tool

## Testing
- `pre-commit run --files pipelines/back_translation/pipeline.py tools/sandbox.py tests/test_code_interpreter_tool.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684feb8191d8832a8674a8bb083c8ba2