### PR TITLE
Add GitHub search tool

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -5,3 +5,11 @@
   steps:
   - do something
   title: Example task
+- id: P3-19
+  title: Implement a GitHub Search API tool
+  priority: medium
+  steps: []
+  acceptance_criteria:
+    - Given a query for a specific open-source library
+    - When the GitHub Search tool is called with the query
+    - Then it returns a list of relevant repository URLs and descriptions

--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -14,6 +14,7 @@ from tools import (
     code_interpreter,
     consolidate_memory,
     fact_check_claim,
+    github_search,
     html_scraper,
     pdf_extract,
     retrieve_memory,
@@ -108,6 +109,7 @@ DEFAULT_TOOLS: Dict[str, Callable[..., object]] = {
     "summarize": summarize_text,
     "fact_check": fact_check_claim,
     "code_interpreter": code_interpreter,
+    "github_search": github_search,
 }
 
 

--- a/services/tool_registry/config.yml
+++ b/services/tool_registry/config.yml
@@ -13,4 +13,6 @@ permissions:
     - Evaluator
   code_interpreter:
     - CodeResearcher
+  github_search:
+    - CodeResearcher
 

--- a/tests/test_github_search_tool.py
+++ b/tests/test_github_search_tool.py
@@ -1,0 +1,73 @@
+import importlib
+import time
+from typing import Any
+
+import pytest
+
+gs = importlib.import_module("tools.github_search")
+
+
+class DummyResponse:
+    def __init__(
+        self, status_code: int, data: Any, headers: dict | None = None
+    ) -> None:
+        self.status_code = status_code
+        self._data = data
+        self.headers = headers or {}
+        self.text = str(data)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise gs.requests.HTTPError(f"{self.status_code}", response=self)
+
+    def json(self) -> Any:
+        return self._data
+
+
+def test_repo_search_parses_results(monkeypatch):
+    data = {
+        "items": [
+            {
+                "html_url": "http://github.com/example/repo",
+                "full_name": "example/repo",
+                "description": "Test repo",
+            }
+        ]
+    }
+
+    def fake_get(url: str, headers: Any, params: Any, timeout: int) -> DummyResponse:
+        assert params["q"] == "langchain"
+        return DummyResponse(200, data)
+
+    monkeypatch.setenv("GITHUB_TOKEN", "x")
+    monkeypatch.setattr(gs.requests, "get", fake_get)
+    results = gs.github_search("langchain")
+    assert results == [
+        {
+            "url": "http://github.com/example/repo",
+            "name": "example/repo",
+            "description": "Test repo",
+        }
+    ]
+
+
+def test_repo_search_rate_limit(monkeypatch):
+    calls = []
+
+    def fake_get(url: str, headers: Any, params: Any, timeout: int) -> DummyResponse:
+        calls.append(1)
+        headers_resp = {"X-RateLimit-Reset": str(int(time.time()) + 1)}
+        return DummyResponse(403, {"message": "rate limit exceeded"}, headers_resp)
+
+    monkeypatch.setenv("GITHUB_TOKEN", "x")
+    monkeypatch.setattr(gs.requests, "get", fake_get)
+    monkeypatch.setattr(gs.time, "sleep", lambda s: None)
+    with pytest.raises(ValueError):
+        gs.github_search("query", retries=1)
+    assert len(calls) == 2
+
+
+def test_empty_query(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "x")
+    with pytest.raises(ValueError):
+        gs.github_search("  ")

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -3,6 +3,7 @@
 from . import web_search
 from .code_interpreter import code_interpreter
 from .fact_check import fact_check_claim
+from .github_search import github_search
 from .html_scraper import html_scraper
 from .ltm_client import consolidate_memory, retrieve_memory
 from .pdf_reader import pdf_extract
@@ -12,6 +13,7 @@ __all__ = [
     "consolidate_memory",
     "retrieve_memory",
     "web_search",
+    "github_search",
     "html_scraper",
     "pdf_extract",
     "summarize_text",

--- a/tools/github_search.py
+++ b/tools/github_search.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+"""GitHub Search API wrapper with basic rate limit handling."""
+
+import os
+import time
+from typing import Dict, List, Optional
+
+import requests
+
+
+def _github_request(
+    endpoint: str,
+    params: Dict[str, str],
+    *,
+    token: str,
+    retries: int,
+    backoff: float,
+) -> Dict[str, object]:
+    """Perform a GET request to the GitHub API with exponential backoff."""
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    url = f"https://api.github.com{endpoint}"
+    for attempt in range(retries + 1):
+        try:
+            resp = requests.get(url, headers=headers, params=params, timeout=10)
+            if resp.status_code == 403 and "rate limit" in resp.text.lower():
+                reset = resp.headers.get("X-RateLimit-Reset")
+                if reset and reset.isdigit():
+                    wait = max(0, int(reset) - int(time.time()))
+                else:
+                    wait = backoff * 2**attempt
+                time.sleep(wait)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            if attempt >= retries:
+                raise ValueError(f"GitHub API request failed: {exc}") from exc
+            time.sleep(backoff * 2**attempt)
+    raise ValueError("GitHub API request failed")
+
+
+def github_search(
+    query: str,
+    *,
+    search_type: str = "repositories",
+    token: Optional[str] = None,
+    top_k: int = 5,
+    retries: int = 2,
+    backoff: float = 1.0,
+) -> List[Dict[str, str]]:
+    """Search GitHub for repositories, code, or issues.
+
+    Parameters
+    ----------
+    query: str
+        Search query string.
+    search_type: str
+        One of ``"repositories"``, ``"code"``, or ``"issues"``.
+    token: str | None
+        Personal access token. Defaults to ``GITHUB_TOKEN`` environment variable.
+    top_k: int
+        Maximum number of results to return.
+    retries: int
+        Number of retry attempts on failure.
+    backoff: float
+        Base seconds to wait between retries.
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        A list of results with fields depending on ``search_type``.
+    """
+
+    token = token or os.getenv("GITHUB_TOKEN")
+    if not token:
+        raise ValueError("Missing GitHub token")
+    if not query.strip():
+        raise ValueError("Query string cannot be empty")
+
+    endpoint_map = {
+        "repositories": "/search/repositories",
+        "code": "/search/code",
+        "issues": "/search/issues",
+    }
+    if search_type not in endpoint_map:
+        raise ValueError(f"Invalid search_type: {search_type}")
+
+    params = {"q": query, "per_page": str(top_k)}
+    data = _github_request(
+        endpoint_map[search_type],
+        params,
+        token=token,
+        retries=retries,
+        backoff=backoff,
+    )
+
+    items = data.get("items", [])
+    results: List[Dict[str, str]] = []
+    if search_type == "repositories":
+        for item in items:
+            results.append(
+                {
+                    "url": item.get("html_url", ""),
+                    "name": item.get("full_name", ""),
+                    "description": item.get("description") or "",
+                }
+            )
+    elif search_type == "code":
+        for item in items:
+            repo = item.get("repository", {})
+            results.append(
+                {
+                    "url": item.get("html_url", ""),
+                    "path": item.get("path", ""),
+                    "repository": repo.get("full_name", ""),
+                }
+            )
+    else:  # issues
+        for item in items:
+            results.append(
+                {
+                    "url": item.get("html_url", ""),
+                    "title": item.get("title", ""),
+                    "state": item.get("state", ""),
+                }
+            )
+    return results


### PR DESCRIPTION
## Summary
- implement `github_search` tool for repository, code and issue search
- expose new tool in registry and grant CodeResearcher permissions
- add tests for new GitHub search tool
- queue P3-19 task

## Testing
- `pre-commit run --files .codex/queue.yml services/tool_registry/__init__.py services/tool_registry/config.yml tools/__init__.py tools/github_search.py tests/test_github_search_tool.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ffcf4b2d8832aba6791903e470146