### PR TITLE
Implement forgetting API for LTM service

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -1,3 +1,11 @@
+- id: CR-P2-01A
+  title: Harden LTM Service API with Forgetting Endpoint
+  priority: high
+  steps: []
+  acceptance_criteria:
+    - forgetting route deletes a record
+    - invalid bodies return 422
+
 - id: P3-15
   title: Integrate graph database for Semantic LTM
   priority: high

--- a/services/ltm_service/semantic_memory.py
+++ b/services/ltm_service/semantic_memory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -39,6 +40,8 @@ class SemanticMemoryService:
     ) -> List[Dict[str, Any]]:
         results = []
         for fact in self._facts:
+            if fact.get("deleted_at"):
+                continue
             if subject and fact["subject"] != subject:
                 continue
             if predicate and fact["predicate"] != predicate:
@@ -47,3 +50,14 @@ class SemanticMemoryService:
                 continue
             results.append(fact)
         return results
+
+    def forget_fact(self, fact_id: str, *, hard: bool = False) -> bool:
+        for fact in list(self._facts):
+            if fact["id"] != fact_id:
+                continue
+            if hard:
+                self._facts.remove(fact)
+            else:
+                fact["deleted_at"] = time.time()
+            return True
+        return False


### PR DESCRIPTION
## Summary
- add Pydantic request schemas and RBAC decorator for LTM service
- implement `/forget/<id>` endpoint with soft delete
- expose forget helpers for episodic and semantic memory
- validate request bodies and add tests for schema errors and forgetting
- track CR-P2-01A in the Codex queue

## Testing
- `pre-commit run --files services/ltm_service/api.py services/ltm_service/episodic_memory.py services/ltm_service/semantic_memory.py tests/test_ltm_service_api.py .codex/queue.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*
- `python scripts/sync_codex_tasks.py` *(fails: GitHub API error 404: {"message":"Not Found"...)*

------
https://chatgpt.com/codex/tasks/task_e_68500fb39d30832ab32e598cf145a21f