### PR TITLE
Add branch protection check script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,12 @@ The CI pipeline verifies that the queue file matches the tasks. Ensure you run t
 
 All development happens on feature branches. Direct pushes to `main` are disabled.
 Pull requests targeting `main` must have at least one approved review and pass all
-required CI status checks before they can be merged.
+required CI status checks before they can be merged. These settings are enforced
+through the repository's branch protection rules.
+
+To confirm the configuration, you can run `scripts/check_branch_protection.py`.
+The script calls the GitHub API and returns non-zero if the rules are missing or
+incomplete.
 
 ## Environment Setup
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Contributions are welcome and encouraged! Please follow these steps to contribut
 7. **Open a Pull Request** against the main branch of this repository.
 
 All pull requests will be automatically validated by the CI pipeline (P1-02), which includes running linters, unit tests, and checking for code coverage. A review from at least one core team member is required for a PR to be merged.
-Branch protection rules on `main` enforce these checks so direct pushes are rejected.
+Branch protection rules on `main` enforce these checks so direct pushes are rejected. You can verify the policy by running `scripts/check_branch_protection.py` with a GitHub token.
 For instructions on running the pipeline locally and the required 80% coverage threshold, see [docs/ci.md](docs/ci.md).
 
 ## **10. License**

--- a/scripts/check_branch_protection.py
+++ b/scripts/check_branch_protection.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Verify GitHub branch protection settings.
+
+The script checks that the given branch requires pull requests,
+passing status checks, and at least one approving review.
+It expects a GitHub personal access token with repo scope.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+import requests
+
+API_URL = "https://api.github.com/repos/{repo}/branches/{branch}/protection"
+
+
+def fetch_rules(repo: str, branch: str, token: str) -> dict[str, Any]:
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    url = API_URL.format(repo=repo, branch=branch)
+    resp = requests.get(url, headers=headers, timeout=10)
+    if resp.status_code != 200:
+        raise RuntimeError(f"failed to fetch protection: {resp.status_code}")
+    return resp.json()
+
+
+def validate_rules(data: dict[str, Any]) -> bool:
+    status = data.get("required_status_checks")
+    reviews = data.get("required_pull_request_reviews", {})
+    return bool(status) and reviews.get("required_approving_review_count", 0) >= 1
+
+
+def main(branch: str = "main", repo: str | None = None) -> int:
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = repo or os.environ.get("GITHUB_REPOSITORY")
+    if not token or not repo:
+        print("GITHUB_TOKEN and GITHUB_REPOSITORY must be set", file=sys.stderr)
+        return 1
+
+    try:
+        rules = fetch_rules(repo, branch, token)
+    except Exception as exc:  # pragma: no cover - network call
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if validate_rules(rules):
+        print(f"Branch protection for {branch} meets requirements")
+        return 0
+
+    print(f"Branch protection for {branch} is insufficient", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(*(sys.argv[1:3])))


### PR DESCRIPTION
## Summary
- add a helper script to verify GitHub branch protection rules
- note branch protection script in CONTRIBUTING and README

## Testing
- `pre-commit run --files scripts/check_branch_protection.py CONTRIBUTING.md README.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_6850168855ac832abaf9cc8e863d4214