### PR TITLE
Document blue-green deployment decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,17 @@ Tesseract binary to be installed and accessible on the system.
 
 All services are deployed via an automated CD pipeline defined in `.github/workflows/cd.yml`.
 The pipeline uses Terraform and Helm configurations under `infra/` to perform
-"rainbow" deployments. The `scripts/deploy.sh` helper script toggles between
+blue–green deployments. The `scripts/deploy.sh` helper script toggles between
 `blue` and `green` deployments so the new version is spun up alongside the old
 one. Once the new pods are ready, the service selector is patched to shift
-traffic with no interruption before the old deployment is removed. A push to
-`main` deploys to the `staging` environment automatically. After verification,
-an operator can trigger the `promote-production` job to roll out the same
-release to production. In case of issues, `scripts/rollback.sh` reverts the
-selector to the previous color.
+traffic with no interruption before the old deployment is removed. While the
+blueprint originally called for a rainbow rollout, technical leadership approved
+the simpler blue–green approach. See
+[docs/research/2025-blue-green-rainbow-analysis.md](docs/research/2025-blue-green-rainbow-analysis.md)
+for the detailed rationale. A push to `main` deploys to the `staging`
+environment automatically. After verification, an operator can trigger the
+`promote-production` job to roll out the same release to production. In case of
+issues, `scripts/rollback.sh` reverts the selector to the previous color.
 
 ## **8. Project Roadmap**
 

--- a/docs/architecture/decision_records.md
+++ b/docs/architecture/decision_records.md
@@ -1,0 +1,5 @@
+# Architectural Decision Records
+
+This log summarizes significant architecture choices made during the project. Each entry links to a document explaining the reasoning.
+
+- **ADR-001:** [Blue-Green Deployment Rationale](../research/2025-blue-green-rainbow-analysis.md)

--- a/docs/research/2025-blue-green-rainbow-analysis.md
+++ b/docs/research/2025-blue-green-rainbow-analysis.md
@@ -1,0 +1,20 @@
+# Blue-Green vs. Rainbow Deployment for Stateful Agents
+
+The project blueprint specifies a **rainbow** deployment strategy to guarantee zero-downtime when rolling out new agent service versions. In practice, the `scripts/deploy.sh` helper currently performs a simpler **blue–green** switch over.
+
+## Why Blue-Green?
+
+- **Simpler namespace management.** Each color corresponds to a full deployment with its own label selector. Ephemeral agent pods can continue running under the old color until drained.
+- **Reduced resource footprint.** Only two versions ever run at once, avoiding the proliferation of multicolored replicas typical of a rainbow rollout.
+- **Kubernetes readiness gates.** The script waits for the new color's deployment to become ready before traffic is shifted, ensuring ongoing tasks are not interrupted.
+
+While rainbow deployments gradually shift traffic across multiple versions, the blue-green approach still satisfies the blueprint's core requirement: new pods come online before the old ones are terminated, preserving long-lived agent workflows.
+
+## Risk Mitigation
+
+- Agent state is stored externally (e.g., in Redis and the LTM service), so pod replacement does not wipe working memory.
+- Rolling back is fast: `scripts/rollback.sh` flips the service selector back to the previous color.
+
+## Decision
+
+Technical leadership approved continuing with blue-green deployments as the default strategy. The analysis above is recorded here to document the rationale for deviating from the original rainbow specification.


### PR DESCRIPTION
## Summary
- add architecture decision log
- document rationale for using blue-green deployment instead of rainbow
- update README to reference the decision document

## Testing
- `pre-commit run --files README.md docs/research/2025-blue-green-rainbow-analysis.md docs/architecture/decision_records.md`
- `pytest -q` *(fails: ImportError in services/ltm_service/api.py)*

------
https://chatgpt.com/codex/tasks/task_e_685017483abc832a8cfba2bfe37daa7a