### PR TITLE
Implement evaluator training metrics

### DIFF
--- a/docs/reports/p2_gap_analysis.md
+++ b/docs/reports/p2_gap_analysis.md
@@ -25,7 +25,7 @@ This document maps each Phase 2 change request (P2‑01 through P2‑20) to the 
 | P2‑14 | Judge calibration test suite | ✔ | `test_judge_calibration_mean_kappa_above_threshold` computes Cohen's Kappa【F:tests/test_judge_calibration.py†L1-L63】 |
 | P2‑15 | Research synthetic data generation | ✔ | Study outlines teacher‑student and back‑translation methods【F:docs/research/2025-synthetic-data-research.md†L1-L18】 |
 | P2‑16 | Synthetic dataset of errors and corrections | ✔ | `generate_self_correction_dataset.py` builds dataset from golden reports【F:scripts/generate_self_correction_dataset.py†L1-L56】 |
-| P2‑17 | Fine-tune Evaluator on correction dataset | ⚠ | Training script outputs accuracy but improvement metrics not stored【F:scripts/train_evaluator.py†L84-L111】 |
+| P2‑17 | Fine-tune Evaluator on correction dataset | ✔ | Training script saves baseline and fine-tuned accuracy to metrics file【F:scripts/train_evaluator.py†L119-L142】 |
 | P2‑18 | Human-in-the-loop breakpoint node | ✔ | Orchestration pauses when node type `HUMAN_IN_THE_LOOP_BREAKPOINT` encountered【F:engine/orchestration_engine.py†L260-L279】【F:docs/hitl_breakpoint.md†L1-L11】 |
 | P2‑19 | Research memory consolidation & forgetting | ✔ | Report compares candidate algorithms and recommends hybrid decay【F:docs/research/2025-ltm-forgetting-study.md†L1-L18】【F:docs/research/2025-ltm-forgetting-study.md†L40-L48】 |
 | P2‑20 | Basic LTM forgetting mechanism | ⚠ | Episodic service exposes pruning/decay methods and job script but no scheduled integration【F:scripts/episodic_forgetting_job.py†L1-L18】【F:tests/test_forgetting_job.py†L62-L117】 |

--- a/tests/test_train_evaluator.py
+++ b/tests/test_train_evaluator.py
@@ -13,3 +13,49 @@ def test_prepare_datasets(tmp_path):
     train_ds, eval_ds = train_evaluator.prepare_datasets(data_file, test_split=0.5)
     assert len(train_ds) + len(eval_ds) == 2
     assert all("input" in ex and "label" in ex for ex in train_ds)
+
+
+def test_metrics_file_created(tmp_path, monkeypatch):
+    data_file = tmp_path / "data.json"
+    data_file.write_text("[]", encoding="utf-8")
+
+    out_root = tmp_path / "models"
+    baseline_trainer = object()
+    finetuned_trainer = object()
+
+    def fake_build_trainer(*args, **kwargs):
+        return baseline_trainer
+
+    def fake_train_model(*args, **kwargs):
+        # emulate side effect of creating output directory
+        out_dir = kwargs.get("out_dir") or args[3]
+        (out_dir).mkdir(parents=True, exist_ok=True)
+        return finetuned_trainer
+
+    def fake_evaluate_model(trainer, _):
+        if trainer is baseline_trainer:
+            return 0.5
+        return 0.75
+
+    monkeypatch.setattr(train_evaluator, "build_trainer", fake_build_trainer)
+    monkeypatch.setattr(train_evaluator, "train_model", fake_train_model)
+    monkeypatch.setattr(train_evaluator, "evaluate_model", fake_evaluate_model)
+
+    args = [
+        "--data-path",
+        str(data_file),
+        "--model",
+        "dummy",
+        "--epochs",
+        "1",
+        "--out-root",
+        str(out_root),
+        "--version",
+        "v1",
+    ]
+    monkeypatch.setattr("sys.argv", ["train_evaluator.py", *args])
+    train_evaluator.main()
+
+    metrics = json.loads((out_root / "v1" / "metrics.json").read_text())
+    assert metrics["baseline_model_accuracy"] == 0.5
+    assert metrics["finetuned_model_accuracy"] == 0.75


### PR DESCRIPTION
## Summary
- generate trainer helper for evaluator models
- evaluate baseline before fine-tuning
- persist baseline vs finetuned accuracy in `metrics.json`
- document improved capability in phase 2 gap analysis
- test metrics file creation

## Testing
- `pre-commit run --files scripts/train_evaluator.py tests/test_train_evaluator.py docs/reports/p2_gap_analysis.md`
- `pytest tests/test_train_evaluator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68501a28ece0832abb9507949d243e7d