### PR TITLE
Implement pluggable LLM client

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -32,3 +32,11 @@
     - When the GitHub Search tool is called with the query
     - Then it returns a list of relevant repository URLs and descriptions
 
+- id: CR-DEV-01
+  title: Implement Pluggable LLM Client for Local and Cloud Model Support
+  priority: medium
+  steps: []
+  acceptance_criteria:
+    - Given LLM_PROVIDER="ollama" the client sends requests to the local server
+    - Given LLM_PROVIDER="openai_compatible" the client sends requests to the configured cloud endpoint
+    - Changing environment variables switches models without code changes

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,10 @@
+"""Service utilities and clients."""
+
+from .llm_client import LLMClient, OllamaClient, OpenAICompatibleClient, load_llm_client
+
+__all__ = [
+    "LLMClient",
+    "OllamaClient",
+    "OpenAICompatibleClient",
+    "load_llm_client",
+]

--- a/services/llm_client.py
+++ b/services/llm_client.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Pluggable LLM client supporting local and cloud backends."""
+
+import os
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Sequence
+
+import openai
+import requests
+
+
+class LLMClient(ABC):
+    """Abstract base LLM client."""
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+
+    @abstractmethod
+    def invoke(self, messages: Sequence[Dict[str, str]], **kwargs: Any) -> str:
+        """Generate a completion from ``messages``."""
+        raise NotImplementedError
+
+
+class OllamaClient(LLMClient):
+    """Client for a local Ollama server."""
+
+    def __init__(self, model: str, base_url: str | None = None) -> None:
+        super().__init__(model)
+        self.base_url = base_url or os.getenv(
+            "OLLAMA_BASE_URL", "http://localhost:11434"
+        )
+
+    def invoke(self, messages: Sequence[Dict[str, str]], **kwargs: Any) -> str:
+        url = f"{self.base_url}/api/chat"
+        resp = requests.post(
+            url,
+            json={"model": self.model, "messages": list(messages)},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # Ollama returns {{"message": {{"content": ...}}}}
+        return data.get("message", {}).get("content", data.get("content", ""))
+
+
+class OpenAICompatibleClient(LLMClient):
+    """Client for OpenAI-compatible endpoints using the openai library."""
+
+    def __init__(self, model: str, api_key: str, base_url: str) -> None:
+        super().__init__(model)
+        self.client = openai.OpenAI(api_key=api_key, base_url=base_url)
+
+    def invoke(self, messages: Sequence[Dict[str, str]], **kwargs: Any) -> str:
+        resp = self.client.chat.completions.create(
+            model=self.model, messages=list(messages), **kwargs
+        )
+        return resp.choices[0].message.content
+
+
+def load_llm_client() -> LLMClient:
+    """Instantiate an LLM client based on environment configuration."""
+
+    provider = os.getenv("LLM_PROVIDER", "ollama").lower()
+    model = os.getenv("LLM_MODEL_NAME", "llama3")
+
+    if provider == "ollama":
+        base = os.getenv("LLM_API_BASE_URL")
+        return OllamaClient(model, base)
+
+    if provider == "openai_compatible":
+        base = os.getenv("LLM_API_BASE_URL", "https://api.openai.com/v1")
+        api_key = os.getenv("LLM_API_KEY")
+        if not api_key:
+            raise ValueError("LLM_API_KEY is required for OpenAI-compatible client")
+        return OpenAICompatibleClient(model, api_key, base)
+
+    raise ValueError(f"Unsupported LLM_PROVIDER: {provider}")
+
+
+__all__ = [
+    "LLMClient",
+    "OllamaClient",
+    "OpenAICompatibleClient",
+    "load_llm_client",
+]

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,74 @@
+import importlib
+import types
+
+llm_module = importlib.import_module("services.llm_client")
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_ollama_client(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("LLM_MODEL_NAME", "llama3")
+
+    calls = {}
+
+    def fake_post(url: str, json: dict, timeout: int):
+        calls["url"] = url
+        calls["json"] = json
+        return DummyResponse({"message": {"content": "hi"}})
+
+    monkeypatch.setattr(llm_module.requests, "post", fake_post)
+
+    client = llm_module.load_llm_client()
+    result = client.invoke([{"role": "user", "content": "hello"}])
+
+    assert result == "hi"
+    assert calls["url"].endswith("/api/chat")
+    assert calls["json"]["model"] == "llama3"
+
+
+def test_openai_client(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "openai_compatible")
+    monkeypatch.setenv("LLM_MODEL_NAME", "test-model")
+    monkeypatch.setenv("LLM_API_KEY", "key")
+    monkeypatch.setenv("LLM_API_BASE_URL", "http://cloud")
+
+    called = {}
+
+    class DummyOpenAI:
+        def __init__(self, *args, **kwargs):
+            called["api_key"] = kwargs.get("api_key")
+            called["base_url"] = kwargs.get("base_url")
+            self.chat = types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=self._create)
+            )
+
+        def _create(self, model: str, messages):
+            called["model"] = model
+            called["messages"] = messages
+            return types.SimpleNamespace(
+                choices=[
+                    types.SimpleNamespace(message=types.SimpleNamespace(content="ok"))
+                ]
+            )
+
+    monkeypatch.setattr("openai.OpenAI", DummyOpenAI)
+    importlib.reload(llm_module)
+    client = llm_module.load_llm_client()
+    result = client.invoke([{"role": "user", "content": "hi"}])
+
+    assert result == "ok"
+    assert called["api_key"] == "key"
+    assert called["base_url"] == "http://cloud"
+    assert called["model"] == "test-model"
+    assert called["messages"][0]["content"] == "hi"


### PR DESCRIPTION
## Summary
- add new `LLMClient` abstraction with Ollama and OpenAI backends
- expose client loader in `services.__init__`
- document new task in `.codex/queue.yml`
- test both client implementations

## Testing
- `pre-commit run --files services/llm_client.py services/__init__.py tests/test_llm_client.py .codex/queue.yml`
- `pytest -q tests/test_llm_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68501b38a384832aad9af48b6581a286