### PR TITLE
Implement Codex Notary queue integration

### DIFF
--- a/scripts/codex_notary.py
+++ b/scripts/codex_notary.py
@@ -1,0 +1,81 @@
+import os
+import re
+import sys
+from typing import List
+
+import yaml
+
+from scripts import issue_logger
+
+GITHUB_API = "https://api.github.com"
+
+
+def load_queue(path: str) -> List[dict]:
+    if not os.path.exists(path):
+        return []
+    with open(path) as f:
+        data = yaml.safe_load(f) or []
+    return [d for d in data if isinstance(d, dict)]
+
+
+def save_queue(path: str, tasks: List[dict]) -> None:
+    with open(path, "w") as f:
+        yaml.safe_dump(tasks, f, sort_keys=False)
+
+
+def _issue_number_from_url(url: str) -> int | None:
+    m = re.search(r"/issues/(\d+)", url)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def create_issues_for_queue(queue_path: str, repo: str) -> int:
+    tasks = load_queue(queue_path)
+    changed = False
+    for t in tasks:
+        if t.get("issue_id"):
+            continue
+        title = f"{t.get('id')}: {t.get('title', '')}".strip()
+        body_parts: List[str] = []
+        if t.get("strategic_rationale"):
+            body_parts.append(f"**Strategic Rationale**\n{t['strategic_rationale']}")
+        if t.get("detailed_description"):
+            body_parts.append(f"**Detailed Description**\n{t['detailed_description']}")
+        body = "\n\n".join(body_parts)
+        labels: List[str] = []
+        if t.get("phase"):
+            labels.append(f"phase:{t['phase']}")
+        if t.get("epic"):
+            labels.append(f"epic:{t['epic']}")
+        url = issue_logger.create_issue(title, body, repo, labels=labels)
+        if not url:
+            print(f"Failed to create issue for {t.get('id')}", file=sys.stderr)
+            return 1
+        num = _issue_number_from_url(url)
+        if num:
+            t["issue_id"] = num
+            changed = True
+        else:
+            print(f"Could not parse issue number from {url}", file=sys.stderr)
+            return 1
+    if changed:
+        save_queue(queue_path, tasks)
+    return 0
+
+
+def main(argv: List[str] | None = None) -> int:
+    queue_path = argv[0] if argv else os.path.join(".codex", "queue.yml")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        print("GITHUB_REPOSITORY not set", file=sys.stderr)
+        return 1
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN not set", file=sys.stderr)
+        return 1
+    return create_issues_for_queue(queue_path, repo)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_codex_notary.py
+++ b/tests/test_codex_notary.py
@@ -1,0 +1,32 @@
+import os
+from unittest import mock
+
+import yaml
+
+from scripts import codex_notary
+
+
+def test_create_issue_updates_queue(tmp_path):
+    queue = tmp_path / "queue.yml"
+    data = [
+        {"id": "CR-1", "title": "Test", "phase": "Automation", "epic": "Codex Workflow"}
+    ]
+    queue.write_text(yaml.safe_dump(data))
+
+    called = {}
+
+    def fake_create_issue(title, body, repo, labels=None):
+        called["title"] = title
+        called["labels"] = labels
+        return "https://api.github.com/repos/u/r/issues/42"
+
+    with mock.patch.dict(
+        os.environ, {"GITHUB_REPOSITORY": "u/r", "GITHUB_TOKEN": "t"}
+    ), mock.patch.object(codex_notary.issue_logger, "create_issue", fake_create_issue):
+        exitcode = codex_notary.main([str(queue)])
+
+    assert exitcode == 0
+    updated = yaml.safe_load(queue.read_text())
+    assert updated[0]["issue_id"] == 42
+    assert called["title"].startswith("CR-1")
+    assert "phase:Automation" in called["labels"]


### PR DESCRIPTION
## Summary
- add `scripts/codex_notary.py` to turn queue items into GitHub issues
- test Codex Notary queue update logic

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_codex_notary.py -q`
- ❌ `pytest -q` *(failed: execution timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6850147ec040832abd480b4abf52bbc3