### PR TITLE
Fix RBAC path parameter bug

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,6 +1,18 @@
 """Service utilities and clients."""
 
-from .llm_client import LLMClient, OllamaClient, OpenAICompatibleClient, load_llm_client
+
+def __getattr__(name: str):
+    if name in {
+        "LLMClient",
+        "OllamaClient",
+        "OpenAICompatibleClient",
+        "load_llm_client",
+    }:
+        from . import llm_client as _lc
+
+        return getattr(_lc, name)
+    raise AttributeError(name)
+
 
 __all__ = [
     "LLMClient",


### PR DESCRIPTION
## Summary
- allow fallback when pydantic isn't available
- lazily import llm client to avoid heavyweight deps during tests
- fix RBAC decorator to use request path

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_async_concurrency.py::test_concurrent_retrieves_under_latency -q`
- `pytest -q` *(fails: 41 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685020145338832abaf955931b62cdc6