### PR TITLE
Improve HTML scraper to handle simple JS content

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,5 @@ sentence-transformers==2.6.1
 tenacity==8.2.3
 datasets==3.6.0
 lxml_html_clean==0.4.2
+trafilatura==2.0.0
 

--- a/tests/test_html_scraper_tool.py
+++ b/tests/test_html_scraper_tool.py
@@ -73,11 +73,12 @@ def test_html_scraper_dynamic_content(tmp_path):
     httpd, t = _serve_dir(tmp_path)
     try:
         url = f"http://localhost:{httpd.server_port}/dynamic.html"
-        with pytest.raises(ValueError):
-            html_scraper(url)
+        text = html_scraper(url)
     finally:
         httpd.shutdown()
         t.join()
+
+    assert "Hi" in text
 
 
 def test_html_scraper_traversal(tmp_path):

--- a/tools/html_scraper.py
+++ b/tools/html_scraper.py
@@ -3,14 +3,37 @@ from __future__ import annotations
 """Simplistic HTML scraper returning main article text."""
 
 import os
+import re
 from pathlib import Path
 from urllib.parse import urlparse
 
 import requests
+import trafilatura
 from bs4 import BeautifulSoup
 from readability import Document
 
 from .validation import validate_path_or_url
+
+
+def _extract_main_text(html: str) -> str:
+    """Extract article text from raw HTML using readability with trafilatura fallback."""
+    doc = Document(html)
+    article_html = doc.summary(html_partial=True)
+    soup = BeautifulSoup(article_html, "html.parser")
+    for tag in soup(
+        ["script", "style", "noscript", "header", "footer", "nav", "aside"]
+    ):
+        tag.decompose()
+
+    article = soup.find("article") or soup.find("main") or soup
+    paragraphs = [p.get_text(strip=True) for p in article.find_all("p")]
+    text = "\n".join(paragraphs).strip()
+    if text:
+        return text
+
+    # Fallback to trafilatura if readability extraction fails
+    text = trafilatura.extract(html, include_comments=False, include_tables=False) or ""
+    return text.strip()
 
 
 def html_scraper(url: str, *, timeout: int = 10) -> str:
@@ -31,21 +54,31 @@ def html_scraper(url: str, *, timeout: int = 10) -> str:
             raise FileNotFoundError(validated)
         html_text = Path(validated).read_text(encoding="utf-8", errors="ignore")
 
-    # Use readability to isolate the article HTML, falling back to full page
-    doc = Document(html_text)
-    article_html = doc.summary(html_partial=True)
-    soup = BeautifulSoup(article_html, "html.parser")
-    for tag in soup(
-        ["script", "style", "noscript", "header", "footer", "nav", "aside"]
-    ):
-        tag.decompose()
+    text = _extract_main_text(html_text)
+    if not text:
+        # look for trivial inline script assigning to document.body.innerHTML
+        match = re.search(
+            r"document\.body\.innerHTML\s*=\s*(['\"])(.*?)\1",
+            html_text,
+            re.DOTALL,
+        )
+        if match:
+            text = _extract_main_text(match.group(2))
 
-    article = soup.find("article") or soup.find("main") or soup
-    paragraphs = [p.get_text(strip=True) for p in article.find_all("p")]
-    text = "\n".join(paragraphs)
-    if not paragraphs:
-        raise ValueError("Page appears to require JavaScript rendering")
+    if not text:
+        # Attempt JS-rendered snapshot via remote service
+        try:
+            resp = requests.get(f"https://r.jina.ai/{validated}", timeout=timeout)
+            resp.raise_for_status()
+            rendered = resp.text
+            md_index = rendered.find("Markdown Content:")
+            if md_index != -1:
+                rendered = rendered[md_index + len("Markdown Content:") :]
+            text = rendered.strip()
+        except requests.RequestException:
+            text = ""
 
-    if not text.strip():
+    if not text:
         raise ValueError("No extractable text found in HTML")
+
     return text


### PR DESCRIPTION
## Summary
- fallback to remote prerender service and basic JS snippet parsing
- use readability before trafilatura
- update tests for dynamic content
- add `trafilatura` dependency

## Testing
- `pre-commit run --files tools/html_scraper.py tests/test_html_scraper_tool.py requirements.txt`
- `pytest tests/test_html_scraper_tool.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685017c1f82c832ab7a3f8eebbab690b