### PR TITLE
Replace deprecated utcnow usage

### DIFF
--- a/scripts/dataset_curation.py
+++ b/scripts/dataset_curation.py
@@ -1,7 +1,7 @@
 import argparse
+import datetime
 import json
 import random
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -46,7 +46,7 @@ def validate_records(records: List[Dict]) -> Tuple[List[Dict], List[Dict]]:
 
 
 def save_version(records: List[Dict], out_dir: Path) -> str:
-    version_id = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    version_id = datetime.datetime.now(datetime.UTC).strftime("%Y%m%d_%H%M%S")
     version_path = out_dir / version_id
     version_path.mkdir(parents=True, exist_ok=True)
     (version_path / "dataset.json").write_text(

--- a/scripts/issue_logger.py
+++ b/scripts/issue_logger.py
@@ -1,11 +1,11 @@
 import argparse
+import datetime
 import fcntl
 import json
 import os
 import sys
 import tempfile
 import time
-from datetime import datetime
 from typing import List, Optional
 
 import requests
@@ -250,14 +250,14 @@ class CodexAgentLogger:
         self.started: Optional[str] = None
 
     def start(self) -> None:
-        self.started = datetime.utcnow().isoformat()
+        self.started = datetime.datetime.now(datetime.UTC).isoformat()
 
     def finish(self, worklog: dict) -> None:
         worklog = dict(worklog)
         worklog.setdefault("agent_id", self.agent_id)
         if self.started and "started" not in worklog:
             worklog["started"] = self.started
-        worklog.setdefault("finished", datetime.utcnow().isoformat())
+        worklog.setdefault("finished", datetime.datetime.now(datetime.UTC).isoformat())
         url = post_worklog_comment(self.target_url, worklog)
         if not url:
             print("Worklog comment failed; stored for retry", file=sys.stderr)

--- a/scripts/train_evaluator.py
+++ b/scripts/train_evaluator.py
@@ -1,6 +1,6 @@
 import argparse
+import datetime
 import json
-from datetime import datetime
 from pathlib import Path
 from typing import Tuple
 
@@ -113,7 +113,10 @@ def main() -> None:
     parser.add_argument("--out-root", type=Path, default=Path("models/evaluator"))
     args = parser.parse_args()
 
-    version = args.version or f"evaluator-{datetime.utcnow().strftime('%Y%m%d')}"
+    version = (
+        args.version
+        or f"evaluator-{datetime.datetime.now(datetime.UTC).strftime('%Y%m%d')}"
+    )
     out_dir = args.out_root / version
 
     train_ds, eval_ds = prepare_datasets(args.data_path, args.test_split)

--- a/scripts/train_reward_model.py
+++ b/scripts/train_reward_model.py
@@ -1,5 +1,5 @@
 import argparse
-from datetime import datetime
+import datetime
 from pathlib import Path
 
 from pipelines.reward_model import RewardModelTrainer
@@ -12,7 +12,9 @@ def main() -> None:
     parser.add_argument("--version", default=None)
     args = parser.parse_args()
 
-    version = args.version or datetime.utcnow().strftime("reward-%Y%m%d_%H%M%S")
+    version = args.version or datetime.datetime.now(datetime.UTC).strftime(
+        "reward-%Y%m%d_%H%M%S"
+    )
     out_dir = args.out_root / version
 
     trainer = RewardModelTrainer(args.data_path, out_dir)

--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 """Simple in-memory Tool Registry with RBAC controls."""
 
+import datetime
 import os
-from datetime import datetime
 from typing import Callable, Dict, Iterable, Optional
 
 import yaml
@@ -53,7 +53,7 @@ class ToolRegistry:
             "tool.init",
             attributes={
                 "tool.name": name,
-                "init.timestamp": datetime.utcnow().isoformat(),
+                "init.timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
                 "parent.span_id": hex(parent_id),
             },
         ) as span:

--- a/services/tool_registry/registry.py
+++ b/services/tool_registry/registry.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import datetime
 import json
 import logging
-from datetime import datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs, urlparse
 
@@ -46,7 +46,9 @@ class ToolRegistryServer:
                     logger.warning(
                         json.dumps(
                             {
-                                "timestamp": datetime.utcnow().isoformat(),
+                                "timestamp": datetime.datetime.now(
+                                    datetime.UTC
+                                ).isoformat(),
                                 "role": role,
                                 "tool": name,
                                 "client_ip": self.client_address[0],

--- a/tests/benchmarks/browsecomp_evaluator.py
+++ b/tests/benchmarks/browsecomp_evaluator.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 import time
-from datetime import datetime
 from typing import Any, Dict, Iterable
 
 
@@ -65,5 +65,7 @@ class BrowseCompEvaluator:
             "pass_rate": passed / len(results) if results else 0.0,
             "results": results,
         }
-        self.history.append({"timestamp": datetime.utcnow().isoformat(), **summary})
+        self.history.append(
+            {"timestamp": datetime.datetime.now(datetime.UTC).isoformat(), **summary}
+        )
         return summary


### PR DESCRIPTION
## Summary
- modernize datetime usage for UTC timestamps

## Testing
- `pre-commit run --files scripts/issue_logger.py scripts/dataset_curation.py scripts/train_evaluator.py scripts/train_reward_model.py services/tool_registry/registry.py services/tool_registry/__init__.py tests/benchmarks/browsecomp_evaluator.py`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68502046e73c832a8678155492bc8d1d