### PR TITLE
Enforce LLM guidance loss in MARL training

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -64,3 +64,14 @@
   acceptance_criteria:
     - Subgraph final state merges into parent scratchpad
     - Parent graph resumes after subgraph completion
+- id: CR-ADR-003-IMPL
+  title: Enforce LLM-Grounded Communication Paradigm in Training Pipeline
+  priority: high
+  steps:
+    - make guidance_loss mandatory in trainers
+    - remove deprecated emergent protocols
+    - add CI check for guidance_loss in configs
+  acceptance_criteria:
+    - trainer raises ConfigurationError if guidance_loss missing
+    - CI fails for configs without guidance_loss
+    - deprecated emergent files removed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,9 @@ repos:
         entry: scripts/check_tool_imports.py
         language: python
         types: [python]
+      - id: guidance-loss-check
+        name: ensure guidance_loss present in training configs
+        entry: scripts/check_guidance_loss.py
+        language: python
+        pass_filenames: false
+        additional_dependencies: [PyYAML]

--- a/configs/training/sample_supervised.json
+++ b/configs/training/sample_supervised.json
@@ -1,0 +1,5 @@
+{
+  "model": "tiny",
+  "learning_rate": 1e-5,
+  "guidance_loss": {"type": "cosine", "weight": 0.2}
+}

--- a/configs/training/sample_supervised.yml
+++ b/configs/training/sample_supervised.yml
@@ -1,0 +1,5 @@
+model: tiny
+learning_rate: 1e-5
+guidance_loss:
+  type: cosine
+  weight: 0.2

--- a/scripts/check_guidance_loss.py
+++ b/scripts/check_guidance_loss.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Fail CI if training configs lack a guidance_loss block."""
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback if PyYAML missing
+    yaml = None
+
+
+def load_config(path: Path):
+    text = path.read_text(encoding="utf-8")
+    if path.suffix in {".yml", ".yaml"}:
+        if yaml is None:
+            raise RuntimeError("PyYAML required for YAML config parsing")
+        return yaml.safe_load(text) or {}
+    if path.suffix == ".json":
+        return json.loads(text or "{}")
+    return {}
+
+
+def main() -> int:
+    base = Path("configs/training")
+    if not base.exists():
+        return 0
+    missing = []
+    for file in base.rglob("*"):
+        if file.suffix not in {".yml", ".yaml", ".json"}:
+            continue
+        data = load_config(file)
+        if "guidance_loss" not in data:
+            missing.append(str(file))
+    if missing:
+        print(
+            "Configuration files missing guidance_loss (see ADR-003):", file=sys.stderr
+        )
+        for path in missing:
+            print(f"  {path}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/learning/__init__.py
+++ b/services/learning/__init__.py
@@ -1,6 +1,25 @@
 """Learning utilities and optimizers."""
 
-from .ppo_policy_optimizer import PPOPolicyOptimizer
-from .rlaif_system import RLAIFSystem
+from importlib import import_module
+from typing import TYPE_CHECKING
 
-__all__ = ["RLAIFSystem", "PPOPolicyOptimizer"]
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from .exceptions import ConfigurationError
+    from .marl_trainer import MARLTrainer
+    from .ppo_policy_optimizer import PPOPolicyOptimizer
+    from .rlaif_system import RLAIFSystem
+
+
+def __getattr__(name: str):
+    if name == "PPOPolicyOptimizer":
+        return import_module(".ppo_policy_optimizer", __name__).PPOPolicyOptimizer
+    if name == "RLAIFSystem":
+        return import_module(".rlaif_system", __name__).RLAIFSystem
+    if name == "MARLTrainer":
+        return import_module(".marl_trainer", __name__).MARLTrainer
+    if name == "ConfigurationError":
+        return import_module(".exceptions", __name__).ConfigurationError
+    raise AttributeError(name)
+
+
+__all__ = ["RLAIFSystem", "PPOPolicyOptimizer", "MARLTrainer", "ConfigurationError"]

--- a/services/learning/exceptions.py
+++ b/services/learning/exceptions.py
@@ -1,0 +1,2 @@
+class ConfigurationError(Exception):
+    """Raised when a training configuration is invalid."""

--- a/services/learning/marl_trainer.py
+++ b/services/learning/marl_trainer.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .exceptions import ConfigurationError
+
+
+class MARLTrainer:
+    """Simplified multi-agent training loop."""
+
+    def __init__(self, config: Dict) -> None:
+        if "guidance_loss" not in config:
+            raise ConfigurationError(
+                "guidance_loss block required by ADR-003 for LLM-grounded training"
+            )
+        self.config = config
+        self.guidance_loss_cfg = config["guidance_loss"]
+
+    def train(self) -> None:  # pragma: no cover - placeholder
+        """Run a single training step (stub)."""
+        pass

--- a/tests/test_marl_trainer.py
+++ b/tests/test_marl_trainer.py
@@ -1,0 +1,13 @@
+import pytest
+
+from services.learning.exceptions import ConfigurationError
+from services.learning.marl_trainer import MARLTrainer
+
+
+def test_marl_trainer_requires_guidance_loss():
+    with pytest.raises(ConfigurationError):
+        MARLTrainer({})
+
+    cfg = {"guidance_loss": {"type": "cosine", "weight": 0.5}}
+    trainer = MARLTrainer(cfg)
+    assert trainer.guidance_loss_cfg["type"] == "cosine"


### PR DESCRIPTION
## Summary
- require guidance_loss block when instantiating a MARLTrainer
- add ConfigurationError exception type
- create config samples under `configs/training`
- implement CI hook to verify training configs include guidance_loss
- update pre-commit configuration
- queue CR-ADR-003-IMPL task
- basic unit test for MARLTrainer

## Testing
- `pre-commit run --files services/learning/__init__.py tests/test_marl_trainer.py scripts/check_guidance_loss.py .pre-commit-config.yaml services/learning/marl_trainer.py services/learning/exceptions.py configs/training/sample_supervised.yml configs/training/sample_supervised.json .codex/queue.yml`
- `pytest tests/test_marl_trainer.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: transformers, jsonschema, googletrans, trafilatura, opentelemetry, fastapi, tenacity, datasets)*

------
https://chatgpt.com/codex/tasks/task_e_6850299916bc832abce18dcc7407af9c