### PR TITLE
Implement LLM guidance loss

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -75,3 +75,10 @@
     - trainer raises ConfigurationError if guidance_loss missing
     - CI fails for configs without guidance_loss
     - deprecated emergent files removed
+- id: CR-02
+  title: Detailed Implementation of the LLM-Based Auxiliary Guidance Loss
+  priority: high
+  steps: []
+  acceptance_criteria:
+    - dataset generation pipeline outputs at least 1000 mappings
+    - training logs show policy_loss and guidance_loss at each step

--- a/pipelines/langground_dataset/__init__.py
+++ b/pipelines/langground_dataset/__init__.py
@@ -1,0 +1,3 @@
+from .pipeline import CommunicationDatasetPipeline
+
+__all__ = ["CommunicationDatasetPipeline"]

--- a/pipelines/langground_dataset/pipeline.py
+++ b/pipelines/langground_dataset/pipeline.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Tuple
+
+
+class CommunicationDatasetPipeline:
+    """Generate (observation, action) -> natural language message pairs."""
+
+    def __init__(
+        self, llm: Callable[[str], str], out_dir: str | Path = "data/comms_dataset"
+    ) -> None:
+        self.llm = llm
+        self.out_dir = Path(out_dir)
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+
+    def _build_prompt(self, obs: str, act: str) -> str:
+        return f"Observation: {obs}\nAction: {act}\nDescribe this state in natural language."
+
+    def generate_record(self, obs: str, act: str) -> Dict[str, str]:
+        prompt = self._build_prompt(obs, act)
+        message = self.llm(prompt)
+        return {"observation": obs, "action": act, "message": str(message)}
+
+    def run(
+        self, pairs: Iterable[Tuple[str, str]], out_file: str | Path | None = None
+    ) -> List[Dict[str, str]]:
+        records = [self.generate_record(o, a) for o, a in pairs]
+        if out_file:
+            Path(out_file).write_text(json.dumps(records, indent=2), encoding="utf-8")
+        return records

--- a/scripts/generate_comms_dataset.py
+++ b/scripts/generate_comms_dataset.py
@@ -1,0 +1,32 @@
+"""Script to generate a synthetic communication dataset using an LLM."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import openai
+
+from pipelines.langground_dataset import CommunicationDatasetPipeline
+
+
+def openai_llm(prompt: str) -> str:
+    response = openai.ChatCompletion.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message["content"]
+
+
+def main() -> None:
+    pairs_path = Path("data/observation_action_pairs.json")
+    pairs = json.loads(pairs_path.read_text(encoding="utf-8"))
+    pipeline = CommunicationDatasetPipeline(openai_llm)
+    records = pipeline.run([(p["observation"], p["action"]) for p in pairs])
+    out_file = Path("data/comms_dataset/generated.json")
+    out_file.write_text(json.dumps(records, indent=2), encoding="utf-8")
+    print(f"Wrote {len(records)} records to {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/learning/marl_trainer.py
+++ b/services/learning/marl_trainer.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from typing import Dict
+import logging
+import math
+from typing import Dict, Iterable, List, Tuple
+
+from services.ltm_service import SimpleEmbeddingClient
 
 from .exceptions import ConfigurationError
 
@@ -8,14 +12,41 @@ from .exceptions import ConfigurationError
 class MARLTrainer:
     """Simplified multi-agent training loop."""
 
-    def __init__(self, config: Dict) -> None:
+    def __init__(
+        self, config: Dict, dataset: Dict[Tuple[str, str], str] | None = None
+    ) -> None:
         if "guidance_loss" not in config:
             raise ConfigurationError(
                 "guidance_loss block required by ADR-003 for LLM-grounded training"
             )
         self.config = config
         self.guidance_loss_cfg = config["guidance_loss"]
+        self.dataset = dataset or {}
+        self.embedder = SimpleEmbeddingClient()
+        self.logger = logging.getLogger(__name__)
 
-    def train(self) -> None:  # pragma: no cover - placeholder
-        """Run a single training step (stub)."""
-        pass
+    @staticmethod
+    def _cosine(a: List[float], b: List[float]) -> float:
+        dot = sum(x * y for x, y in zip(a, b))
+        na = math.sqrt(sum(x * x for x in a))
+        nb = math.sqrt(sum(x * x for x in b))
+        return dot / (na * nb) if na and nb else 0.0
+
+    def train(self, batch: Iterable[Dict]) -> None:
+        """Run a toy training loop computing guidance loss."""
+        weight = float(self.guidance_loss_cfg.get("weight", 1.0))
+        for item in batch:
+            obs = item.get("observation", "")
+            act = item.get("action", "")
+            msg_vec: List[float] = item.get("message_vec", [])
+            policy_loss = float(item.get("policy_loss", 0.0))
+            ref_text = self.dataset.get((obs, act), "")
+            ref_vec = (
+                self.embedder.embed([ref_text])[0] if ref_text else [0.0] * len(msg_vec)
+            )
+            guidance_loss = 1.0 - self._cosine(msg_vec, ref_vec)
+            total = policy_loss + weight * guidance_loss
+            self.logger.info(
+                "policy_loss=%s guidance_loss=%s", policy_loss, guidance_loss
+            )
+            item["total_loss"] = total

--- a/tests/test_comm_dataset_pipeline.py
+++ b/tests/test_comm_dataset_pipeline.py
@@ -1,0 +1,16 @@
+import json
+
+from pipelines.langground_dataset import CommunicationDatasetPipeline
+
+
+def test_dataset_generation(tmp_path):
+    def fake_llm(prompt: str) -> str:
+        return "message"
+
+    pairs = [(f"obs{i}", f"act{i}") for i in range(1000)]
+    out_file = tmp_path / "data.json"
+    pipeline = CommunicationDatasetPipeline(fake_llm, out_dir=tmp_path)
+    records = pipeline.run(pairs, out_file)
+    assert len(records) >= 1000
+    saved = json.loads(out_file.read_text())
+    assert len(saved) == len(records)

--- a/tests/test_marl_trainer_guidance_logging.py
+++ b/tests/test_marl_trainer_guidance_logging.py
@@ -1,0 +1,23 @@
+import logging
+
+from services.learning.marl_trainer import MARLTrainer
+
+
+def test_guidance_loss_logging(caplog):
+    cfg = {"guidance_loss": {"type": "cosine", "weight": 0.5}}
+    dataset = {("obs", "act"): "hello"}
+    trainer = MARLTrainer(cfg, dataset)
+    batch = [
+        {
+            "observation": "obs",
+            "action": "act",
+            "message_vec": [0.1, 0.2],
+            "policy_loss": 0.3,
+        }
+    ]
+    with caplog.at_level(logging.INFO):
+        trainer.train(batch)
+    assert any(
+        "policy_loss" in r.message and "guidance_loss" in r.message
+        for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- add LangGround dataset generation pipeline
- integrate guidance loss in MARLTrainer
- provide script to generate the dataset
- update codex queue with CR-02
- test dataset generation and logging

## Testing
- `pre-commit run --files pipelines/langground_dataset/pipeline.py tests/test_comm_dataset_pipeline.py tests/test_marl_trainer_guidance_logging.py`
- `pytest tests/test_comm_dataset_pipeline.py tests/test_marl_trainer_guidance_logging.py tests/test_marl_trainer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68502c4b8c3c832a82e12c49d6e289c6