### PR TITLE
Add future development note for economy research

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,3 +5,7 @@ This site contains design docs, research papers, and project reports for the Age
 ## Guides
 
 - [Semantic Memory with Neo4j](semantic_memory_neo4j.md)
+
+## Research
+
+- [An Internal Economy for Computational Resource Allocation in Multi-Agent Systems](research/2025-computational-economy-for-multi-agents.md) - *future development*

--- a/docs/research/2025-computational-economy-for-multi-agents.md
+++ b/docs/research/2025-computational-economy-for-multi-agents.md
@@ -1,6 +1,9 @@
 
 # **An Internal Economy for Computational Resource Allocation in Multi-Agent Systems**
 
+> **Status:** Proposed for future development. This document outlines a potential
+> architecture for resource allocation using an internal economy.
+
 ## **Part I: Foundations of Computational Economies in Multi-Agent Systems**
 
 The development of sophisticated multi-agent systems (MAS), particularly those powered by Large Language Models (LLMs), presents a paradigm shift in automated problem-solving. However, this power comes at a significant computational cost, a challenge that necessitates a move beyond static cost-mitigation techniques toward dynamic, intelligent resource management. This report outlines a comprehensive framework for implementing an internal "economy" for computational resource allocation within a multi-agent research system. By modeling the system as a micro-economy, where agents are economic actors, computational resources are goods, and tasks are market opportunities, we can introduce powerful levers for controlling operational costs and formally navigating the trade-off between expenditure and the quality of research outcomes.


### PR DESCRIPTION
## Summary
- mark computational economy research as proposed future development
- list the research paper in the docs index

## Testing
- `pre-commit run --files docs/index.md docs/research/2025-computational-economy-for-multi-agents.md`
- `pytest -q` *(failed: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_685034ab7d08832a8fcb5c40579cc7e5