### PR TITLE
Add protocol evaluation metrics

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -124,3 +124,11 @@
   acceptance_criteria:
     - dataset generation pipeline outputs at least 1000 mappings
     - training logs show policy_loss and guidance_loss at each step
+- id: CR-03
+  title: Enhancement of the Evaluation Framework to Include ZSC, CIC, and Interpretability Metrics
+  priority: medium
+  steps: []
+  acceptance_criteria:
+    - Given two agents from separate runs
+    - When the evaluation pipeline runs
+    - Then the report includes ZSC, CIC, and Interpretability scores

--- a/docs/pipelines/protocol_eval.md
+++ b/docs/pipelines/protocol_eval.md
@@ -1,0 +1,10 @@
+# Protocol Evaluation Pipeline
+
+This pipeline measures the quality of emergent communication.
+It exposes helper functions to compute:
+
+- **Zero-Shot Coordination (ZSC) Score** – average reward when agents from independent runs are paired together.
+- **Causal Influence of Communication (CIC)** – mutual information between a sent message and the receiver's next action.
+- **Interpretability Score** – cosine similarity between message vectors and their target natural language concepts.
+
+The metrics can be imported from `services.evaluation` and composed into more complex evaluation suites.

--- a/services/evaluation/__init__.py
+++ b/services/evaluation/__init__.py
@@ -1,0 +1,3 @@
+from .comm_metrics import compute_cic, compute_interpretability, compute_zsc_score
+
+__all__ = ["compute_zsc_score", "compute_cic", "compute_interpretability"]

--- a/services/evaluation/comm_metrics.py
+++ b/services/evaluation/comm_metrics.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Iterable, Sequence
+
+from services.ltm_service import SimpleEmbeddingClient
+
+
+def compute_zsc_score(rewards: Sequence[float]) -> float:
+    """Return mean reward over evaluation episodes."""
+    return sum(rewards) / len(rewards) if rewards else 0.0
+
+
+def compute_cic(messages: Sequence[str], actions: Sequence[str]) -> float:
+    """Compute mutual information between messages and subsequent actions."""
+    if len(messages) != len(actions):
+        raise ValueError("messages and actions must be same length")
+    n = len(messages)
+    if n == 0:
+        return 0.0
+
+    joint = Counter(zip(messages, actions))
+    msg_counts = Counter(messages)
+    act_counts = Counter(actions)
+
+    mi = 0.0
+    for (m, a), count in joint.items():
+        p_joint = count / n
+        p_m = msg_counts[m] / n
+        p_a = act_counts[a] / n
+        mi += p_joint * math.log(p_joint / (p_m * p_a + 1e-12) + 1e-12)
+    return mi
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(x * x for x in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def compute_interpretability(
+    message_vectors: Sequence[Sequence[float]],
+    concept_texts: Sequence[str],
+    embedder: SimpleEmbeddingClient | None = None,
+) -> float:
+    """Compute average cosine similarity between messages and concept embeddings."""
+    if len(message_vectors) != len(concept_texts):
+        raise ValueError("message_vectors and concept_texts must be same length")
+    if not message_vectors:
+        return 0.0
+    embedder = embedder or SimpleEmbeddingClient()
+    concept_vectors = embedder.embed(list(concept_texts))
+    sims = [_cosine(m, c) for m, c in zip(message_vectors, concept_vectors)]
+    return sum(sims) / len(sims)

--- a/tests/test_comm_metrics.py
+++ b/tests/test_comm_metrics.py
@@ -1,0 +1,29 @@
+import pytest
+
+from services.evaluation import (
+    compute_zsc_score,
+    compute_cic,
+    compute_interpretability,
+)
+from services.ltm_service import SimpleEmbeddingClient
+
+
+def test_compute_zsc_score():
+    assert compute_zsc_score([1.0, 2.0, 3.0]) == 2.0
+    assert compute_zsc_score([]) == 0.0
+
+
+def test_compute_cic():
+    msgs = ["a", "a", "b", "b"]
+    acts = ["a", "a", "b", "b"]
+    val = compute_cic(msgs, acts)
+    assert val == pytest.approx(0.6931, rel=1e-3)
+    assert compute_cic([], []) == 0.0
+
+
+def test_compute_interpretability():
+    embedder = SimpleEmbeddingClient()
+    concepts = ["hi", "bye"]
+    vecs = embedder.embed(concepts)
+    score = compute_interpretability(vecs, concepts, embedder)
+    assert score == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- implement Zero-Shot Coordination, CIC and Interpretability metrics
- document new protocol evaluation pipeline
- add tests for metrics
- track new CR-03 in codex queue

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_comm_metrics.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: opentelemetry)*

------
https://chatgpt.com/codex/tasks/task_e_685035e607b4832aa3f893d0615d20c5