### PR TITLE
Implement Codex Notary ID fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,9 @@ Each agent resides in a folder under `agents/`. Every folder contains:
 - The file `.codex/queue.yml` must reflect the latest open change requests.
 - Run `python scripts/sync_codex_tasks.py` to compare open issues with queued tasks.
 - Address any reported discrepancies before committing.
+
+## Codex Issue Workflows
+- The `Codex Notary` workflow opens GitHub issues for new entries in `.codex/queue.yml`.
+- The `Codex Archivist` workflow posts agent logs to the issue once it is closed.
+- Both workflows expect `issue_logger.create_issue` to return `{url, number}` and
+  rely on the stored `issue_id` for traceability.

--- a/scripts/codex_archivist.py
+++ b/scripts/codex_archivist.py
@@ -1,0 +1,23 @@
+import argparse
+
+from scripts import issue_logger
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Post worklog to closed issue")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--issue", type=int, required=True)
+    parser.add_argument("--worklog", required=True)
+    args = parser.parse_args(argv)
+
+    issue_url = f"{issue_logger.GITHUB_API}/repos/{args.repo}/issues/{args.issue}"
+    data = issue_logger._load_worklog(args.worklog)
+    url = issue_logger.post_worklog_comment(issue_url, data)
+    if not url:
+        return 1
+    print(f"Posted worklog to {url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/codex_task_runner.py
+++ b/scripts/codex_task_runner.py
@@ -103,9 +103,9 @@ def main():
                     + yaml.safe_dump(task)
                 )
                 repo = task.get("repo", "")
-                url = create_issue(task["title"], body, repo, task.get("labels", []))
-                if url:
-                    print(f"Created issue for {task['id']}: {url}")
+                result = create_issue(task["title"], body, repo, task.get("labels", []))
+                if result:
+                    print(f"Created issue for {task['id']}: {result['url']}")
 
 
 if __name__ == "__main__":

--- a/scripts/issue_logger.py
+++ b/scripts/issue_logger.py
@@ -86,11 +86,11 @@ def _store_pending_worklog(target: str, data: dict) -> None:
 
 def create_issue(
     title: str, body: str, repo: str, labels: List[str] | None = None
-) -> str:
-    """Create a GitHub issue and return its URL."""
+) -> dict | None:
+    """Create a GitHub issue and return its metadata."""
     token = _get_token()
     if not token:
-        return ""
+        return None
 
     url = f"{GITHUB_API}/repos/{repo}/issues"
     headers = {"Authorization": f"token {token}"}
@@ -99,11 +99,12 @@ def create_issue(
         payload["labels"] = labels
     resp = _request_with_retry("post", url, headers=headers, json=payload)
     if not resp:
-        return ""
+        return None
     if resp.status_code >= 300:
         print(f"GitHub API error {resp.status_code}: {resp.text}", file=sys.stderr)
-        return ""
-    return resp.json().get("html_url", "")
+        return None
+    data = resp.json()
+    return {"url": data.get("html_url", ""), "number": data.get("number")}
 
 
 def post_comment(issue_url: str, body: str) -> str:

--- a/tests/test_codex_archivist.py
+++ b/tests/test_codex_archivist.py
@@ -1,0 +1,27 @@
+import json
+from unittest import mock
+
+from scripts import codex_archivist
+
+
+def test_archivist_posts_worklog(tmp_path):
+    wl = tmp_path / "wl.json"
+    wl.write_text(json.dumps({"task_name": "t"}))
+
+    called = {}
+
+    def fake_post(url, data):
+        called["url"] = url
+        called["data"] = data
+        return "http://example.com/c1"
+
+    with mock.patch.object(
+        codex_archivist.issue_logger, "post_worklog_comment", fake_post
+    ):
+        exitcode = codex_archivist.main(
+            ["--repo", "u/r", "--issue", "42", "--worklog", str(wl)]
+        )
+
+    assert exitcode == 0
+    assert called["url"].endswith("/repos/u/r/issues/42")
+    assert called["data"]["task_name"] == "t"

--- a/tests/test_codex_notary.py
+++ b/tests/test_codex_notary.py
@@ -18,7 +18,7 @@ def test_create_issue_updates_queue(tmp_path):
     def fake_create_issue(title, body, repo, labels=None):
         called["title"] = title
         called["labels"] = labels
-        return "https://api.github.com/repos/u/r/issues/42"
+        return {"url": "https://api.github.com/repos/u/r/issues/42", "number": 42}
 
     with mock.patch.dict(
         os.environ, {"GITHUB_REPOSITORY": "u/r", "GITHUB_TOKEN": "t"}


### PR DESCRIPTION
## Summary
- return GitHub issue number and url when creating issues
- store numeric issue IDs directly in codex queue
- add Codex Archivist helper for posting worklogs
- update Codex scripts to use new return type
- document Codex issue workflows
- test notary, issue logger and archivist flows

## Testing
- `pre-commit run --files scripts/issue_logger.py scripts/codex_notary.py scripts/codex_archivist.py scripts/codex_task_runner.py tests/test_codex_issue_logger.py tests/test_codex_notary.py tests/test_codex_archivist.py AGENTS.md`
- `pytest tests/test_codex_issue_logger.py tests/test_codex_notary.py tests/test_codex_archivist.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685031af6d90832aa4026b7d4a6b7d0a