### PR TITLE
Implement intent-based authorization layer

### DIFF
--- a/services/authz/__init__.py
+++ b/services/authz/__init__.py
@@ -1,0 +1,12 @@
+"""Intent-based authorization utilities."""
+
+from importlib import import_module
+
+
+def __getattr__(name: str):
+    if name in {"IntentAuthorizer", "IntentAuthZServer"}:
+        return getattr(import_module(".intent_authorizer", __name__), name)
+    raise AttributeError(name)
+
+
+__all__ = ["IntentAuthorizer", "IntentAuthZServer"]

--- a/services/authz/intent_authorizer.py
+++ b/services/authz/intent_authorizer.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""Intent-based authorization middleware."""
+
+import json
+import logging
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Dict, Iterable
+from urllib.parse import urlparse
+
+import yaml
+
+from services.tool_registry import AccessDeniedError, ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class IntentAuthorizer:
+    """Validate that a tool is allowed for a given intent."""
+
+    def __init__(self, policy: Dict[str, Iterable[str]] | None = None) -> None:
+        self.policy: Dict[str, set[str]] = {
+            k: set(v) for k, v in (policy or {}).items()
+        }
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "IntentAuthorizer":
+        data = yaml.safe_load(open(path)) or {}
+        return cls(data.get("intents", {}))
+
+    def allowed(self, intent: str, tool: str) -> bool:
+        allowed_tools = self.policy.get(intent, set())
+        return tool in allowed_tools
+
+
+class IntentAuthZServer:
+    """HTTP sidecar enforcing intent-based authorization."""
+
+    def __init__(
+        self,
+        registry: ToolRegistry,
+        authorizer: IntentAuthorizer,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 8002,
+    ) -> None:
+        self.registry = registry
+        self.authorizer = authorizer
+        self.httpd = HTTPServer((host, port), self._handler())
+
+    def _handler(self):
+        registry = self.registry
+        authorizer = self.authorizer
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, format: str, *args) -> None:  # pragma: no cover
+                return
+
+            def do_POST(self) -> None:
+                parsed = urlparse(self.path)
+                if parsed.path != "/invoke":
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                length = int(self.headers.get("Content-Length", 0))
+                data = self.rfile.read(length)
+                try:
+                    payload = json.loads(data) if data else {}
+                except json.JSONDecodeError:
+                    payload = {}
+                role = payload.get("agent", "")
+                intent = payload.get("intent", "")
+                tool = payload.get("tool", "")
+                args = payload.get("args", [])
+                kwargs = payload.get("kwargs", {})
+
+                if not authorizer.allowed(intent, tool):
+                    logger.warning(
+                        "ToolInvocationViolation(%s, %s, %s)", role, intent, tool
+                    )
+                    self.send_response(403)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error": "forbidden"}).encode())
+                    return
+                try:
+                    result = registry.invoke(role, tool, *args, **kwargs)
+                except AccessDeniedError as exc:
+                    self.send_response(403)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error": str(exc)}).encode())
+                    return
+                except KeyError as exc:
+                    self.send_response(404)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error": str(exc)}).encode())
+                    return
+
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(json.dumps({"result": result}).encode())
+
+        return Handler
+
+    def serve_forever(self) -> None:  # pragma: no cover - manual run
+        self.httpd.serve_forever()

--- a/services/authz/policy.yml
+++ b/services/authz/policy.yml
@@ -1,0 +1,5 @@
+intents:
+  generate_report:
+    - retrieve_memory
+  modify_users:
+    - modify_user

--- a/tests/test_intent_authz.py
+++ b/tests/test_intent_authz.py
@@ -1,0 +1,42 @@
+import logging
+from threading import Thread
+
+import requests
+
+from services.authz import IntentAuthorizer, IntentAuthZServer
+from services.tool_registry import ToolRegistry
+
+
+def dummy_tool():
+    return "ok"
+
+
+def _start_server(policy):
+    registry = ToolRegistry()
+    registry.register_tool("modify_user", dummy_tool, allowed_roles=["Admin"])
+    authorizer = IntentAuthorizer(policy)
+    server = IntentAuthZServer(registry, authorizer, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.httpd.server_port}"
+    return server, thread, endpoint
+
+
+def test_deny_out_of_intent_tool_call(caplog):
+    policy = {"intents": {"generate_report": ["retrieve_memory"]}}
+    server, thread, endpoint = _start_server(policy)
+    try:
+        caplog.set_level(logging.WARNING)
+        resp = requests.post(
+            f"{endpoint}/invoke",
+            json={
+                "agent": "Admin",
+                "intent": "generate_report",
+                "tool": "modify_user",
+            },
+        )
+        assert resp.status_code == 403
+        assert any("ToolInvocationViolation" in rec.message for rec in caplog.records)
+    finally:
+        server.httpd.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- add intent-based authorization middleware and HTTP sidecar
- provide a default policy mapping intents to allowed tools
- verify denial of out-of-intent tool calls

## Testing
- `pre-commit run --files services/authz/__init__.py services/authz/intent_authorizer.py services/authz/policy.yml tests/test_intent_authz.py`
- `pytest -q` *(fails: FileNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68504229b044832a84945dc6681c4039