### PR TITLE
Implement audit logging for ToolRegistry

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -132,3 +132,11 @@
     - Given two agents from separate runs
     - When the evaluation pipeline runs
     - Then the report includes ZSC, CIC, and Interpretability scores
+- id: CR-05c
+  title: Enable Continuous Monitoring & Auditing
+  priority: medium
+  steps: []
+  acceptance_criteria:
+    - Given an agent issues any tool call
+    - When the call completes or is blocked
+    - Then a log entry is emitted with timestamp, agent_id, action, intent, and outcome

--- a/codex_tasks.md
+++ b/codex_tasks.md
@@ -1359,3 +1359,14 @@ acceptance_criteria:
   - docs/change-requests.md notes consolidation date
   - Issue link is recorded here
 ```
+
+```codex-task
+id: CR-05c
+title: Enable Continuous Monitoring & Auditing
+priority: medium
+steps: []
+acceptance_criteria:
+  - Given an agent issues any tool call
+  - When the call completes or is blocked
+  - Then a log entry is emitted with timestamp, agent_id, action, intent, and outcome
+```

--- a/docs/change_request_ledger.md
+++ b/docs/change_request_ledger.md
@@ -24,3 +24,4 @@ This ledger tracks open change requests across the project. Each entry lists the
 | CR-004 | Hierarchical Policy Executor | Open |
 | CR-005 | Lifelong skill generalization support | Open |
 | CR-006 | Adopt RLlib and Isaac Lab tooling | Open |
+| CR-05c | Enable Continuous Monitoring & Auditing | Open |

--- a/docs/tracing_schema.md
+++ b/docs/tracing_schema.md
@@ -24,6 +24,8 @@ Earlier traces produced with version 1.0 remain readable via `ToolCallTrace.from
 | `input_tokens`  | Optional token count for the input.  |
 | `output_tokens` | Optional token count for the output. |
 | `latency_ms`    | Latency in milliseconds of the call. |
+| `intent`        | Optional intent associated with the call. |
+| `unauthorized_call` | Boolean flag if access was denied. |
 
 Agents are encouraged to populate token counts and latency whenever possible.
 

--- a/services/tracing/tracing_schema.py
+++ b/services/tracing/tracing_schema.py
@@ -22,6 +22,8 @@ class ToolCallTrace:
     input_tokens: Optional[int] = None
     output_tokens: Optional[int] = None
     latency_ms: Optional[float] = None
+    intent: Optional[str] = None
+    unauthorized_call: Optional[bool] = None
     schema_version: str = SCHEMA_VERSION
 
     def record(self) -> None:
@@ -34,6 +36,8 @@ class ToolCallTrace:
                 "agent_role": self.agent_role,
                 "tool_name": self.tool_name,
                 "tool_input": str(self.tool_input),
+                "intent": self.intent or "",
+                "unauthorized_call": bool(self.unauthorized_call),
             },
         ) as span:
             if self.tool_output is not None:
@@ -61,5 +65,7 @@ class ToolCallTrace:
             input_tokens=attrs.get("input_tokens"),
             output_tokens=attrs.get("output_tokens"),
             latency_ms=attrs.get("latency_ms"),
+            intent=attrs.get("intent"),
+            unauthorized_call=attrs.get("unauthorized_call"),
             schema_version=version,
         )


### PR DESCRIPTION
## Summary
- extend tracing schema to include security fields
- log tool invocation events and unauthorized access
- document new schema attributes
- queue change request CR-05c and document in ledger
- add codex task entry
- test logging of tool invocations

## Testing
- `pre-commit run --files services/tool_registry/__init__.py services/tracing/tracing_schema.py docs/tracing_schema.md .codex/queue.yml docs/change_request_ledger.md codex_tasks.md tests/test_tool_registry.py`
- `pytest -q tests/test_tool_registry.py::test_tool_invocation_audit_logged tests/test_tool_registry.py::test_tool_invocation_audit_blocked`

------
https://chatgpt.com/codex/tasks/task_e_6850422e5138832aab73b7527810f0b7