### PR TITLE
Add CR-05b-04 sandbox stability task

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -157,3 +157,13 @@
     - Given an agent issues any tool call
     - When the call completes or is blocked
     - Then a log entry is emitted with timestamp, agent_id, action, intent, and outcome
+- id: CR-05b-04
+  title: Verify sandbox and optional-suite stability post-migration
+  priority: low
+  steps:
+    - Rerun `test_sandbox.py` under the new core suite to confirm sandbox isolation and timeouts still work.
+    - Execute the 'optional' and 'integration' markers locally and in CI to catch any regressions in slow or optional tests.
+    - Fix any failures (e.g. missing fixtures, new dependency issues, or timeouts).
+  acceptance_criteria:
+    - All @pytest.mark.core tests (including sandbox) pass under the parallel runner.
+    - optional and integration tests continue to pass in their respective CI jobs.

--- a/codex_tasks.md
+++ b/codex_tasks.md
@@ -1383,3 +1383,15 @@ acceptance_criteria:
   - When the call completes or is blocked
   - Then a log entry is emitted with timestamp, agent_id, action, intent, and outcome
 ```
+```codex-task
+id: CR-05b-04
+title: Verify sandbox and optional-suite stability post-migration
+priority: low
+steps:
+  - "Rerun `test_sandbox.py` under the new core suite to confirm sandbox isolation and timeouts still work."
+  - "Execute the 'optional' and 'integration' markers locally and in CI to catch any regressions in slow or optional tests."
+  - "Fix any failures (e.g. missing fixtures, new dependency issues, or timeouts)."
+acceptance_criteria:
+  - "All @pytest.mark.core tests (including sandbox) pass under the parallel runner."
+  - "optional and integration tests continue to pass in their respective CI jobs."
+```


### PR DESCRIPTION
## Summary
- add CR-05b-04 to codex tasks and queue

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `pytest -m optional -q`
- `pytest -m integration -q`


------
https://chatgpt.com/codex/tasks/task_e_6850538af354832a80af390836835010