### PR TITLE
Add core-tests pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,8 @@ repos:
         language: python
         pass_filenames: false
         additional_dependencies: [PyYAML]
+      - id: core-tests
+        name: run core test suite
+        entry: bash scripts/run_core_tests.sh
+        language: system
+        pass_filenames: false

--- a/scripts/run_core_tests.sh
+++ b/scripts/run_core_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the lightweight core test suite and fail fast on first error
+pytest -m "core" --maxfail=1 -vv "$@"


### PR DESCRIPTION
## Summary
- add run_core_tests.sh and mark as executable
- wire up core-tests hook in pre-commit config

## Testing
- `pytest -m core -vv` *(fails: KeyboardInterrupt)*
- `pre-commit run --files scripts/run_core_tests.sh .pre-commit-config.yaml` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6850537333e4832a95ac4052a0cfcc75