### PR TITLE
Implement Reputation Service with persistent store

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -6,6 +6,14 @@
     - forgetting route deletes a record
     - invalid bodies return 422
 
+- id: CR-01
+  title: New Component - Reputation Service & Persistent Data Store
+  priority: high
+  steps: []
+  acceptance_criteria:
+    - FastAPI service stores evaluations in PostgreSQL
+    - Reputation scores aggregate by task type
+
 - id: P3-15
   title: Integrate graph database for Semantic LTM
   priority: high

--- a/constraints.txt
+++ b/constraints.txt
@@ -31,4 +31,6 @@ sentence-transformers==2.6.1
 tenacity==8.2.3
 datasets==3.6.0
 lxml_html_clean==0.4.2
+SQLAlchemy==2.0.29
+asyncpg==0.29.0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,5 +45,30 @@ services:
       - otel-collector
       - weaviate
 
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: example
+      POSTGRES_USER: agent
+      POSTGRES_DB: reputation
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  reputation-service:
+    build: .
+    image: agentic/research-engine:latest
+    command: uvicorn services.reputation.app:app --host 0.0.0.0 --port 8090 --workers ${WORKER_COUNT:-4}
+    environment:
+      DATABASE_URL: postgresql+asyncpg://agent:example@postgres:5432/reputation
+      WORKER_COUNT: ${WORKER_COUNT:-4}
+    ports:
+      - "8090:8090"
+    depends_on:
+      - postgres
+      - otel-collector
+
 volumes:
   weaviate_data:
+  postgres_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,6 @@ tenacity==8.2.3
 datasets==3.6.0
 lxml_html_clean==0.4.2
 trafilatura==2.0.0
+SQLAlchemy==2.0.29
+asyncpg==0.29.0
 

--- a/services/reputation/__init__.py
+++ b/services/reputation/__init__.py
@@ -1,0 +1,5 @@
+"""Reputation service FastAPI app."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/services/reputation/app.py
+++ b/services/reputation/app.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from .models import Base
+from .service import ReputationService
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./reputation.db")
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+Base.metadata.create_all(engine)
+
+service = ReputationService(SessionLocal)
+app = FastAPI(title="Reputation Service")
+
+
+class AgentCreate(BaseModel):
+    agent_type: str
+    model_base: Optional[str] = None
+    status: str = "active"
+
+
+class TaskCreate(BaseModel):
+    task_type: str
+    query_text: Optional[str] = None
+    parent_task_id: Optional[str] = None
+
+
+class AssignmentCreate(BaseModel):
+    task_id: str
+    agent_id: str
+
+
+class EvaluationCreate(BaseModel):
+    assignment_id: str
+    evaluator_id: str
+    performance_vector: Dict[str, Any] = Field(default_factory=dict)
+    is_final: bool = False
+
+
+@app.post("/agents")
+def create_agent(req: AgentCreate) -> Dict[str, str]:
+    agent_id = service.add_agent(req.agent_type, req.model_base, req.status)
+    return {"agent_id": agent_id}
+
+
+@app.post("/tasks")
+def create_task(req: TaskCreate) -> Dict[str, str]:
+    task_id = service.add_task(req.task_type, req.query_text, req.parent_task_id)
+    return {"task_id": task_id}
+
+
+@app.post("/assignments")
+def create_assignment(req: AssignmentCreate) -> Dict[str, str]:
+    assignment_id = service.assign(req.task_id, req.agent_id)
+    return {"assignment_id": assignment_id}
+
+
+@app.post("/evaluations")
+def create_evaluation(req: EvaluationCreate) -> Dict[str, str]:
+    evaluation_id = service.record_evaluation(
+        req.assignment_id,
+        req.evaluator_id,
+        req.performance_vector,
+        is_final=req.is_final,
+    )
+    return {"evaluation_id": evaluation_id}
+
+
+@app.get("/reputation/{agent_id}")
+def get_reputation(agent_id: str, context: Optional[str] = None) -> Dict[str, Any]:
+    rep = service.get_reputation(agent_id, context)
+    return {"reputation": rep}

--- a/services/reputation/main.py
+++ b/services/reputation/main.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import uvicorn
+
+from .app import app
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    uvicorn.run(app, host="0.0.0.0", port=8090)

--- a/services/reputation/models.py
+++ b/services/reputation/models.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class Agent(Base):
+    __tablename__ = "agents"
+
+    agent_id = Column(String, primary_key=True, default=_uuid)
+    agent_type = Column(String, nullable=False)
+    model_base = Column(String, nullable=True)
+    creation_timestamp = Column(DateTime, default=datetime.utcnow)
+    status = Column(String, nullable=False, default="active")
+
+    assignments = relationship("Assignment", back_populates="agent")
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    task_id = Column(String, primary_key=True, default=_uuid)
+    parent_task_id = Column(String, ForeignKey("tasks.task_id"), nullable=True)
+    task_type = Column(String, nullable=False)
+    query_text = Column(Text, nullable=True)
+    creation_timestamp = Column(DateTime, default=datetime.utcnow)
+
+    assignments = relationship("Assignment", back_populates="task")
+
+
+class Assignment(Base):
+    __tablename__ = "assignments"
+
+    assignment_id = Column(String, primary_key=True, default=_uuid)
+    task_id = Column(String, ForeignKey("tasks.task_id"), nullable=False)
+    agent_id = Column(String, ForeignKey("agents.agent_id"), nullable=False)
+    assignment_timestamp = Column(DateTime, default=datetime.utcnow)
+
+    agent = relationship("Agent", back_populates="assignments")
+    task = relationship("Task", back_populates="assignments")
+    evaluations = relationship("Evaluation", back_populates="assignment")
+
+
+class Evaluation(Base):
+    __tablename__ = "evaluations"
+
+    evaluation_id = Column(String, primary_key=True, default=_uuid)
+    assignment_id = Column(
+        String, ForeignKey("assignments.assignment_id"), nullable=False
+    )
+    evaluator_id = Column(String, nullable=False)
+    evaluation_timestamp = Column(DateTime, default=datetime.utcnow)
+    performance_vector = Column(JSON, nullable=False)
+    is_final = Column(Boolean, default=False)
+
+    assignment = relationship("Assignment", back_populates="evaluations")
+
+
+class ReputationScore(Base):
+    __tablename__ = "reputation_scores"
+    __table_args__ = (UniqueConstraint("agent_id", "context", name="uq_agent_context"),)
+
+    id = Column(String, primary_key=True, default=_uuid)
+    agent_id = Column(String, ForeignKey("agents.agent_id"), nullable=False)
+    context = Column(String, nullable=True)
+    reputation_vector = Column(JSON, nullable=False)
+    confidence_score = Column(Float, default=0.0)
+    last_updated_timestamp = Column(DateTime, default=datetime.utcnow)
+
+    agent = relationship("Agent")

--- a/services/reputation/service.py
+++ b/services/reputation/service.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Dict
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .models import Agent, Assignment, Evaluation, ReputationScore, Task
+
+
+class ReputationService:
+    """Manage reputation data and aggregation logic."""
+
+    def __init__(self, session_factory) -> None:
+        self._session_factory = session_factory
+
+    def add_agent(
+        self, agent_type: str, model_base: str | None = None, status: str = "active"
+    ) -> str:
+        with self._session_factory() as session:
+            agent = Agent(agent_type=agent_type, model_base=model_base, status=status)
+            session.add(agent)
+            session.commit()
+            return agent.agent_id
+
+    def add_task(
+        self,
+        task_type: str,
+        query_text: str | None = None,
+        parent_task_id: str | None = None,
+    ) -> str:
+        with self._session_factory() as session:
+            task = Task(
+                task_type=task_type,
+                query_text=query_text,
+                parent_task_id=parent_task_id,
+            )
+            session.add(task)
+            session.commit()
+            return task.task_id
+
+    def assign(self, task_id: str, agent_id: str) -> str:
+        with self._session_factory() as session:
+            assignment = Assignment(task_id=task_id, agent_id=agent_id)
+            session.add(assignment)
+            session.commit()
+            return assignment.assignment_id
+
+    def record_evaluation(
+        self,
+        assignment_id: str,
+        evaluator_id: str,
+        performance_vector: Dict[str, Any],
+        *,
+        is_final: bool = False,
+    ) -> str:
+        with self._session_factory() as session:
+            evaluation = Evaluation(
+                assignment_id=assignment_id,
+                evaluator_id=evaluator_id,
+                performance_vector=performance_vector,
+                is_final=is_final,
+            )
+            session.add(evaluation)
+            session.commit()
+            # Update reputation cache
+            assignment = session.get(Assignment, assignment_id)
+            if assignment is None:
+                return evaluation.evaluation_id
+            task = session.get(Task, assignment.task_id)
+            context = task.task_type if task else None
+            self._update_reputation(session, assignment.agent_id, context)
+            session.commit()
+            return evaluation.evaluation_id
+
+    def _update_reputation(
+        self, session: Session, agent_id: str, context: str | None
+    ) -> None:
+        stmt = (
+            select(Evaluation.performance_vector)
+            .join(Assignment, Evaluation.assignment_id == Assignment.assignment_id)
+            .join(Task, Assignment.task_id == Task.task_id)
+            .where(Assignment.agent_id == agent_id)
+        )
+        if context:
+            stmt = stmt.where(Task.task_type == context)
+        rows = session.execute(stmt).all()
+        if not rows:
+            return
+        totals: defaultdict[str, float] = defaultdict(float)
+        for row in rows:
+            vec = row[0] or {}
+            for k, v in vec.items():
+                totals[k] += float(v)
+        count = len(rows)
+        avg = {k: v / count for k, v in totals.items()}
+        rep = session.execute(
+            select(ReputationScore).where(
+                ReputationScore.agent_id == agent_id, ReputationScore.context == context
+            )
+        ).scalar_one_or_none()
+        if rep is None:
+            rep = ReputationScore(
+                agent_id=agent_id,
+                context=context,
+                reputation_vector=avg,
+                confidence_score=float(count),
+            )
+            session.add(rep)
+        else:
+            rep.reputation_vector = avg
+            rep.confidence_score = float(count)
+        session.flush()
+
+    def get_reputation(
+        self, agent_id: str, context: str | None = None
+    ) -> Dict[str, Any] | None:
+        with self._session_factory() as session:
+            rep = session.execute(
+                select(ReputationScore).where(
+                    ReputationScore.agent_id == agent_id,
+                    ReputationScore.context == context,
+                )
+            ).scalar_one_or_none()
+            return rep.reputation_vector if rep else None

--- a/tests/test_reputation_service.py
+++ b/tests/test_reputation_service.py
@@ -1,0 +1,24 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.reputation.models import Base
+from services.reputation.service import ReputationService
+
+
+def setup_service():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return ReputationService(Session)
+
+
+def test_reputation_aggregation():
+    service = setup_service()
+    agent_id = service.add_agent("WebResearcher")
+    task_id = service.add_task("research", "Find info")
+    assign_id = service.assign(task_id, agent_id)
+    service.record_evaluation(assign_id, "Eval1", {"accuracy": 0.8})
+    service.record_evaluation(assign_id, "Eval1", {"accuracy": 0.6})
+
+    rep = service.get_reputation(agent_id, "research")
+    assert rep == {"accuracy": 0.7}


### PR DESCRIPTION
## Summary
- add microservice `services.reputation` with models and service logic
- wire up Postgres and service in `docker-compose.yml`
- pin SQLAlchemy/asyncpg dependencies
- document new change request in `.codex/queue.yml`
- include basic unit test for reputation aggregation

## Testing
- `pytest tests/test_reputation_service.py -q`
- `python scripts/sync_codex_tasks.py` *(fails: GITHUB_REPOSITORY not set)*
- `pre-commit run --files requirements.txt constraints.txt docker-compose.yml services/reputation/__init__.py services/reputation/models.py services/reputation/service.py services/reputation/app.py services/reputation/main.py tests/test_reputation_service.py .codex/queue.yml` *(fails: run core test suite interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68506aab2134832aa9ed1a2fd585db87