### PR TITLE
Implement versioned reputation service API

### DIFF
--- a/services/reputation/app.py
+++ b/services/reputation/app.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
-from fastapi import FastAPI
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -17,7 +17,47 @@ SessionLocal = sessionmaker(bind=engine)
 Base.metadata.create_all(engine)
 
 service = ReputationService(SessionLocal)
-app = FastAPI(title="Reputation Service")
+app = FastAPI(title="Reputation Service", version="1.0.0")
+
+
+def _parse_api_keys(raw: str) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    for pair in raw.split(","):
+        if not pair:
+            continue
+        role, token = pair.split(":", 1)
+        mapping[token.strip()] = role.strip()
+    return mapping
+
+
+API_KEYS = _parse_api_keys(
+    os.getenv(
+        "REPUTATION_API_KEYS",
+        "evaluator:evaluator-token,planner:planner-token,admin:admin-token",
+    )
+)
+
+
+def get_role(authorization: str = Header(...)) -> str:
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="unauthorized")
+    token = authorization.split()[1]
+    role = API_KEYS.get(token)
+    if not role:
+        raise HTTPException(status_code=401, detail="unauthorized")
+    return role
+
+
+def require_role(allowed: List[str]):
+    def _inner(role: str = Depends(get_role)) -> str:
+        if role not in allowed:
+            raise HTTPException(status_code=403, detail="forbidden")
+        return role
+
+    return _inner
+
+
+router = APIRouter(prefix="/v1")
 
 
 class AgentCreate(BaseModel):
@@ -77,3 +117,61 @@ def create_evaluation(req: EvaluationCreate) -> Dict[str, str]:
 def get_reputation(agent_id: str, context: Optional[str] = None) -> Dict[str, Any]:
     rep = service.get_reputation(agent_id, context)
     return {"reputation": rep}
+
+
+@router.post(
+    "/evaluations",
+    status_code=201,
+    dependencies=[Depends(require_role(["evaluator"]))],
+)
+def create_evaluation_v1(req: EvaluationCreate) -> Dict[str, str]:
+    evaluation_id = service.record_evaluation(
+        req.assignment_id,
+        req.evaluator_id,
+        req.performance_vector,
+        is_final=req.is_final,
+    )
+    return {"evaluation_id": evaluation_id}
+
+
+@router.get(
+    "/reputation/{agent_id}",
+    dependencies=[Depends(require_role(["planner", "admin"]))],
+)
+def get_reputation_v1(agent_id: str, context: Optional[str] = None) -> Dict[str, Any]:
+    rep = service.get_reputation_record(agent_id, context)
+    if not rep:
+        raise HTTPException(status_code=404, detail="not found")
+    return rep
+
+
+@router.get(
+    "/reputation/query",
+    dependencies=[Depends(require_role(["planner", "admin"]))],
+)
+def query_reputation_v1(
+    context: Optional[str] = Query(None),
+    top_n: int = Query(10, ge=1, le=100),
+    sort_by: Optional[str] = Query(None),
+    offset: int = Query(0, ge=0),
+) -> Dict[str, Any]:
+    results = service.query_reputations(
+        context, top_n=top_n, sort_by=sort_by, offset=offset
+    )
+    return {"results": results, "offset": offset, "limit": top_n}
+
+
+@router.get(
+    "/agents/{agent_id}/history",
+    dependencies=[Depends(require_role(["admin"]))],
+)
+def get_history_v1(
+    agent_id: str,
+    offset: int = Query(0, ge=0),
+    limit: int = Query(20, ge=1, le=100),
+) -> Dict[str, Any]:
+    records = service.get_history(agent_id, offset=offset, limit=limit)
+    return {"results": records, "offset": offset, "limit": limit}
+
+
+app.include_router(router, prefix="/api")

--- a/tests/test_reputation_api.py
+++ b/tests/test_reputation_api.py
@@ -1,0 +1,42 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.reputation.models import Base
+from services.reputation.service import ReputationService
+
+pytestmark = pytest.mark.core
+
+
+def setup_service():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return ReputationService(Session)
+
+
+def test_query_reputation_sorting():
+    service = setup_service()
+    a1 = service.add_agent("worker")
+    a2 = service.add_agent("worker")
+    task = service.add_task("research")
+    assign1 = service.assign(task, a1)
+    assign2 = service.assign(task, a2)
+    service.record_evaluation(assign1, "eval", {"accuracy": 0.5})
+    service.record_evaluation(assign2, "eval", {"accuracy": 0.9})
+
+    results = service.query_reputations("research", top_n=2, sort_by="accuracy")
+    assert results[0]["agent_id"] == a2
+    assert results[1]["agent_id"] == a1
+
+
+def test_get_history_pagination():
+    service = setup_service()
+    agent = service.add_agent("worker")
+    task = service.add_task("test")
+    assign = service.assign(task, agent)
+    for i in range(5):
+        service.record_evaluation(assign, "ev", {"score": i})
+    hist = service.get_history(agent, offset=1, limit=2)
+    assert len(hist) == 2
+    assert hist[0]["performance_vector"]["score"] == 3


### PR DESCRIPTION
## Summary
- implement API key auth and RBAC for the reputation service
- add versioned API endpoints under `/api/v1`
- support querying reputations and retrieving agent history with pagination
- expose helper methods in reputation service
- test service query and history logic

## Testing
- `pytest tests/test_reputation_api.py -q`
- `pre-commit run --files services/reputation/service.py services/reputation/app.py tests/test_reputation_api.py` *(fails: tests require heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685071222374832a80c6ee6a6872addc