### PR TITLE
Link reputation data with LTM

### DIFF
--- a/tests/test_reputation_service.py
+++ b/tests/test_reputation_service.py
@@ -1,3 +1,4 @@
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -21,4 +22,4 @@ def test_reputation_aggregation():
     service.record_evaluation(assign_id, "Eval1", {"accuracy": 0.6})
 
     rep = service.get_reputation(agent_id, "research")
-    assert rep == {"accuracy": 0.7}
+    assert rep["accuracy"] == pytest.approx(0.7, abs=1e-3)


### PR DESCRIPTION
## Summary
- connect `ReputationService` to the LTM service
- weight reputation updates using episodic memory history
- store episodic evaluation records and semantic reputation facts
- adjust reputation service test for floating point comparison

## Testing
- `pytest -q tests/test_reputation_service.py tests/test_reputation_event_loop.py`

------
https://chatgpt.com/codex/tasks/task_e_6850df5b7f0c832a9a0de74cd59a4076