### PR TITLE
Implement graph trace API

### DIFF
--- a/services/tracing/__init__.py
+++ b/services/tracing/__init__.py
@@ -1,5 +1,13 @@
 """Tracing utilities and context helpers."""
 
+from .graph_api import GraphTraceExporter, create_app, spans_to_graph
 from .metrics import get_metrics, increment_metric, reset_metrics
 
-__all__ = ["get_metrics", "increment_metric", "reset_metrics"]
+__all__ = [
+    "get_metrics",
+    "increment_metric",
+    "reset_metrics",
+    "GraphTraceExporter",
+    "create_app",
+    "spans_to_graph",
+]

--- a/services/tracing/graph_api.py
+++ b/services/tracing/graph_api.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Expose execution graph derived from OpenTelemetry spans."""
+
+from typing import Dict, List, Set
+
+from fastapi import FastAPI
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+
+def spans_to_graph(spans: List[ReadableSpan]) -> Dict[str, List[Dict]]:
+    """Convert spans to a graph representation."""
+    nodes: Set[str] = set()
+    edges: List[Dict[str, object]] = []
+    for span in spans:
+        if span.name.startswith("node:"):
+            node = span.name.split(":", 1)[1]
+            nodes.add(node)
+        elif span.name == "edge":
+            start = span.attributes.get("from")
+            end = span.attributes.get("to")
+            if start and end:
+                edges.append(
+                    {
+                        "from": str(start),
+                        "to": str(end),
+                        "type": span.attributes.get("type"),
+                        "timestamp": span.start_time / 1e9,
+                    }
+                )
+    return {"nodes": sorted(nodes), "edges": edges}
+
+
+class GraphTraceExporter(SpanExporter):
+    """Collect spans in memory for graph extraction."""
+
+    def __init__(self) -> None:
+        self.spans: List[ReadableSpan] = []
+
+    def export(
+        self, spans: List[ReadableSpan]
+    ) -> SpanExportResult:  # pragma: no cover - OTLP interface
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:  # pragma: no cover - interface req
+        self.spans.clear()
+
+    def force_flush(
+        self, timeout_millis: int = 30_000
+    ) -> bool:  # pragma: no cover - interface req
+        return True
+
+
+def create_app(exporter: GraphTraceExporter) -> FastAPI:
+    """Return a FastAPI app exposing the current execution graph."""
+
+    app = FastAPI(title="Graph Trace API", version="1.0.0")
+
+    @app.get("/graph")
+    def get_graph() -> Dict[str, List[Dict]]:
+        return spans_to_graph(exporter.spans)
+
+    return app

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib
+
+from fastapi.testclient import TestClient
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from engine.orchestration_engine import GraphState, create_orchestration_engine
+from services.tracing import GraphTraceExporter, create_app
+
+
+def test_graph_api_returns_graph():
+    importlib.reload(trace)
+    exporter = GraphTraceExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    engine = create_orchestration_engine()
+
+    def node_a(state: GraphState, scratchpad: dict) -> GraphState:
+        state.update({"a": 1})
+        return state
+
+    def node_b(state: GraphState, scratchpad: dict) -> GraphState:
+        state.update({"b": state.data["a"]})
+        return state
+
+    engine.add_node("A", node_a)
+    engine.add_node("B", node_b)
+    engine.add_edge("A", "B")
+
+    engine.run(GraphState())
+
+    app = create_app(exporter)
+    client = TestClient(app)
+    resp = client.get("/graph")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data["nodes"]) == {"A", "B"}
+    assert any(e["from"] == "A" and e["to"] == "B" for e in data["edges"])


### PR DESCRIPTION
## Summary
- expose execution graph from collected OpenTelemetry spans via `GraphTraceExporter`
- provide FastAPI app for retrieving the graph
- test basic graph extraction logic

## Testing
- `pre-commit run --files services/tracing/graph_api.py services/tracing/__init__.py tests/test_graph_api.py` *(fails: Required test coverage of 80% not reached)*
- `pytest -q` *(fails: errors during collection due to missing SciPy/OpenBLAS)*

------
https://chatgpt.com/codex/tasks/task_e_68510628d034832a88ee56dd17fa1ce5