### PR TITLE
Implement uncertainty display in execution graph

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -197,3 +197,11 @@
   - Investigate Supervisor merging logic
   - Add regression test for plan length reduction
   title: Replace deprecated utcnow usage
+- acceptance_criteria:
+  - Edges and nodes styled based on agent-provided confidence scores
+  - Agent's primary intended plan visually distinct
+  - Selecting a belief node reveals the evidence chain
+  id: CR-1.2
+  priority: medium
+  steps: []
+  title: Uncertainty & Intent Display

--- a/codex_tasks.md
+++ b/codex_tasks.md
@@ -1408,3 +1408,14 @@ acceptance_criteria:
   - Planner queries the reputation API before assigning tasks
   - Weighted sum considers reputation score, token cost and load
 ```
+
+```codex-task
+id: CR-1.2
+title: Uncertainty & Intent Display
+priority: medium
+steps: []
+acceptance_criteria:
+  - Edges and nodes styled based on agent-provided confidence scores
+  - Agent's primary intended plan visually distinct
+  - Selecting a belief node reveals the evidence chain
+```

--- a/services/tracing/graph_api.py
+++ b/services/tracing/graph_api.py
@@ -2,21 +2,36 @@ from __future__ import annotations
 
 """Expose execution graph derived from OpenTelemetry spans."""
 
-from typing import Dict, List, Set
+import json
+from typing import Any, Dict, List, Set
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
 
-def spans_to_graph(spans: List[ReadableSpan]) -> Dict[str, List[Dict]]:
-    """Convert spans to a graph representation."""
-    nodes: Set[str] = set()
-    edges: List[Dict[str, object]] = []
+def _extract_node_states(spans: List[ReadableSpan]) -> Dict[str, Dict[str, Any]]:
+    """Return mapping of node name to parsed ``state_out`` JSON."""
+    states: Dict[str, Dict[str, Any]] = {}
+    for span in spans:
+        if span.name.startswith("node:") and "state_out" in span.attributes:
+            node = span.name.split(":", 1)[1]
+            try:
+                states[node] = json.loads(span.attributes["state_out"])
+            except Exception:
+                states[node] = {}
+    return states
+
+
+def spans_to_graph(spans: List[ReadableSpan]) -> Dict[str, List[Dict[str, Any]]]:
+    """Convert spans to a graph representation with node metadata."""
+    states = _extract_node_states(spans)
+    nodes_set: Set[str] = set(states)
+    edges: List[Dict[str, Any]] = []
     for span in spans:
         if span.name.startswith("node:"):
             node = span.name.split(":", 1)[1]
-            nodes.add(node)
+            nodes_set.add(node)
         elif span.name == "edge":
             start = span.attributes.get("from")
             end = span.attributes.get("to")
@@ -29,7 +44,15 @@ def spans_to_graph(spans: List[ReadableSpan]) -> Dict[str, List[Dict]]:
                         "timestamp": span.start_time / 1e9,
                     }
                 )
-    return {"nodes": sorted(nodes), "edges": edges}
+
+    nodes: List[Dict[str, Any]] = []
+    for name in sorted(nodes_set):
+        state = states.get(name, {})
+        conf = state.get("scratchpad", {}).get("confidence")
+        intent = state.get("scratchpad", {}).get("intent")
+        nodes.append({"id": name, "confidence": conf, "intent": intent})
+
+    return {"nodes": nodes, "edges": edges}
 
 
 class GraphTraceExporter(SpanExporter):
@@ -59,7 +82,20 @@ def create_app(exporter: GraphTraceExporter) -> FastAPI:
     app = FastAPI(title="Graph Trace API", version="1.0.0")
 
     @app.get("/graph")
-    def get_graph() -> Dict[str, List[Dict]]:
+    def get_graph() -> Dict[str, List[Dict[str, Any]]]:
         return spans_to_graph(exporter.spans)
+
+    @app.get("/belief/{node}/{key}")
+    def get_belief(node: str, key: str) -> Dict[str, Any]:
+        states = _extract_node_states(exporter.spans)
+        state = states.get(node)
+        if not state:
+            raise HTTPException(status_code=404, detail="node not found")
+        value = None
+        if key in state.get("data", {}):
+            value = state["data"][key]
+        elif key in state.get("scratchpad", {}):
+            value = state["scratchpad"][key]
+        return {"value": value, "history": state.get("history", [])}
 
     return app

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -39,5 +39,44 @@ def test_graph_api_returns_graph():
     resp = client.get("/graph")
     assert resp.status_code == 200
     data = resp.json()
-    assert set(data["nodes"]) == {"A", "B"}
+    assert {n["id"] for n in data["nodes"]} == {"A", "B"}
     assert any(e["from"] == "A" and e["to"] == "B" for e in data["edges"])
+
+
+def test_graph_encodes_confidence_and_belief_provenance():
+    importlib.reload(trace)
+    exporter = GraphTraceExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    engine = create_orchestration_engine()
+
+    def node_a(state: GraphState, scratchpad: dict) -> GraphState:
+        scratchpad["confidence"] = 0.75
+        scratchpad["intent"] = "B"
+        state.update({"a": 1})
+        return state
+
+    def node_b(state: GraphState, scratchpad: dict) -> GraphState:
+        return state
+
+    engine.add_node("A", node_a)
+    engine.add_node("B", node_b)
+    engine.add_edge("A", "B")
+
+    engine.run(GraphState())
+
+    app = create_app(exporter)
+    client = TestClient(app)
+
+    data = client.get("/graph").json()
+    node_a_data = next(n for n in data["nodes"] if n["id"] == "A")
+    assert node_a_data["confidence"] == 0.75
+    assert node_a_data["intent"] == "B"
+
+    resp = client.get("/belief/A/confidence")
+    assert resp.status_code == 200
+    belief = resp.json()
+    assert belief["value"] == 0.75
+    assert belief["history"]


### PR DESCRIPTION
## Summary
- expose node confidence and intent via graph API
- return belief provenance for each node
- test graph API updates
- add CR-1.2 to task docs and queue

## Testing
- `black services/tracing/graph_api.py tests/test_graph_api.py`
- `isort services/tracing/graph_api.py tests/test_graph_api.py`
- `pytest tests/test_graph_api.py::test_graph_api_returns_graph` *(failed: Killed)*


------
https://chatgpt.com/codex/tasks/task_e_685112bc4314832a91a0e11b76aede2f