### PR TITLE
Add procedural memory service

### DIFF
--- a/services/ltm_service/__init__.py
+++ b/services/ltm_service/__init__.py
@@ -4,6 +4,7 @@ from .api import LTMService, LTMServiceServer
 from .embedding_client import EmbeddingClient, SimpleEmbeddingClient
 from .episodic_memory import EpisodicMemoryService, InMemoryStorage
 from .openapi_app import create_app
+from .procedural_memory import ProceduralMemoryService
 from .semantic_memory import SemanticMemoryService
 from .vector_store import InMemoryVectorStore, VectorStore, WeaviateVectorStore
 
@@ -13,6 +14,7 @@ __all__ = [
     "create_app",
     "EpisodicMemoryService",
     "InMemoryStorage",
+    "ProceduralMemoryService",
     "SemanticMemoryService",
     "EmbeddingClient",
     "SimpleEmbeddingClient",

--- a/services/ltm_service/openapi_app.py
+++ b/services/ltm_service/openapi_app.py
@@ -125,6 +125,11 @@ if __name__ == "__main__":  # pragma: no cover - manual execution
     import uvicorn
 
     from .episodic_memory import EpisodicMemoryService, InMemoryStorage
+    from .procedural_memory import ProceduralMemoryService
 
-    service = LTMService(EpisodicMemoryService(InMemoryStorage()))
+    episodic = EpisodicMemoryService(InMemoryStorage())
+    service = LTMService(
+        episodic,
+        procedural_memory=ProceduralMemoryService(InMemoryStorage()),
+    )
     uvicorn.run(create_app(service), host="0.0.0.0", port=8081)

--- a/services/ltm_service/procedural_memory.py
+++ b/services/ltm_service/procedural_memory.py
@@ -1,0 +1,63 @@
+"""Procedural memory module built on top of episodic memory semantics."""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable, List
+
+from .episodic_memory import EpisodicMemoryService
+
+
+class ProceduralMemoryService(EpisodicMemoryService):
+    """Store and execute reusable procedures."""
+
+    def __init__(
+        self,
+        storage_backend,
+        *,
+        embedding_client=None,
+        vector_store=None,
+        action_registry: Dict[str, Callable[..., Any]] | None = None,
+    ) -> None:
+        super().__init__(
+            storage_backend,
+            embedding_client=embedding_client,
+            vector_store=vector_store,
+        )
+        self.action_registry: Dict[str, Callable[..., Any]] = action_registry or {
+            "add": lambda a, b: a + b,
+            "mul": lambda a, b: a * b,
+        }
+
+    def store_procedure(
+        self, task_context: Dict, procedure: Iterable[Dict], outcome: Dict
+    ) -> str:
+        """Persist a procedure for later reuse."""
+        return super().store_experience(
+            task_context,
+            {"procedure": list(procedure)},
+            outcome,
+        )
+
+    def retrieve_similar_procedures(self, query: Dict, *, limit: int = 5) -> List[Dict]:
+        """Retrieve procedures relevant to the query."""
+        return super().retrieve_similar_experiences(query, limit=limit)
+
+    def forget_procedure(self, procedure_id: str, *, hard: bool = False) -> bool:
+        """Forget a stored procedure."""
+        return super().forget_experience(procedure_id, hard=hard)
+
+    def execute_procedure(self, procedure_id: str) -> List[Any]:
+        """Execute the stored procedure and return step results."""
+        rec = self.storage._data.get(procedure_id)
+        if not rec or rec.get("deleted_at"):
+            raise KeyError("procedure not found")
+        steps = rec.get("execution_trace", {}).get("procedure", [])
+        results = []
+        for step in steps:
+            action = step.get("action")
+            func = self.action_registry.get(action)
+            if func is None:
+                raise ValueError(f"Unknown action: {action}")
+            args = step.get("args", [])
+            kwargs = step.get("kwargs", {})
+            results.append(func(*args, **kwargs))
+        return results

--- a/tests/fixtures/procedural_contract/procedure_retrieve_success.json
+++ b/tests/fixtures/procedural_contract/procedure_retrieve_success.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "headers": {"X-Role": "viewer"},
+    "params": {"memory_type": "procedural"},
+    "json": {"query": {"description": "Add numbers"}}
+  },
+  "response": {
+    "status": 200,
+    "body": {"results": "*"}
+  }
+}

--- a/tests/fixtures/procedural_contract/procedure_store_success.json
+++ b/tests/fixtures/procedural_contract/procedure_store_success.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "headers": {"X-Role": "editor"},
+    "json": {
+      "record": {
+        "task_context": {"description": "Add numbers"},
+        "procedure": [{"action": "add", "args": [1, 2]}],
+        "outcome": {"success": true}
+      },
+      "memory_type": "procedural"
+    }
+  },
+  "response": {
+    "status": 201,
+    "body": {"id": "*"}
+  }
+}

--- a/tests/test_procedural_memory_contract.py
+++ b/tests/test_procedural_memory_contract.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+from threading import Thread
+
+import requests
+
+from services.ltm_service import (
+    EpisodicMemoryService,
+    InMemoryStorage,
+    LTMService,
+    LTMServiceServer,
+    ProceduralMemoryService,
+)
+
+FIXTURE_DIR = Path("tests/fixtures/procedural_contract")
+
+
+def _start_server() -> tuple[LTMServiceServer, str]:
+    episodic = EpisodicMemoryService(InMemoryStorage())
+    procedural = ProceduralMemoryService(InMemoryStorage())
+    service = LTMService(episodic, procedural_memory=procedural)
+    server = LTMServiceServer(service, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.httpd.server_port}"
+    return server, endpoint
+
+
+def _load_case(name: str) -> dict:
+    path = FIXTURE_DIR / f"{name}.json"
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _assert_contract(resp: requests.Response, expected: dict) -> None:
+    assert resp.status_code == expected["status"]
+    body = resp.json()
+    for key, value in expected.get("body", {}).items():
+        if value == "*":
+            assert key in body
+        else:
+            assert body.get(key) == value
+
+
+def test_store_and_execute_procedure():
+    server, endpoint = _start_server()
+    case_store = _load_case("procedure_store_success")
+    resp = requests.post(
+        f"{endpoint}/memory",
+        headers=case_store["request"].get("headers", {}),
+        json=case_store["request"].get("json"),
+    )
+    _assert_contract(resp, case_store["response"])
+    proc_id = resp.json()["id"]
+
+    case_retrieve = _load_case("procedure_retrieve_success")
+    resp = requests.get(
+        f"{endpoint}/memory",
+        headers=case_retrieve["request"].get("headers", {}),
+        params=case_retrieve["request"].get("params"),
+        json=case_retrieve["request"].get("json"),
+    )
+    _assert_contract(resp, case_retrieve["response"])
+
+    output = server.service._modules["procedural"].execute_procedure(proc_id)
+    assert output == [3]
+    server.httpd.shutdown()


### PR DESCRIPTION
## Summary
- add a ProceduralMemoryService
- expose procedural memory in LTMService
- update OpenAPI app for procedural memory
- test storing and executing a procedure

## Testing
- `pre-commit run --files services/ltm_service/procedural_memory.py services/ltm_service/__init__.py services/ltm_service/api.py services/ltm_service/openapi_app.py tests/test_procedural_memory_contract.py tests/fixtures/procedural_contract/procedure_store_success.json tests/fixtures/procedural_contract/procedure_retrieve_success.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512c844680832aa51cca67f89c29c1