### PR TITLE
Implement skill logging via base agent

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Base agent class with skill logging support."""
+
+from typing import Any, Dict, List, Optional
+
+from engine.state import State
+from services.tool_registry import ToolRegistry, create_default_registry
+from services.tracing.tracing_schema import ToolCallTrace
+
+
+class BaseAgent:
+    """Base class providing tool call tracing and procedure storage."""
+
+    def __init__(
+        self,
+        role: str,
+        tool_registry: ToolRegistry | Dict[str, Any] | None = None,
+        *,
+        ltm_endpoint: str | None = None,
+    ) -> None:
+        self.role = role
+        if isinstance(tool_registry, ToolRegistry):
+            self.registry: Optional[ToolRegistry] = tool_registry
+            self.tool_registry = tool_registry
+        else:
+            self.registry = None
+            self.tool_registry = tool_registry or create_default_registry()
+        self.ltm_endpoint = ltm_endpoint
+        self._procedure: List[Dict[str, Any]] = []
+
+    def _log_tool(
+        self,
+        name: str,
+        args: List[Any],
+        kwargs: Dict[str, Any],
+        result: Any,
+        *,
+        agent_id: str = "",
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        latency_ms: float | None = None,
+    ) -> None:
+        """Record a tool invocation in the procedure and emit a trace span."""
+        self._procedure.append({"action": name, "args": args, "kwargs": kwargs})
+        ToolCallTrace(
+            agent_id=agent_id,
+            agent_role=self.role,
+            tool_name=name,
+            tool_input={"args": args, "kwargs": kwargs},
+            tool_output=result,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            latency_ms=latency_ms,
+        ).record()
+
+    def _store_procedure(self, state: State) -> None:
+        """Persist the recorded procedure to procedural memory."""
+        if not self._procedure or self.registry is None:
+            return
+        state.history.append({"action": "procedure", "steps": self._procedure})
+        try:
+            self.registry.invoke(
+                self.role,
+                "consolidate_memory",
+                {
+                    "task_context": state.data,
+                    "procedure": self._procedure,
+                    "outcome": {"success": True},
+                },
+                memory_type="procedural",
+                endpoint=self.ltm_endpoint,
+            )
+        except Exception:
+            pass
+        self._procedure = []

--- a/agents/code_researcher.py
+++ b/agents/code_researcher.py
@@ -6,20 +6,24 @@ import time
 from typing import Any, Callable, Dict, List, Optional
 
 from engine.orchestration_engine import GraphState
-from services.tracing.tracing_schema import ToolCallTrace
+from services.tool_registry import ToolRegistry
+
+from .base import BaseAgent
 
 
-class CodeResearcherAgent:
+class CodeResearcherAgent(BaseAgent):
     """Agent specializing in code analysis and execution."""
 
     def __init__(
         self,
-        tool_registry: Dict[str, Callable[..., Any]],
+        tool_registry: Dict[str, Callable[..., Any]] | ToolRegistry,
         *,
         rate_limit_per_minute: int = 5,
         max_retries: int = 3,
+        ltm_endpoint: str | None = None,
     ) -> None:
-        self.tool_registry = tool_registry
+        super().__init__("CodeResearcher", tool_registry, ltm_endpoint=ltm_endpoint)
+        self.tool_registry = tool_registry  # type: ignore[assignment]
         self.rate_limit = rate_limit_per_minute
         self.max_retries = max_retries
         self.call_times: List[float] = []
@@ -40,12 +44,22 @@ class CodeResearcherAgent:
         self.call_times.append(now)
 
     def _call_with_retry(
-        self, func: Callable[..., Any], *args: Any, **kwargs: Any
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        tool_name: str | None = None,
+        trace_kwargs: Dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> Any:
         backoff = 1.0
         for attempt in range(self.max_retries):
             try:
-                return func(*args, **kwargs)
+                result = func(*args, **kwargs)
+                if tool_name:
+                    self._log_tool(
+                        tool_name, list(args), kwargs, result, **(trace_kwargs or {})
+                    )
+                return result
             except Exception as exc:
                 if attempt >= self.max_retries - 1:
                     raise RuntimeError(
@@ -61,18 +75,21 @@ class CodeResearcherAgent:
         self._check_rate_limit()
         start = time.perf_counter()
         try:
-            result = self._call_with_retry(self.code_interpreter, code, args=args or [])
+            result = self._call_with_retry(
+                self.code_interpreter,
+                code,
+                args=args or [],
+            )
         except Exception as exc:
             result = {"stdout": "", "stderr": str(exc), "returncode": -1}
         latency_ms = (time.perf_counter() - start) * 1000
-        ToolCallTrace(
-            agent_id="",
-            agent_role="CodeResearcher",
-            tool_name="code_interpreter",
-            tool_input=code,
-            tool_output=result,
+        self._log_tool(
+            "code_interpreter",
+            [code],
+            {"args": args or []},
+            result,
             latency_ms=latency_ms,
-        ).record()
+        )
         return result
 
     # ------------------------------------------------------------------
@@ -85,4 +102,5 @@ class CodeResearcherAgent:
         args = state.data.get("code_args", [])
         result = self.analyze_code(code, args)
         state.update({"code_result": result})
+        self._store_procedure(state)
         return state


### PR DESCRIPTION
## Summary
- add `BaseAgent` to log tool call sequences and persist procedures
- instrument `WebResearcherAgent` and `CodeResearcherAgent` to use the base class

## Testing
- `pre-commit run --files agents/base.py agents/web_researcher.py agents/code_researcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685131980b60832a99783197aa8ba6fa