### PR TITLE
Add LTM hit/miss metrics

### DIFF
--- a/docs/dashboards/ltm_metrics_dashboard.md
+++ b/docs/dashboards/ltm_metrics_dashboard.md
@@ -1,0 +1,11 @@
+# LTM Metrics Dashboard
+
+The monitoring service exports counters for each long-term memory module. These metrics help operators understand recall effectiveness and data quality.
+
+## Metrics
+
+- `ltm.hits` – number of successful retrievals
+- `ltm.misses` – number of failed retrievals
+
+Both metrics include a `memory_type` attribute with values `episodic`, `semantic`, and `procedural`. Dashboards group these counters to visualize hit rates over time.
+

--- a/docs/epics/phase4_production_hardening_epic.md
+++ b/docs/epics/phase4_production_hardening_epic.md
@@ -21,7 +21,8 @@ This epic translates the updated Phase 4 blueprint into a structured set of chan
    - Add fallback logic when no procedure matches.
 4. **P4-04R – Observability: LTM Metrics**
    - Add counters for episodic, semantic, and procedural memory hits/misses.
-   - Expose metrics via the monitoring service and update dashboards.
+   - Metrics `ltm.hits` and `ltm.misses` are exported with a `memory_type` label.
+   - Expose these metrics via the monitoring service and update dashboards.
 5. **P4-05R – Procedural Memory Recall Research**
    - Continue research comparing retrieval-augmented generation with fine-tuning for skill recall.
    - Document findings in `docs/research` and update the blueprint accordingly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,3 +25,5 @@ nav:
       - Phase 1 Gap Analysis: docs/reports/phase1-gap-analysis-report.md
       - Phase 1 UAT Gap Analysis: docs/reports/phase1-uat-gap-analysis-report.md
       - Phase 1 UAT Review Agenda: docs/reports/phase1-uat-review-agenda-report.md
+  - Dashboards:
+      - LTM Metrics: docs/dashboards/ltm_metrics_dashboard.md

--- a/services/monitoring/system_monitor.py
+++ b/services/monitoring/system_monitor.py
@@ -59,6 +59,12 @@ class SystemMonitor:
             "agent.collaboration_effectiveness",
             description="Collaboration effectiveness",
         )
+        self._ltm_hit_counter = self._meter.create_counter(
+            "ltm.hits", description="LTM retrieval hits"
+        )
+        self._ltm_miss_counter = self._meter.create_counter(
+            "ltm.misses", description="LTM retrieval misses"
+        )
 
     @classmethod
     def from_otlp(cls, endpoint: str = "http://localhost:4317") -> "SystemMonitor":
@@ -98,3 +104,11 @@ class SystemMonitor:
             if collab is not None:
                 self._collab_effectiveness.record(collab, attributes)
                 span.set_attribute("collaboration_effectiveness", collab)
+
+    def record_ltm_result(self, memory_type: str, hit: bool) -> None:
+        """Record the outcome of an LTM lookup."""
+        attributes = {"memory_type": memory_type}
+        if hit:
+            self._ltm_hit_counter.add(1, attributes)
+        else:
+            self._ltm_miss_counter.add(1, attributes)

--- a/tests/test_ltm_metrics.py
+++ b/tests/test_ltm_metrics.py
@@ -1,0 +1,52 @@
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+from services.ltm_service import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.api import LTMService
+from services.monitoring.system_monitor import SystemMonitor
+
+
+class InMemorySpanExporter(SpanExporter):
+    def __init__(self) -> None:
+        self.spans = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
+
+
+def test_ltm_hit_and_miss_metrics(monkeypatch):
+    import importlib
+
+    import opentelemetry.metrics._internal as metrics_internal
+    import opentelemetry.trace as trace
+
+    importlib.reload(trace)
+    importlib.reload(metrics_internal)
+    metric_reader = InMemoryMetricReader()
+    span_exporter = InMemorySpanExporter()
+    monitor = SystemMonitor(metric_reader, span_exporter)
+    service = LTMService(EpisodicMemoryService(InMemoryStorage()), monitor=monitor)
+
+    service.consolidate(
+        "episodic",
+        {"task_context": {"desc": "x"}, "execution_trace": {}, "outcome": {}},
+    )
+    service.retrieve("episodic", {"desc": "x"})  # hit
+    service.retrieve("semantic", {"subject": "nope"})  # miss
+
+    data = metric_reader.get_metrics_data()
+    names = {
+        m.name
+        for rm in data.resource_metrics
+        for sm in rm.scope_metrics
+        for m in sm.metrics
+    }
+    assert "ltm.hits" in names
+    assert "ltm.misses" in names


### PR DESCRIPTION
## Summary
- track LTM retrieval hits and misses in `SystemMonitor`
- expose metrics via `LTMService` and optional monitor
- document new counters and dashboard
- update epic with metric names and docs navigation
- test hit/miss counter logic

## Testing
- `pre-commit run --files tests/test_ltm_metrics.py services/monitoring/system_monitor.py services/ltm_service/api.py docs/epics/phase4_production_hardening_epic.md mkdocs.yml docs/dashboards/ltm_metrics_dashboard.md`
- `pytest -q tests/test_system_monitor.py tests/test_ltm_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_68513b400c8c832a95ec34679088a71f