### PR TITLE
Implement multi-agent fine-tuning pipeline

### DIFF
--- a/pipelines/fine_tuning/__init__.py
+++ b/pipelines/fine_tuning/__init__.py
@@ -1,0 +1,3 @@
+from .pipeline import MultiAgentFinetunePipeline
+
+__all__ = ["MultiAgentFinetunePipeline"]

--- a/pipelines/fine_tuning/pipeline.py
+++ b/pipelines/fine_tuning/pipeline.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import concurrent.futures
+from pathlib import Path
+from typing import Dict, Mapping, Type
+
+from pipelines.supervisor_policy import SupervisorPolicyTrainer
+
+
+class MultiAgentFinetunePipeline:
+    """Run fine-tuning jobs for multiple agents in parallel."""
+
+    def __init__(
+        self,
+        dataset_map: Mapping[str, str | Path],
+        reward_model_path: str | Path,
+        model_name: str = "sshleifer/tiny-gpt2",
+        out_root: str | Path = "models/agent_society",
+        trainer_cls: Type[SupervisorPolicyTrainer] = SupervisorPolicyTrainer,
+    ) -> None:
+        self.dataset_map = {k: Path(v) for k, v in dataset_map.items()}
+        self.reward_model_path = Path(reward_model_path)
+        self.model_name = model_name
+        self.out_root = Path(out_root)
+        self.trainer_cls = trainer_cls
+
+    def _run_job(self, agent_id: str, data_path: Path, epochs: int) -> Dict:
+        out_dir = self.out_root / agent_id
+        trainer = self.trainer_cls(
+            data_path,
+            self.reward_model_path,
+            model_name=self.model_name,
+            out_dir=out_dir,
+        )
+        return trainer.run(epochs=epochs)
+
+    def run(self, epochs: int = 1, max_workers: int | None = None) -> Dict[str, Dict]:
+        """Execute fine-tuning for all agents and return metrics per agent."""
+        results: Dict[str, Dict] = {}
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as exe:
+            futures = {
+                exe.submit(self._run_job, aid, path, epochs): aid
+                for aid, path in self.dataset_map.items()
+            }
+            for future in concurrent.futures.as_completed(futures):
+                aid = futures[future]
+                results[aid] = future.result()
+        return results

--- a/tests/test_fine_tuning_pipeline.py
+++ b/tests/test_fine_tuning_pipeline.py
@@ -1,0 +1,41 @@
+import time
+from pathlib import Path
+
+from pipelines.fine_tuning import MultiAgentFinetunePipeline
+
+
+def test_multi_agent_finetune_parallel(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeTrainer:
+        def __init__(
+            self, data_path, reward_model_path, model_name="", out_dir=Path(".")
+        ):
+            self.data_path = Path(data_path)
+            self.out_dir = Path(out_dir)
+
+        def run(self, epochs: int = 1):
+            calls.append(self.data_path.name)
+            time.sleep(0.1)
+            return {"average_reward": 1.0}
+
+    dataset_map = {}
+    for i in range(5):
+        data = tmp_path / f"agent{i}.json"
+        data.write_text("[]", encoding="utf-8")
+        dataset_map[f"agent{i}"] = data
+
+    reward_file = tmp_path / "reward.json"
+    reward_file.write_text("{}", encoding="utf-8")
+
+    pipeline = MultiAgentFinetunePipeline(
+        dataset_map, reward_file, trainer_cls=FakeTrainer, out_root=tmp_path
+    )
+    start = time.perf_counter()
+    metrics = pipeline.run(epochs=1, max_workers=5)
+    duration = time.perf_counter() - start
+
+    assert set(calls) == {f"agent{i}.json" for i in range(5)}
+    assert set(metrics.keys()) == {f"agent{i}" for i in range(5)}
+    # parallel execution should be faster than sequential (0.5s)
+    assert duration < 0.5


### PR DESCRIPTION
## Summary
- implement `MultiAgentFinetunePipeline` for running multiple fine-tuning jobs in parallel
- expose pipeline in new `pipelines.fine_tuning` package
- add unit test validating parallel execution

## Testing
- `pre-commit run --files pipelines/fine_tuning/pipeline.py pipelines/fine_tuning/__init__.py tests/test_fine_tuning_pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513e340910832aaff0173af041d5bc