### PR TITLE
Implement specialist agent selection

### DIFF
--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -15,3 +15,10 @@ Set the environment variable `USE_PLAN_TEMPLATES=1` or pass
 `use_plan_templates=True` to `SupervisorAgent` when constructing it.
 The number of memories considered is controlled by `retrieval_limit`.
 
+## Specialist agent selection
+
+Pass `available_agents` and `agent_skills` to `SupervisorAgent` to route tasks to
+the most relevant specialist. `agent_skills` maps each agent id to a list of
+skill tags. The Supervisor scores each task topic against these tags and assigns
+the agent with the highest overlap.
+

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -232,3 +232,15 @@ def test_plan_template_applied_when_enabled():
     assert plain["graph"] != template_plan["graph"]
     assert templ["graph"] == template_plan["graph"]
     server.httpd.shutdown()
+
+
+def test_skill_based_agent_selection():
+    skills = {"A1": ["transformer", "lstm"], "A2": ["finance"]}
+    agent = SupervisorAgent(
+        available_agents=["A1", "A2"],
+        agent_skills=skills,
+    )
+    agent.plan_schema = {}
+    plan = agent.plan_research_task("Transformer vs LSTM")
+    agents = [n["agent"] for n in plan["graph"]["nodes"] if n["agent"] != "Supervisor"]
+    assert all(a == "A1" for a in agents)


### PR DESCRIPTION
## Summary
- enable SupervisorAgent to pick specialists based on skills
- document specialist agent selection parameters
- test skill-based assignment

## Testing
- `pre-commit run --files agents/supervisor.py tests/test_supervisor.py docs/supervisor.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68513f9db9d0832a82c9cb04f501b044