### PR TITLE
Implement CitationAgent and enforce citation node

### DIFF
--- a/agents/citation_agent.py
+++ b/agents/citation_agent.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""CitationAgent for source-claim matching and citation formatting."""
+
+import difflib
+import re
+from typing import Any, Dict, List, Optional
+
+from engine.orchestration_engine import GraphState
+from engine.state import State
+
+from .base import BaseAgent
+
+
+class CitationAgent(BaseAgent):
+    """Match report claims to sources and insert formatted citations."""
+
+    def __init__(self, tool_registry: Optional[Dict[str, Any]] = None, *, default_style: str = "APA") -> None:
+        super().__init__("CitationAgent", tool_registry)
+        self.default_style = default_style
+
+    # ------------------------------------------------------------------
+    # Core helpers
+    # ------------------------------------------------------------------
+    def _split_sentences(self, text: str) -> List[str]:
+        sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()]
+        return sentences
+
+    def _match_source(self, claim: str, sources: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Return the source with highest similarity to ``claim``."""
+        best: Optional[Dict[str, Any]] = None
+        best_score = 0.0
+        for src in sources:
+            text = str(src.get("text", ""))
+            ratio = difflib.SequenceMatcher(None, claim.lower(), text.lower()).ratio()
+            if ratio > best_score:
+                best_score = ratio
+                best = src
+        return best
+
+    def _format_citation(self, source: Dict[str, Any], style: str) -> str:
+        author = source.get("author", "Unknown")
+        title = source.get("title", "Untitled")
+        year = source.get("year", "n.d.")
+        url = source.get("url", "")
+        if style.lower() == "mla":
+            return f"{author}. \"{title}.\" {year}. {url}".strip()
+        return f"{author} ({year}). {title}. {url}".strip()
+
+    def cite_report(self, report: str, sources: List[Dict[str, Any]], *, style: str | None = None) -> Dict[str, Any]:
+        style = style or self.default_style
+        sentences = self._split_sentences(report)
+        citations: List[str] = []
+        processed: List[str] = []
+        for sent in sentences:
+            src = self._match_source(sent, sources)
+            if src:
+                cite = self._format_citation(src, style)
+                citations.append(cite)
+                sent = f"{sent} ({cite})"
+            processed.append(sent)
+        return {"report": " ".join(processed), "citations": citations}
+
+    # ------------------------------------------------------------------
+    # Graph node integration
+    # ------------------------------------------------------------------
+    def __call__(self, state: GraphState, scratchpad: Dict[str, Any]) -> GraphState:
+        report = state.data.get("report")
+        sources = state.data.get("sources")
+        if not isinstance(report, str) or not isinstance(sources, list):
+            return state
+        style = state.data.get("citation_style", self.default_style)
+        result = self.cite_report(report, sources, style=style)
+        state.update(result)
+        return state

--- a/agents/supervisor.py
+++ b/agents/supervisor.py
@@ -157,6 +157,8 @@ class SupervisorAgent:
             nodes.append({"id": node_id, "agent": agent, **task})
             edges.append({"from": node_id, "to": "synthesis"})
         nodes.append({"id": "synthesis", "agent": "Supervisor", "task": "synthesize"})
+        nodes.append({"id": "citation", "agent": "CitationAgent", "task": "cite"})
+        edges.append({"from": "synthesis", "to": "citation"})
 
         plan = {
             "query": query,

--- a/tests/test_citation_agent.py
+++ b/tests/test_citation_agent.py
@@ -1,0 +1,36 @@
+import pytest
+
+from agents.citation_agent import CitationAgent
+from engine.orchestration_engine import GraphState
+
+pytestmark = pytest.mark.core
+
+
+def test_citation_agent_formats_apa():
+    agent = CitationAgent()
+    source = {
+        "author": "Smith",
+        "title": "AI Research",
+        "year": 2024,
+        "url": "http://example.com",
+    }
+    apa = agent._format_citation(source, "APA")
+    assert "Smith" in apa and "2024" in apa
+
+
+def test_citation_agent_inserts_citations():
+    agent = CitationAgent()
+    report = "Cats purr."
+    sources = [
+        {
+            "text": "Cats often purr when happy.",
+            "author": "Jones",
+            "title": "Felines",
+            "year": 2023,
+            "url": "http://cats.com",
+        }
+    ]
+    state = GraphState(data={"report": report, "sources": sources})
+    out = agent(state, {})
+    assert "cats.com" in out.data["citations"][0]
+    assert "(" in out.data["report"]

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -244,3 +244,12 @@ def test_skill_based_agent_selection():
     plan = agent.plan_research_task("Transformer vs LSTM")
     agents = [n["agent"] for n in plan["graph"]["nodes"] if n["agent"] != "Supervisor"]
     assert all(a == "A1" for a in agents)
+
+
+def test_plan_includes_citation_agent():
+    agent = SupervisorAgent()
+    agent.plan_schema = {}
+    plan = agent.plan_research_task("Example topic")
+    nodes = plan["graph"]["nodes"]
+    assert nodes[-1]["agent"] == "CitationAgent"
+    assert {"from": "synthesis", "to": "citation"} in plan["graph"]["edges"]


### PR DESCRIPTION
## Summary
- add `CitationAgent` implementation for matching claims to sources
- support APA and MLA citation formatting
- add CitationAgent node after synthesis in Supervisor planning
- test citation formatting and plan output

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851458cd138832aaf81fb7d299a3f4b