### PR TITLE
Implement checkpoint resumption and backoff

### DIFF
--- a/agents/citation_agent.py
+++ b/agents/citation_agent.py
@@ -7,7 +7,6 @@ import re
 from typing import Any, Dict, List, Optional
 
 from engine.orchestration_engine import GraphState
-from engine.state import State
 
 from .base import BaseAgent
 
@@ -15,7 +14,12 @@ from .base import BaseAgent
 class CitationAgent(BaseAgent):
     """Match report claims to sources and insert formatted citations."""
 
-    def __init__(self, tool_registry: Optional[Dict[str, Any]] = None, *, default_style: str = "APA") -> None:
+    def __init__(
+        self,
+        tool_registry: Optional[Dict[str, Any]] = None,
+        *,
+        default_style: str = "APA",
+    ) -> None:
         super().__init__("CitationAgent", tool_registry)
         self.default_style = default_style
 
@@ -26,7 +30,9 @@ class CitationAgent(BaseAgent):
         sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()]
         return sentences
 
-    def _match_source(self, claim: str, sources: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    def _match_source(
+        self, claim: str, sources: List[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
         """Return the source with highest similarity to ``claim``."""
         best: Optional[Dict[str, Any]] = None
         best_score = 0.0
@@ -44,10 +50,12 @@ class CitationAgent(BaseAgent):
         year = source.get("year", "n.d.")
         url = source.get("url", "")
         if style.lower() == "mla":
-            return f"{author}. \"{title}.\" {year}. {url}".strip()
+            return f'{author}. "{title}." {year}. {url}'.strip()
         return f"{author} ({year}). {title}. {url}".strip()
 
-    def cite_report(self, report: str, sources: List[Dict[str, Any]], *, style: str | None = None) -> Dict[str, Any]:
+    def cite_report(
+        self, report: str, sources: List[Dict[str, Any]], *, style: str | None = None
+    ) -> Dict[str, Any]:
         style = style or self.default_style
         sentences = self._split_sentences(report)
         citations: List[str] = []

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from engine.orchestration_engine import (
+    GraphState,
+    InMemorySaver,
+    create_orchestration_engine,
+)
+
+
+def test_resume_from_checkpoint():
+    cp = InMemorySaver()
+    engine = create_orchestration_engine()
+    engine.checkpointer = cp
+
+    flag = {"fail": True}
+
+    def node_a(state: GraphState, _sp: dict) -> GraphState:
+        state.update({"x": 1})
+        return state
+
+    def node_b(state: GraphState, _sp: dict) -> GraphState:
+        if flag["fail"]:
+            raise RuntimeError("boom")
+        state.update({"x": state.data["x"] + 1})
+        return state
+
+    engine.add_node("A", node_a)
+    engine.add_node("B", node_b)
+    engine.add_edge("A", "B")
+
+    try:
+        asyncio.run(engine.run_async(GraphState(), thread_id="t1"))
+    except RuntimeError:
+        pass
+
+    saved = cp.load("t1")
+    assert saved and saved[0] == "A"
+
+    flag["fail"] = False
+    resumed = asyncio.run(engine.resume_from_checkpoint_async("t1"))
+    assert resumed.data["x"] == 2

--- a/tests/test_mast_suite.py
+++ b/tests/test_mast_suite.py
@@ -1,0 +1,71 @@
+import asyncio
+from threading import Thread
+
+import pytest
+
+from agents.evaluator import EvaluatorAgent
+from agents.memory_manager import MemoryManagerAgent
+from agents.supervisor import SupervisorAgent
+from engine.collaboration.group_chat import GroupChatManager
+from engine.orchestration_engine import GraphState
+from services.ltm_service import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.api import LTMService, LTMServiceServer
+
+pytestmark = pytest.mark.core
+
+
+def _start_server():
+    storage = InMemoryStorage()
+    service = LTMService(EpisodicMemoryService(storage))
+    server = LTMServiceServer(service, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.httpd.server_port}"
+    return server, endpoint
+
+
+def test_mast_step_repetition():
+    server, endpoint = _start_server()
+    mm = MemoryManagerAgent(endpoint=endpoint)
+
+    sup_first = SupervisorAgent(ltm_endpoint=endpoint, use_plan_templates=False)
+    state = sup_first.analyze_query("Transformer vs LSTM")
+    mm(state, {})
+
+    sup_base = SupervisorAgent(ltm_endpoint=endpoint, use_plan_templates=False)
+    baseline = sup_base.plan_research_task("Transformer vs LSTM vs CNN")
+    baseline_len = len(baseline["graph"]["nodes"])
+
+    sup_recall = SupervisorAgent(
+        ltm_endpoint=endpoint, use_plan_templates=True, retrieval_limit=1
+    )
+    recalled = sup_recall.plan_research_task("Transformer vs LSTM vs CNN")
+    recalled_len = len(recalled["graph"]["nodes"])
+
+    assert recalled["context"], "episodic memory should be recalled"
+    assert recalled_len < baseline_len
+    server.httpd.shutdown()
+
+
+def test_mast_information_withholding():
+    def agent_a(messages, state, scratch):
+        return {"content": "42", "type": "message", "recipient": "B"}
+
+    def agent_b(messages, state, scratch):
+        if messages:
+            state.update({"answer": messages[0]["content"]})
+        return {"content": "FINISH", "type": "finish"}
+
+    manager = GroupChatManager({"A": agent_a, "B": agent_b}, max_turns=2)
+    state = GraphState()
+    result = asyncio.run(manager.run(state))
+
+    assert result.data.get("answer") == "42"
+
+
+def test_mast_incorrect_verification():
+    agent = EvaluatorAgent()
+    summary = "Paris is the capital of Germany."
+    sources = ["Paris is the capital of France."]
+    result = agent.verify_factual_accuracy(summary, sources)
+    assert "Paris is the capital of Germany." in result["unsupported_facts"]

--- a/tools/knowledge_graph_search.py
+++ b/tools/knowledge_graph_search.py
@@ -8,11 +8,21 @@ from .ltm_client import retrieve_memory
 
 
 def knowledge_graph_search(
-    query: Dict[str, Any], *, limit: int = 5, endpoint: Optional[str] = None
+    query: Dict[str, Any],
+    *,
+    limit: int = 5,
+    endpoint: Optional[str] = None,
+    retries: int = 2,
+    backoff: float = 1.0,
 ) -> List[Dict[str, Any]]:
     """Return facts matching ``query`` from semantic memory."""
     if not isinstance(query, dict):
         raise ValueError("query must be a dictionary")
     return retrieve_memory(
-        query, memory_type="semantic", limit=limit, endpoint=endpoint
+        query,
+        memory_type="semantic",
+        limit=limit,
+        endpoint=endpoint,
+        retries=retries,
+        backoff=backoff,
     )

--- a/tools/ltm_client.py
+++ b/tools/ltm_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import time
 from typing import Dict, List, Optional
 
 import requests
@@ -15,16 +16,24 @@ def consolidate_memory(
     *,
     memory_type: str = "episodic",
     endpoint: Optional[str] = None,
+    retries: int = 2,
+    backoff: float = 1.0,
 ) -> str:
     url = f"{_endpoint(endpoint)}/memory"
-    resp = requests.post(
-        url,
-        json={"memory_type": memory_type, "record": record},
-        headers={"X-Role": "editor"},
-        timeout=10,
-    )
-    resp.raise_for_status()
-    return resp.json().get("id", "")
+    for attempt in range(retries + 1):
+        try:
+            resp = requests.post(
+                url,
+                json={"memory_type": memory_type, "record": record},
+                headers={"X-Role": "editor"},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            return resp.json().get("id", "")
+        except requests.RequestException as exc:
+            if attempt >= retries:
+                raise ValueError(f"Memory consolidation failed: {exc}") from exc
+            time.sleep(backoff * 2**attempt)
 
 
 def retrieve_memory(
@@ -33,14 +42,22 @@ def retrieve_memory(
     memory_type: str = "episodic",
     limit: int = 5,
     endpoint: Optional[str] = None,
+    retries: int = 2,
+    backoff: float = 1.0,
 ) -> List[Dict]:
     url = f"{_endpoint(endpoint)}/memory"
-    resp = requests.get(
-        url,
-        params={"memory_type": memory_type, "limit": str(limit)},
-        json={"query": query},
-        headers={"X-Role": "viewer"},
-        timeout=10,
-    )
-    resp.raise_for_status()
-    return resp.json().get("results", [])
+    for attempt in range(retries + 1):
+        try:
+            resp = requests.get(
+                url,
+                params={"memory_type": memory_type, "limit": str(limit)},
+                json={"query": query},
+                headers={"X-Role": "viewer"},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            return resp.json().get("results", [])
+        except requests.RequestException as exc:
+            if attempt >= retries:
+                raise ValueError(f"Memory retrieval failed: {exc}") from exc
+            time.sleep(backoff * 2**attempt)


### PR DESCRIPTION
## Summary
- add checkpoint resumability helpers and in-memory saver update
- apply exponential backoff across HTML scraper, LTM client, knowledge graph search, and PDF reader
- provide MAST tests for step repetition, info withholding, and incorrect verification
- test checkpoint resume logic

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685148432aa4832a97d6f89195d421fd