### PR TITLE
Fix hierarchical subgraph state merging

### DIFF
--- a/tests/test_hierarchical_subgraph.py
+++ b/tests/test_hierarchical_subgraph.py
@@ -59,3 +59,55 @@ def test_subgraph_propagates_state_and_parent_resumes():
     result = asyncio.run(parent.run_async(GraphState()))
     assert result.scratchpad["finding"] == "value"
     assert result.scratchpad["steps"] == ["A", "SUB", "B"]
+
+
+def test_nested_subgraphs_merge_state_back_to_parent():
+    parent = OrchestrationEngine()
+    sub1 = OrchestrationEngine()
+    sub2 = OrchestrationEngine()
+
+    def inner(state: GraphState) -> GraphState:
+        state.update({"flag": True})
+        state.scratchpad["order"].append("inner")
+        return state
+
+    sub2.add_node("inner", inner)
+
+    def sub1_start(state: GraphState) -> GraphState:
+        state.scratchpad["order"].append("sub1_start")
+        return state
+
+    sub1.add_node("sub1_start", sub1_start)
+    sub1.add_subgraph("inner_sub", sub2)
+
+    def sub1_end(state: GraphState) -> GraphState:
+        state.scratchpad["order"].append("sub1_end")
+        return state
+
+    sub1.add_node("sub1_end", sub1_end)
+    sub1.add_edge("sub1_start", "inner_sub")
+    sub1.add_edge("inner_sub", "sub1_end")
+
+    def start(state: GraphState, sp: dict) -> GraphState:
+        sp["order"] = ["start"]
+        return state
+
+    def finish(state: GraphState, sp: dict) -> GraphState:
+        sp["order"].append("finish")
+        return state
+
+    parent.add_node("start", start)
+    parent.add_subgraph("sub", sub1)
+    parent.add_node("finish", finish)
+    parent.add_edge("start", "sub")
+    parent.add_edge("sub", "finish")
+
+    result = asyncio.run(parent.run_async(GraphState()))
+    assert result.data["flag"] is True
+    assert result.scratchpad["order"] == [
+        "start",
+        "sub1_start",
+        "inner",
+        "sub1_end",
+        "finish",
+    ]


### PR DESCRIPTION
## Summary
- propagate subgraph scratchpad updates up to the parent state
- merge child state back into parent in `OrchestrationEngine`
- test nested subgraph state propagation

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68514bf304b0832a85e426559da696d9