### PR TITLE
Implement persistent semantic memory via Neo4j backend

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -33,4 +33,5 @@ datasets==3.6.0
 lxml_html_clean==0.4.2
 SQLAlchemy==2.0.29
 asyncpg==0.29.0
+neo4j==5.19.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,5 @@ lxml_html_clean==0.4.2
 trafilatura==2.0.0
 SQLAlchemy==2.0.29
 asyncpg==0.29.0
+neo4j==5.19.0
 

--- a/tests/test_semantic_memory_persistence.py
+++ b/tests/test_semantic_memory_persistence.py
@@ -1,0 +1,25 @@
+import os
+
+import pytest
+
+from services.ltm_service.semantic_memory import SemanticMemoryService
+
+
+def test_semantic_memory_persists_between_instances():
+    if not (
+        os.getenv("NEO4J_URI")
+        and os.getenv("NEO4J_USER")
+        and os.getenv("NEO4J_PASSWORD")
+    ):
+        pytest.skip("neo4j not configured")
+
+    service = SemanticMemoryService()
+    rec_id = service.store_fact("A", "REL", "B")
+    service.close()
+
+    service = SemanticMemoryService()
+    results = service.query_facts(subject="A", predicate="REL", object="B")
+    service.forget_fact(rec_id, hard=True)
+    service.close()
+
+    assert any(r["id"] == rec_id for r in results)


### PR DESCRIPTION
## Summary
- implement a Neo4j-backed `SemanticMemoryService`
- add optional Neo4j dependency and environment config
- add integration test for persistence across instances

## Testing
- `pre-commit run --files services/ltm_service/semantic_memory.py tests/test_semantic_memory_persistence.py requirements.txt constraints.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68514ec0143c832a995cad1ecf93b869