### PR TITLE
Add locking and concurrency stress test

### DIFF
--- a/engine/collaboration/group_chat.py
+++ b/engine/collaboration/group_chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from threading import Lock
 from typing import Any, Awaitable, Callable, DefaultDict, Dict, List, Optional
 
 from ..state import State
@@ -14,7 +15,9 @@ from .message_protocol import ChatMessage
 class DynamicGroupChat:
     """Simple in-memory group chat with a shared workspace and scratchpad."""
 
-    def __init__(self, shared_workspace: Dict[str, Any]) -> None:
+    def __init__(
+        self, shared_workspace: Dict[str, Any], *, enable_lock: bool = False
+    ) -> None:
         """Initialize the collaborative environment."""
         self.shared_workspace = shared_workspace
         self.message_history: List[Dict[str, Any]] = []
@@ -23,6 +26,7 @@ class DynamicGroupChat:
         self.roles: Dict[str, str] = {}
         self.scratchpad: Dict[str, Any] = {}
         self._state: State | None = None
+        self._lock: Lock | None = Lock() if enable_lock else None
 
     def facilitate_team_collaboration(
         self, team_composition: List[Dict[str, str] | str], task_context: Dict[str, Any]
@@ -53,13 +57,39 @@ class DynamicGroupChat:
 
     def write_scratchpad(self, key: str, value: Any) -> None:
         """Write a value to the shared scratchpad and State."""
-        self.scratchpad[key] = value
-        if self._state is not None:
-            self._state.scratchpad[key] = value
+        if self._lock:
+            with self._lock:
+                self.scratchpad[key] = value
+                if self._state is not None:
+                    self._state.scratchpad[key] = value
+        else:
+            self.scratchpad[key] = value
+            if self._state is not None:
+                self._state.scratchpad[key] = value
 
     def read_scratchpad(self, key: str) -> Any | None:
         """Return an entry from the shared scratchpad."""
+        if self._lock:
+            with self._lock:
+                return self.scratchpad.get(key)
         return self.scratchpad.get(key)
+
+    def update_scratchpad(
+        self, key: str, update_fn: Callable[[Any | None], Any]
+    ) -> Any:
+        """Atomically update a scratchpad entry using ``update_fn``."""
+        if self._lock:
+            with self._lock:
+                new_value = update_fn(self.scratchpad.get(key))
+                self.scratchpad[key] = new_value
+                if self._state is not None:
+                    self._state.scratchpad[key] = new_value
+                return new_value
+        new_value = update_fn(self.scratchpad.get(key))
+        self.scratchpad[key] = new_value
+        if self._state is not None:
+            self._state.scratchpad[key] = new_value
+        return new_value
 
     def post_message(
         self,
@@ -76,23 +106,41 @@ class DynamicGroupChat:
             type=message_type,
             recipient=recipient,
         ).model_dump()
-        self.message_history.append(msg)
-        if recipient:
-            self.inboxes[recipient].append(msg)
+        if self._lock:
+            with self._lock:
+                self.message_history.append(msg)
+                if recipient:
+                    self.inboxes[recipient].append(msg)
+                else:
+                    for agent in self.turn_queue:
+                        if agent != sender:
+                            self.inboxes[agent].append(msg)
         else:
-            for agent in self.turn_queue:
-                if agent != sender:
-                    self.inboxes[agent].append(msg)
+            self.message_history.append(msg)
+            if recipient:
+                self.inboxes[recipient].append(msg)
+            else:
+                for agent in self.turn_queue:
+                    if agent != sender:
+                        self.inboxes[agent].append(msg)
 
     def get_messages(self, agent_id: str) -> List[Dict[str, Any]]:
         """Return and clear the pending messages for the agent."""
-        msgs = self.inboxes.pop(agent_id, [])
+        if self._lock:
+            with self._lock:
+                msgs = self.inboxes.pop(agent_id, [])
+        else:
+            msgs = self.inboxes.pop(agent_id, [])
         return [ChatMessage.model_validate(m).model_dump() for m in msgs]
 
     def update_workspace(self, agent_id: str, key: str, value: Any) -> None:
         """Update the shared workspace if permitted."""
         # Placeholder for role-based permissions; all agents may write for now.
-        self.shared_workspace[key] = value
+        if self._lock:
+            with self._lock:
+                self.shared_workspace[key] = value
+        else:
+            self.shared_workspace[key] = value
 
     def resolve_conflicts(self, key: str, value1: Any, value2: Any) -> Any:
         """Simple last-write-wins conflict resolution."""
@@ -114,10 +162,11 @@ class GroupChatManager:
         *,
         max_turns: int = 10,
         shared_workspace: Optional[Dict[str, Any]] = None,
+        enable_lock: bool = False,
     ) -> None:
         self.agents = agents
         self.max_turns = max_turns
-        self.chat = DynamicGroupChat(shared_workspace or {})
+        self.chat = DynamicGroupChat(shared_workspace or {}, enable_lock=enable_lock)
         self.turn_order = list(agents)
 
     async def run(self, state: "State") -> "State":

--- a/tests/test_group_chat_concurrency.py
+++ b/tests/test_group_chat_concurrency.py
@@ -1,0 +1,24 @@
+import asyncio
+import pytest
+
+from engine.collaboration.group_chat import DynamicGroupChat
+from engine.state import State
+
+pytestmark = pytest.mark.core
+
+
+@pytest.mark.asyncio
+async def test_concurrent_scratchpad_updates():
+    state = State()
+    chat = DynamicGroupChat({}, enable_lock=True)
+    chat.bind_state(state)
+    chat.write_scratchpad("count", 0)
+
+    async def worker():
+        await asyncio.sleep(0)
+        chat.update_scratchpad("count", lambda v: (v or 0) + 1)
+
+    await asyncio.gather(*(worker() for _ in range(200)))
+
+    assert chat.read_scratchpad("count") == 200
+    assert state.scratchpad["count"] == 200


### PR DESCRIPTION
## Summary
- enable optional locking in `DynamicGroupChat`
- allow `GroupChatManager` to enable locking
- add an atomic scratchpad update helper
- test many concurrent scratchpad writers for consistency

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851514d2fb8832a95ac5f314a5e416e