### PR TITLE
Refine CI workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
@@ -54,6 +52,11 @@ jobs:
         run: pre-commit run --all-files
 
   integration:
+    needs: changes
+    if: |
+      needs.changes.outputs.core == 'true' ||
+      needs.changes.outputs.judge == 'true' ||
+      needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/audit/ci_cd.md
+++ b/docs/audit/ci_cd.md
@@ -6,9 +6,9 @@ This document outlines the findings of the audit of the Continuous Integration (
 
 The repository utilizes GitHub Actions for its CI/CD processes. Key workflows include:
 
-*   **`ci.yml`**: The main CI pipeline triggered on pull requests and pushes to `main`. It performs linting, runs a comprehensive test suite (including integration tests with coverage reporting via `pytest --cov`), core system tests, and a security dependency check using `pip-audit`. Coverage reports and test logs are uploaded as artifacts.
+*   **`ci.yml`**: The main CI pipeline triggered on pushes to `main`, on a nightly schedule, or manually. It performs linting, runs a comprehensive test suite (including integration tests with coverage reporting via `pytest --cov`), core system tests, and a security dependency check using `pip-audit`. Coverage reports and test logs are uploaded as artifacts.
 *   **`cd.yml`**: Manages deployments. It deploys to a 'staging' environment automatically on pushes to `main` and allows for manual promotion to 'production' via `workflow_dispatch`. The deployment process uses Terraform and Helm, orchestrated by `scripts/deploy.sh`.
-*   **`minimal-ci.yml`**: A lighter CI workflow, also triggered on pushes to `main` and pull requests (and manually). It runs linters and the test suite with coverage, similar to `ci.yml` but potentially with a subset of tests or a faster execution path. It also uploads a coverage report.
+*   **`minimal-ci.yml`**: A lighter CI workflow triggered on pull requests (and manually). It runs linters and the test suite with coverage, similar to `ci.yml` but with a faster execution path. It also uploads a coverage report.
 *   **`dependency-audit.yml`**: A dedicated workflow for dependency checking, running `pip-audit` weekly and on demand. It automatically creates a GitHub issue if vulnerabilities are detected.
 *   **`judge-pipeline.yml`**: Runs tests specifically for the 'judge' pipeline, triggered by changes to its dedicated paths (`pipelines/judge/**`, `data/golden_judge_dataset/**`), on a schedule, or manually.
 *   **`codex-sync.yml`**: Validates `.codex/queue.yml` on pull requests affecting this file.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,8 +1,7 @@
 # Continuous Integration Guidelines
 
-This project uses GitHub Actions to run tests and code quality checks on every pull request.
-The main workflow is defined in `.github/workflows/ci.yml` and ensures that all
-linters pass and the full test suite runs with coverage enabled.
+This project uses GitHub Actions to run tests and code quality checks on every pull request via the `minimal-ci.yml` workflow.
+The full workflow defined in `.github/workflows/ci.yml` runs when changes are merged to `main` (or on the nightly schedule) and ensures that all linters pass and the complete test suite runs with coverage enabled.
 
 ## Coverage Gates
 


### PR DESCRIPTION
## Summary
- limit `ci.yml` to run on pushes to `main`, nightly, or manual runs
- run `integration` job only when relevant paths change
- document updated triggers in CI docs

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685150e1b5d4832a8ad70c45d899c28d