### PR TITLE
Implement Reputation feedback integration

### DIFF
--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -21,6 +21,7 @@ from tools import (
     html_scraper,
     knowledge_graph_search,
     pdf_extract,
+    publish_reputation_event,
     retrieve_memory,
     summarize_text,
     web_search,
@@ -171,6 +172,7 @@ DEFAULT_TOOLS: Dict[str, Callable[..., object]] = {
     "code_interpreter": code_interpreter,
     "knowledge_graph_search": knowledge_graph_search,
     "github_search": github_search,
+    "reputation_event": publish_reputation_event,
 }
 
 

--- a/services/tool_registry/config.yml
+++ b/services/tool_registry/config.yml
@@ -20,4 +20,6 @@ permissions:
   knowledge_graph_search:
     - Supervisor
     - WebResearcher
+  reputation_event:
+    - Evaluator
 

--- a/tests/test_evaluator_reputation_integration.py
+++ b/tests/test_evaluator_reputation_integration.py
@@ -1,0 +1,38 @@
+import importlib
+from typing import Any
+
+from agents.evaluator import EvaluatorAgent
+
+rc = importlib.import_module("tools.reputation_client")
+
+
+class DummyResp:
+    def __init__(self) -> None:
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> Any:
+        return {"evaluation_id": "1"}
+
+
+def test_evaluator_publishes_reputation(monkeypatch):
+    calls = {}
+
+    def fake_post(url: str, json: Any, headers: Any, timeout: int) -> DummyResp:
+        calls.update(json)
+        return DummyResp()
+
+    monkeypatch.setattr(rc.requests, "post", fake_post)
+    agent = EvaluatorAgent()
+    agent.evaluate_and_publish(
+        {"text": "a"},
+        {},
+        task_id="w1",
+        worker_agent_id="A1",
+        evaluator_id="E1",
+        is_final=True,
+    )
+    assert calls.get("agent_id") == "A1"
+    assert calls.get("workflow_id") == "w1"

--- a/tests/test_reputation_client.py
+++ b/tests/test_reputation_client.py
@@ -1,0 +1,43 @@
+import importlib
+from typing import Any
+
+import pytest
+
+rc = importlib.import_module("tools.reputation_client")
+
+
+class DummyResp:
+    def __init__(self, data: Any) -> None:
+        self._data = data
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> Any:
+        return self._data
+
+
+def test_publish_reputation_event(monkeypatch):
+    def fake_post(url: str, json: Any, headers: Any, timeout: int) -> DummyResp:
+        assert json["agent_id"] == "A"
+        assert "Authorization" in headers
+        return DummyResp({"evaluation_id": "1"})
+
+    monkeypatch.setattr(rc.requests, "post", fake_post)
+    result = rc.publish_reputation_event({"agent_id": "A"})
+    assert result == "1"
+
+
+def test_publish_reputation_event_retries(monkeypatch):
+    calls = []
+
+    def fake_post(url: str, json: Any, headers: Any, timeout: int) -> DummyResp:
+        calls.append(1)
+        raise rc.requests.RequestException("fail")
+
+    monkeypatch.setattr(rc.requests, "post", fake_post)
+    monkeypatch.setattr(rc.time, "sleep", lambda s: None)
+    with pytest.raises(ValueError):
+        rc.publish_reputation_event({"agent_id": "A"}, retries=2)
+    assert len(calls) == 3

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -8,6 +8,7 @@ from .html_scraper import html_scraper
 from .knowledge_graph_search import knowledge_graph_search
 from .ltm_client import consolidate_memory, retrieve_memory
 from .pdf_reader import pdf_extract
+from .reputation_client import publish_reputation_event
 from .summarizer import summarize_text
 
 __all__ = [
@@ -21,4 +22,5 @@ __all__ = [
     "summarize_text",
     "fact_check_claim",
     "code_interpreter",
+    "publish_reputation_event",
 ]

--- a/tools/reputation_client.py
+++ b/tools/reputation_client.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Client for publishing reputation events to the Reputation Service."""
+
+import os
+import time
+from typing import Any, Dict, Optional
+
+import requests
+
+
+def _endpoint(url: Optional[str]) -> str:
+    return url or os.getenv(
+        "REPUTATION_API_URL", "http://localhost:8000/api/v1/evaluations"
+    )
+
+
+def _token(tok: Optional[str]) -> str | None:
+    return tok or os.getenv("REPUTATION_API_TOKEN")
+
+
+def publish_reputation_event(
+    payload: Dict[str, Any],
+    *,
+    url: Optional[str] = None,
+    token: Optional[str] = None,
+    retries: int = 2,
+    backoff: float = 1.0,
+) -> str:
+    """Send a reputation feedback event to the service."""
+
+    endpoint = _endpoint(url)
+    headers = {}
+    tok = _token(token)
+    if tok:
+        headers["Authorization"] = f"Bearer {tok}"
+
+    for attempt in range(retries + 1):
+        try:
+            resp = requests.post(endpoint, json=payload, headers=headers, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("evaluation_id", "")
+        except requests.RequestException as exc:
+            if attempt >= retries:
+                raise ValueError(f"Failed to publish reputation event: {exc}") from exc
+            time.sleep(backoff * 2**attempt)


### PR DESCRIPTION
## Summary
- add ReputationClient tool for publishing evaluation events
- register ReputationClient in ToolRegistry and grant Evaluator access
- update EvaluatorAgent to send reputation events after publishing EvaluationCompletedEvent
- tests for client retry logic and Evaluator integration

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515957dfd8832aae6bcc3c5d8bd007