### PR TITLE
Add semantic_consolidate endpoint

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -250,3 +250,9 @@
   - Validate schemas and benchmark pipelines
   - Record gaps and follow-up CRs
   title: End-to-End Integration & Pipeline Audit
+- acceptance_criteria:
+  - Neo4j consolidation endpoint stores triples
+  id: CR-P4-07A2
+  priority: high
+  steps: []
+  title: Add Neo4j consolidation for semantic memory

--- a/agents/memory_manager.py
+++ b/agents/memory_manager.py
@@ -149,9 +149,8 @@ class MemoryManagerAgent:
             for triple in self._extract_triples(state):
                 self.tool_registry.invoke(
                     "MemoryManager",
-                    "consolidate_memory",
-                    triple,
-                    memory_type="semantic",
+                    "semantic_consolidate",
+                    {"payload": triple, "format": "jsonld"},
                     endpoint=self.endpoint,
                 )
         except Exception:  # pragma: no cover - log only

--- a/docs/integration_audit.md
+++ b/docs/integration_audit.md
@@ -53,7 +53,7 @@ All measurements meet the <300 ms P95 target with negligible error rates.
 |------|--------|-------|
 | User → Supervisor → Planner → MemoryManager → Evaluator | ✅ Implemented | Covered by existing E2E tests and docs |
 | Continuous feedback loop with Reputation Service | ⚠ Partial | Event publishing hooks exist but Reputation integration is stubbed |
-| Semantic LTM graph consolidation | ❌ Missing | MemoryManager does not currently store relationships in Neo4j |
+| Semantic LTM graph consolidation | ✅ Implemented | `/semantic_consolidate` endpoint writes facts to Neo4j |
 
 ### Follow-up Change Requests
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -10,7 +10,6 @@ components:
           title: Memory Type
           type: string
         record:
-          additionalProperties: true
           description: Record to store
           title: Record
           type: object
@@ -41,15 +40,13 @@ components:
       properties:
         query:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           description: Query to match
           title: Query
         task_context:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           description: Deprecated alternative query field
           title: Task Context
@@ -60,13 +57,40 @@ components:
         results:
           description: Matching records
           items:
-            additionalProperties: true
             type: object
           title: Results
           type: array
       required:
       - results
       title: RetrieveResponse
+      type: object
+    SemanticConsolidateRequest:
+      properties:
+        format:
+          default: jsonld
+          description: Payload format
+          title: Format
+          type: string
+        payload:
+          anyOf:
+          - type: object
+          - type: string
+          description: JSON-LD object or Cypher string
+          title: Payload
+      required:
+      - payload
+      title: SemanticConsolidateRequest
+      type: object
+    SemanticConsolidateResponse:
+      properties:
+        result:
+          description: Results from consolidation
+          items: {}
+          title: Result
+          type: array
+      required:
+      - result
+      title: SemanticConsolidateResponse
       type: object
     ValidationError:
       properties:
@@ -95,37 +119,6 @@ info:
 openapi: 3.1.0
 paths:
   /memory:
-    post:
-      operationId: create_memory_memory_post
-      parameters:
-      - in: header
-        name: x-role
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Role
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ConsolidateRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConsolidateResponse'
-          description: Successful Response
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-          description: Validation Error
-      summary: Store an experience
     get:
       operationId: get_memory_memory_get
       parameters:
@@ -172,3 +165,66 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Retrieve similar experiences
+    post:
+      operationId: create_memory_memory_post
+      parameters:
+      - in: header
+        name: x-role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConsolidateRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConsolidateResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Store an experience
+  /semantic_consolidate:
+    post:
+      operationId: semantic_consolidate_semantic_consolidate_post
+      parameters:
+      - in: header
+        name: x-role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SemanticConsolidateRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SemanticConsolidateResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Store facts in the knowledge graph

--- a/docs/semantic_memory_neo4j.md
+++ b/docs/semantic_memory_neo4j.md
@@ -56,3 +56,15 @@ collapsed into a single edge.
 
 Once connected, the LTM service can call `store_fact()` whenever the
 MemoryManager extracts a new fact from verified research outputs.
+
+## API endpoint
+
+Facts can also be written via the `/semantic_consolidate` HTTP endpoint of the
+LTM service. Send either a JSON-LD object describing the triple or a raw Cypher
+statement:
+
+```bash
+curl -X POST http://localhost:8081/semantic_consolidate \
+     -H 'Content-Type: application/json' \
+     -d '{"payload": {"subject": "Transformer", "predicate": "IS_A", "object": "Model"}}'
+```

--- a/services/ltm_service/generate_spec.py
+++ b/services/ltm_service/generate_spec.py
@@ -21,6 +21,9 @@ class Dummy:
     def retrieve(self, memory_type, query, limit=5):
         return []
 
+    def semantic_consolidate(self, payload, fmt="jsonld"):
+        return []
+
 
 app = module.create_app(Dummy())
 path = pathlib.Path(__file__).resolve().parents[2] / "docs" / "openapi.yaml"

--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -22,6 +22,7 @@ from tools import (
     knowledge_graph_search,
     pdf_extract,
     retrieve_memory,
+    semantic_consolidate,
     summarize_text,
     web_search,
 )
@@ -166,6 +167,7 @@ DEFAULT_TOOLS: Dict[str, Callable[..., object]] = {
     "html_scraper": html_scraper,
     "consolidate_memory": consolidate_memory,
     "retrieve_memory": retrieve_memory,
+    "semantic_consolidate": semantic_consolidate,
     "summarize": summarize_text,
     "fact_check": fact_check_claim,
     "code_interpreter": code_interpreter,

--- a/services/tool_registry/config.yml
+++ b/services/tool_registry/config.yml
@@ -7,6 +7,8 @@ permissions:
     - WebResearcher
   consolidate_memory:
     - MemoryManager
+  semantic_consolidate:
+    - MemoryManager
   retrieve_memory:
     - MemoryManager
     - WebResearcher

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -6,13 +6,14 @@ from .fact_check import fact_check_claim
 from .github_search import github_search
 from .html_scraper import html_scraper
 from .knowledge_graph_search import knowledge_graph_search
-from .ltm_client import consolidate_memory, retrieve_memory
+from .ltm_client import consolidate_memory, retrieve_memory, semantic_consolidate
 from .pdf_reader import pdf_extract
 from .summarizer import summarize_text
 
 __all__ = [
     "consolidate_memory",
     "retrieve_memory",
+    "semantic_consolidate",
     "web_search",
     "github_search",
     "knowledge_graph_search",

--- a/tools/ltm_client.py
+++ b/tools/ltm_client.py
@@ -61,3 +61,28 @@ def retrieve_memory(
             if attempt >= retries:
                 raise ValueError(f"Memory retrieval failed: {exc}") from exc
             time.sleep(backoff * 2**attempt)
+
+
+def semantic_consolidate(
+    payload: Dict | str,
+    *,
+    fmt: str = "jsonld",
+    endpoint: Optional[str] = None,
+    retries: int = 2,
+    backoff: float = 1.0,
+) -> List:
+    url = f"{_endpoint(endpoint)}/semantic_consolidate"
+    for attempt in range(retries + 1):
+        try:
+            resp = requests.post(
+                url,
+                json={"payload": payload, "format": fmt},
+                headers={"X-Role": "editor"},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            return resp.json().get("result", [])
+        except requests.RequestException as exc:
+            if attempt >= retries:
+                raise ValueError(f"Semantic consolidation failed: {exc}") from exc
+            time.sleep(backoff * 2**attempt)


### PR DESCRIPTION
## Summary
- extend SemanticMemoryService with cypher and JSON-LD helpers
- support `/semantic_consolidate` in the LTM service and OpenAPI spec
- register new tool and permissions for MemoryManager
- update MemoryManager agent to use the new endpoint
- document Neo4j API usage and mark consolidation as implemented
- sync codex queue with CR-P4-07A2

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685159576318832ab5dfaf93bf42593e