### PR TITLE
Implement validation logging and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
       - name: Summarize failures
         if: always()
         run: python scripts/ci_summary.py tests.log coverage.xml
+      - name: Check validation errors
+        run: python scripts/check_validation_errors.py tests.log
       - name: Fail if tests failed
         if: steps.run-tests.outputs.exitcode != '0'
         run: exit 1

--- a/scripts/check_validation_errors.py
+++ b/scripts/check_validation_errors.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+
+def main(path: str = "tests.log", threshold: int = 5) -> int:
+    log = Path(path)
+    if not log.is_file():
+        print(f"Log not found: {log}", file=sys.stderr)
+        return 0
+    text = log.read_text()
+    count = text.count("InputValidationError")
+    if count > threshold:
+        print(
+            f"Validation errors exceeded threshold: {count} > {threshold}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Validation errors: {count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(*(sys.argv[1:])))

--- a/tests/test_validation_logging.py
+++ b/tests/test_validation_logging.py
@@ -1,0 +1,15 @@
+import logging
+
+import pytest
+
+from tools.validation import InputValidationError, validate_path_or_url
+
+
+def test_log_invalid_path(caplog):
+    caplog.set_level(logging.WARNING)
+    with pytest.raises(InputValidationError):
+        validate_path_or_url("../secret.txt")
+    assert any(
+        "InputValidationError" in r.message and "../secret.txt" in r.message
+        for r in caplog.records
+    )

--- a/tools/validation.py
+++ b/tools/validation.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 """Utilities for validating user-provided file paths and URLs."""
 
+import datetime
+import inspect
+import logging
 import os
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
 ALLOWED_SCHEMES = {"http", "https", "file"}
+
+
+logger = logging.getLogger("security.audit")
 
 
 class InputValidationError(ValueError):
@@ -35,23 +41,29 @@ def validate_path_or_url(target: str, allowed_schemes: set[str] | None = None) -
     InputValidationError
         If the scheme is not allowed or path normalization indicates directory traversal.
     """
-    allowed_schemes = allowed_schemes or ALLOWED_SCHEMES
-    parsed = urlparse(target)
-    scheme = parsed.scheme.lower()
-    if scheme and scheme not in allowed_schemes:
-        raise InputValidationError(f"Invalid URL scheme: {scheme} (HTTP 400)")
+    try:
+        allowed_schemes = allowed_schemes or ALLOWED_SCHEMES
+        parsed = urlparse(target)
+        scheme = parsed.scheme.lower()
+        if scheme and scheme not in allowed_schemes:
+            raise InputValidationError(f"Invalid URL scheme: {scheme} (HTTP 400)")
 
-    if scheme in {"http", "https"}:
-        return target
+        if scheme in {"http", "https"}:
+            return target
 
-    path = unquote(parsed.path) if scheme == "file" else target
-    if ".." in Path(path).parts:
-        raise InputValidationError(
-            "Invalid path: directory traversal detected (HTTP 400)"
-        )
-    normalized = os.path.normpath(path)
-    if ".." in Path(normalized).parts:
-        raise InputValidationError(
-            "Invalid path: directory traversal detected (HTTP 400)"
-        )
-    return normalized
+        path = unquote(parsed.path) if scheme == "file" else target
+        if ".." in Path(path).parts:
+            raise InputValidationError(
+                "Invalid path: directory traversal detected (HTTP 400)"
+            )
+        normalized = os.path.normpath(path)
+        if ".." in Path(normalized).parts:
+            raise InputValidationError(
+                "Invalid path: directory traversal detected (HTTP 400)"
+            )
+        return normalized
+    except InputValidationError:
+        caller = inspect.stack()[1].function
+        ts = datetime.datetime.now(datetime.UTC).isoformat()
+        logger.warning("InputValidationError: %r in %s at %s", target, caller, ts)
+        raise


### PR DESCRIPTION
## Summary
- log path validation failures in `validate_path_or_url`
- add a script to check validation errors in logs
- fail CI when too many validation errors are logged
- test that invalid paths raise and log

## Testing
- `pre-commit run --files tools/validation.py scripts/check_validation_errors.py tests/test_validation_logging.py .github/workflows/ci.yml`
- `pytest -q tests/test_validation_logging.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515cec4024832ab3d22e98842551df