### PR TITLE
Implement subgraph propagation in LTM

### DIFF
--- a/agents/memory_manager.py
+++ b/agents/memory_manager.py
@@ -153,6 +153,15 @@ class MemoryManagerAgent:
                     {"payload": triple, "format": "jsonld"},
                     endpoint=self.endpoint,
                 )
+            entities = state.data.get("entities")
+            relations = state.data.get("relations")
+            if isinstance(entities, list) and isinstance(relations, list):
+                self.tool_registry.invoke(
+                    "MemoryManager",
+                    "propagate_subgraph",
+                    {"entities": entities, "relations": relations},
+                    endpoint=self.endpoint,
+                )
         except Exception:  # pragma: no cover - log only
             logger.exception("Failed to consolidate memory")
         return state

--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -24,6 +24,7 @@ from tools import (
     publish_reputation_event,
     retrieve_memory,
     semantic_consolidate,
+    propagate_subgraph,
     summarize_text,
     web_search,
 )
@@ -169,6 +170,7 @@ DEFAULT_TOOLS: Dict[str, Callable[..., object]] = {
     "consolidate_memory": consolidate_memory,
     "retrieve_memory": retrieve_memory,
     "semantic_consolidate": semantic_consolidate,
+    "propagate_subgraph": propagate_subgraph,
     "summarize": summarize_text,
     "fact_check": fact_check_claim,
     "code_interpreter": code_interpreter,

--- a/tests/test_ltm_service_api.py
+++ b/tests/test_ltm_service_api.py
@@ -135,3 +135,21 @@ def test_schema_validation_and_forget():
     assert not resp.json()["results"]
 
     server.httpd.shutdown()
+
+
+def test_propagate_subgraph_endpoint():
+    server, endpoint = _start_server()
+    subgraph = {
+        "entities": [{"id": "E1"}, {"id": "E2"}],
+        "relations": [
+            {"subject": "E1", "predicate": "LINKS_TO", "object": "E2"}
+        ],
+    }
+    resp = requests.post(f"{endpoint}/propagate_subgraph", json=subgraph)
+    assert resp.status_code == 200
+    stored = server.service.retrieve(
+        "semantic",
+        {"subject": "E1", "predicate": "LINKS_TO", "object": "E2"},
+    )
+    assert stored
+    server.httpd.shutdown()

--- a/tests/test_subgraph_state_propagation.py
+++ b/tests/test_subgraph_state_propagation.py
@@ -1,0 +1,51 @@
+import asyncio
+from threading import Thread
+
+from agents.memory_manager import MemoryManagerAgent
+from engine.orchestration_engine import GraphState, create_orchestration_engine
+from services.ltm_service import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.api import LTMService, LTMServiceServer
+from services.tool_registry import create_default_registry
+
+
+def _start_server():
+    storage = InMemoryStorage()
+    service = LTMService(EpisodicMemoryService(storage))
+    server = LTMServiceServer(service, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.httpd.server_port}"
+    return server, endpoint
+
+
+def test_subgraph_propagation_and_continuity():
+    server, endpoint = _start_server()
+    mm = MemoryManagerAgent(endpoint=endpoint, tool_registry=create_default_registry())
+
+    engine = create_orchestration_engine(memory_manager=mm)
+
+    def step_one(state: GraphState, sp: dict) -> GraphState:
+        state.data["entities"] = [{"id": "E1"}]
+        return state
+
+    def step_two(state: GraphState, sp: dict) -> GraphState:
+        state.data.setdefault("entities", []).append({"id": "E2"})
+        state.data["relations"] = [
+            {"subject": "E1", "predicate": "LINKS_TO", "object": "E2"}
+        ]
+        return state
+
+    engine.add_node("A", step_one)
+    engine.add_node("B", step_two)
+    engine.add_edge("A", "B")
+
+    final = asyncio.run(engine.run_async(GraphState()))
+    assert {"id": "E1"} in final.data["entities"]
+    assert {"id": "E2"} in final.data["entities"]
+
+    stored = server.service.retrieve(
+        "semantic",
+        {"subject": "E1", "predicate": "LINKS_TO", "object": "E2"},
+    )
+    assert stored
+    server.httpd.shutdown()

--- a/tools/ltm_client.py
+++ b/tools/ltm_client.py
@@ -86,3 +86,27 @@ def semantic_consolidate(
             if attempt >= retries:
                 raise ValueError(f"Semantic consolidation failed: {exc}") from exc
             time.sleep(backoff * 2**attempt)
+
+def propagate_subgraph(
+    subgraph: Dict,
+    *,
+    endpoint: Optional[str] = None,
+    retries: int = 2,
+    backoff: float = 1.0,
+) -> List[str]:
+    """Send a subgraph consisting of entities and relations to the LTM service."""
+    url = f"{_endpoint(endpoint)}/propagate_subgraph"
+    for attempt in range(retries + 1):
+        try:
+            resp = requests.post(
+                url,
+                json=subgraph,
+                headers={"X-Role": "editor"},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            return resp.json().get("ids", [])
+        except requests.RequestException as exc:
+            if attempt >= retries:
+                raise ValueError(f"Subgraph propagation failed: {exc}") from exc
+            time.sleep(backoff * 2**attempt)


### PR DESCRIPTION
## Summary
- add propagate_subgraph to LTM client and server
- expose new tool through ToolRegistry
- MemoryManager propagates entities and relations
- OpenAPI app documents new endpoint
- test LTM server and end-to-end subgraph propagation

## Testing
- `bash scripts/agent-setup.sh` *(failed: pip install issues)*
- `pre-commit run --files agents/memory_manager.py tools/ltm_client.py services/tool_registry/__init__.py services/ltm_service/api.py services/ltm_service/openapi_app.py tests/test_ltm_service_api.py tests/test_subgraph_state_propagation.py` *(failed: command not found)*
- `pytest -q tests/test_ltm_service_api.py tests/test_subgraph_state_propagation.py` *(failed: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68515cf9b514832a84c39dae1c2c9e29