### PR TITLE
Add SQL connector tools

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -329,3 +329,13 @@
   priority: high
   steps: []
   title: Add Neo4j consolidation for semantic memory
+- acceptance_criteria:
+  - SELECT queries on SQLite return DataFrame results
+  - Parameterized queries on Postgres return correct results
+  id: CR-P4-17R
+  priority: medium
+  steps:
+  - Implement SqliteQueryTool and PostgresQueryTool classes
+  - Register tools in the registry with RBAC roles
+  - Add tests spinning up SQLite and Postgres instances
+  title: Add Specialized DB Connectors

--- a/codex_tasks.md
+++ b/codex_tasks.md
@@ -1532,3 +1532,15 @@ acceptance_criteria:
   - CI shows coverage >= 95%
   - Follow-up CRs listed for partial or missing flows
 ```
+```codex-task
+id: CR-P4-17R
+title: Add Specialized DB Connectors
+priority: medium
+steps:
+  - Implement SqliteQueryTool and PostgresQueryTool classes
+  - Register tools in the registry with RBAC roles
+  - Add tests spinning up SQLite and Postgres instances
+acceptance_criteria:
+  - SELECT queries on SQLite return DataFrame results
+  - Parameterized queries on Postgres return correct results
+```

--- a/constraints.txt
+++ b/constraints.txt
@@ -31,6 +31,8 @@ sentence-transformers==2.6.1
 tenacity==8.2.3
 datasets==3.6.0
 lxml_html_clean==0.4.2
+pandas==2.2.2
+pgtest==1.3.2
 SQLAlchemy==2.0.29
 asyncpg==0.29.0
 neo4j==5.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,8 @@ tenacity==8.2.3
 datasets==3.6.0
 lxml_html_clean==0.4.2
 trafilatura==2.0.0
+pandas==2.2.2
+pgtest==1.3.2
 SQLAlchemy==2.0.29
 asyncpg==0.29.0
 neo4j==5.19.0

--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -14,6 +14,8 @@ from opentelemetry.trace import NonRecordingSpan, SpanContext
 
 from services.tracing.tracing_schema import ToolCallTrace
 from tools import (
+    PostgresQueryTool,
+    SqliteQueryTool,
     code_interpreter,
     consolidate_memory,
     fact_check_claim,
@@ -174,6 +176,8 @@ DEFAULT_TOOLS: Dict[str, Callable[..., object]] = {
     "code_interpreter": code_interpreter,
     "knowledge_graph_search": knowledge_graph_search,
     "github_search": github_search,
+    "sqlite_query": SqliteQueryTool,
+    "postgres_query": PostgresQueryTool,
     "reputation_event": publish_reputation_event,
 }
 

--- a/services/tool_registry/config.yml
+++ b/services/tool_registry/config.yml
@@ -19,6 +19,10 @@ permissions:
     - CodeResearcher
   github_search:
     - CodeResearcher
+  sqlite_query:
+    - CodeResearcher
+  postgres_query:
+    - CodeResearcher
   knowledge_graph_search:
     - Supervisor
     - WebResearcher

--- a/tests/test_sql_connectors.py
+++ b/tests/test_sql_connectors.py
@@ -1,0 +1,43 @@
+import shutil
+import sqlite3
+
+import asyncpg
+import pandas as pd
+import pytest
+
+from tools.postgres_query import PostgresQueryTool
+from tools.sqlite_query import SqliteQueryTool
+
+
+def test_sqlite_query(tmp_path):
+    db_file = tmp_path / "test.db"
+    conn = sqlite3.connect(db_file)
+    conn.execute("CREATE TABLE users(id INTEGER, name TEXT)")
+    conn.executemany("INSERT INTO users VALUES (?, ?)", [(1, "Alice"), (2, "Bob")])
+    conn.commit()
+    tool = SqliteQueryTool(str(db_file))
+    df = tool.run_query("SELECT name FROM users ORDER BY id")
+    assert isinstance(df, pd.DataFrame)
+    assert df["name"].tolist() == ["Alice", "Bob"]
+
+
+@pytest.mark.asyncio
+async def test_postgres_query():
+    pg_ctl = shutil.which("pg_ctl")
+    if not pg_ctl:
+        pytest.skip("pg_ctl not available")
+    import pgtest
+
+    with pgtest.PGTest(pg_ctl=pg_ctl) as pg:
+        tool = PostgresQueryTool(pg.url)
+        conn = await asyncpg.connect(pg.url)
+        await conn.execute("CREATE TABLE orders(id INT, status TEXT)")
+        await conn.executemany(
+            "INSERT INTO orders VALUES($1, $2)",
+            [(1, "open"), (2, "closed"), (3, "open")],
+        )
+        await conn.close()
+        df = await tool.run_query(
+            "SELECT count(*) FROM orders WHERE status=$1", ["open"]
+        )
+        assert df.iloc[0, 0] == 2

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -8,7 +8,9 @@ from .html_scraper import html_scraper
 from .knowledge_graph_search import knowledge_graph_search
 from .ltm_client import consolidate_memory, retrieve_memory, semantic_consolidate
 from .pdf_reader import pdf_extract
+from .postgres_query import PostgresQueryTool
 from .reputation_client import publish_reputation_event
+from .sqlite_query import SqliteQueryTool
 from .summarizer import summarize_text
 
 __all__ = [
@@ -23,5 +25,7 @@ __all__ = [
     "summarize_text",
     "fact_check_claim",
     "code_interpreter",
+    "SqliteQueryTool",
+    "PostgresQueryTool",
     "publish_reputation_event",
 ]

--- a/tools/postgres_query.py
+++ b/tools/postgres_query.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""PostgreSQL query helper returning pandas DataFrames."""
+
+from typing import Sequence
+
+import asyncpg
+import pandas as pd
+
+
+class PostgresQueryTool:
+    """Execute SQL queries against a PostgreSQL database using asyncpg."""
+
+    def __init__(self, dsn: str) -> None:
+        self.dsn = dsn
+
+    async def run_query(self, sql: str, params: Sequence | None = None) -> pd.DataFrame:
+        """Run a SQL query and return the results as a DataFrame."""
+        conn = await asyncpg.connect(self.dsn)
+        try:
+            records = await conn.fetch(sql, *(params or []))
+        finally:
+            await conn.close()
+        if not records:
+            return pd.DataFrame()
+        columns = records[0].keys()
+        rows = [tuple(r.values()) for r in records]
+        return pd.DataFrame(rows, columns=columns)

--- a/tools/sqlite_query.py
+++ b/tools/sqlite_query.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""SQLite query helper returning pandas DataFrames."""
+
+import sqlite3
+from typing import Sequence
+
+import pandas as pd
+
+
+class SqliteQueryTool:
+    """Execute read-only SQL queries against a SQLite database."""
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    def run_query(self, sql: str, params: Sequence | None = None) -> pd.DataFrame:
+        """Run a SQL query and return the results as a DataFrame."""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(sql, params or [])
+            rows = cursor.fetchall()
+            columns = [desc[0] for desc in cursor.description or []]
+        return pd.DataFrame(rows, columns=columns)


### PR DESCRIPTION
## Summary
- add SqliteQueryTool and PostgresQueryTool
- register DB connectors in tool registry config
- expose connectors through `tools` package
- update change request docs and queue
- add integration tests for the connectors

## Testing
- `bash scripts/agent-setup.sh`
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515d2601c4832a9dda792f74189f99