### PR TITLE
Add spatio-temporal consolidation endpoint

### DIFF
--- a/services/ltm_service/__init__.py
+++ b/services/ltm_service/__init__.py
@@ -5,7 +5,7 @@ from .embedding_client import EmbeddingClient, SimpleEmbeddingClient
 from .episodic_memory import EpisodicMemoryService, InMemoryStorage
 from .openapi_app import create_app
 from .procedural_memory import ProceduralMemoryService
-from .semantic_memory import SemanticMemoryService
+from .semantic_memory import SemanticMemoryService, SpatioTemporalMemoryService
 from .vector_store import InMemoryVectorStore, VectorStore, WeaviateVectorStore
 
 __all__ = [
@@ -16,6 +16,7 @@ __all__ = [
     "InMemoryStorage",
     "ProceduralMemoryService",
     "SemanticMemoryService",
+    "SpatioTemporalMemoryService",
     "EmbeddingClient",
     "SimpleEmbeddingClient",
     "VectorStore",

--- a/services/ltm_service/semantic_memory.py
+++ b/services/ltm_service/semantic_memory.py
@@ -289,6 +289,46 @@ class SpatioTemporalMemoryService(SemanticMemoryService):
                 fact.setdefault("history", []).append(version)
                 break
 
+    def merge_version(
+        self,
+        subject: str,
+        predicate: str,
+        obj: str,
+        *,
+        value: Any,
+        valid_from: float,
+        valid_to: float | None = None,
+        location: Any | None = None,
+    ) -> str:
+        """Store or update a fact with a new temporal version."""
+        if self._facts is None:
+            raise RuntimeError("No in-memory store configured")
+        for fact in self._facts:
+            if (
+                fact["subject"] == subject
+                and fact["predicate"] == predicate
+                and fact["object"] == obj
+            ):
+                self.add_version(
+                    fact["id"],
+                    value=value,
+                    valid_from=valid_from,
+                    valid_to=valid_to,
+                    location=location,
+                )
+                return fact["id"]
+        return self.store_fact(
+            subject,
+            predicate,
+            obj,
+            properties={
+                "value": value,
+                "valid_from": valid_from,
+                "valid_to": valid_to,
+                "location": location,
+            },
+        )
+
     def get_snapshot(self, *, valid_at: float, tx_at: float) -> List[Dict[str, Any]]:
         """Return facts that were valid at the given time with respect to a transaction time."""
         results: List[Dict[str, Any]] = []

--- a/tests/services/test_api.py
+++ b/tests/services/test_api.py
@@ -1,0 +1,65 @@
+from fastapi.testclient import TestClient
+
+from services.ltm_service.api import LTMService
+from services.ltm_service.episodic_memory import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.openapi_app import create_app
+from services.ltm_service.semantic_memory import SpatioTemporalMemoryService
+
+
+def _create_client():
+    service = LTMService(
+        EpisodicMemoryService(InMemoryStorage()),
+        semantic_memory=SpatioTemporalMemoryService(),
+    )
+    app = create_app(service)
+    client = TestClient(app)
+    return client, service
+
+
+def test_temporal_consolidate_merges_versions():
+    client, service = _create_client()
+
+    data1 = {
+        "subject": "S",
+        "predicate": "P",
+        "object": "O",
+        "value": "v1",
+        "valid_from": 0,
+        "valid_to": 50,
+        "location": {"lat": 1},
+    }
+
+    resp = client.post(
+        "/temporal_consolidate", json=data1, headers={"X-Role": "editor"}
+    )
+    assert resp.status_code == 200
+    fid = resp.json()["id"]
+
+    data2 = {
+        "subject": "S",
+        "predicate": "P",
+        "object": "O",
+        "value": "v2",
+        "valid_from": 50,
+        "valid_to": None,
+        "location": {"lat": 2},
+    }
+
+    resp = client.post(
+        "/temporal_consolidate", json=data2, headers={"X-Role": "editor"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == fid
+
+    facts = service.retrieve(
+        "semantic",
+        {"subject": "S", "predicate": "P", "object": "O"},
+        limit=1,
+    )
+    assert facts and len(facts[0]["history"]) == 2
+
+
+def test_openapi_contains_temporal_endpoint():
+    client, _ = _create_client()
+    schema = client.get("/docs/openapi.json").json()
+    assert "/temporal_consolidate" in schema["paths"]


### PR DESCRIPTION
## Summary
- extend semantic memory with merge_version helper
- add temporal_consolidate route in API and FastAPI app
- expose SpatioTemporalMemoryService from service package
- test temporal consolidation via FastAPI

## Testing
- `pre-commit run --files tests/services/test_api.py services/ltm_service/api.py services/ltm_service/openapi_app.py services/ltm_service/semantic_memory.py services/ltm_service/__init__.py`
- `pytest -q tests/services/test_api.py`

------
https://chatgpt.com/codex/tasks/task_e_685164fbf110832ab12a7608ec52197e