### PR TITLE
Add spatio-temporal planning and retrieval

### DIFF
--- a/agents/Planner/prompt.tpl.md
+++ b/agents/Planner/prompt.tpl.md
@@ -2,6 +2,11 @@
 
 Core directive: Generate optimized plans after Supervisor memory lookup.
 
+Include optional `time_range` and `bbox` fields when the query
+specifies a time interval or geographic scope. The `time_range` mapping
+should contain `valid_from` and `valid_to` keys. The `bbox` list must
+be `[min_lon, min_lat, max_lon, max_lat]`.
+
 ## Scratchpad Usage
 You may write intermediate data to the shared scratchpad under the key `<topic>`.
 Example write:

--- a/agents/Supervisor/prompt.tpl.md
+++ b/agents/Supervisor/prompt.tpl.md
@@ -10,6 +10,11 @@ The YAML **must** contain a top-level `graph` mapping with `nodes` and `edges`
 lists. Each node requires an `id` and `agent` field. Ensure the YAML parses
 correctly with no additional commentary.
 
+When the query references a particular time period or geographic region,
+add a top-level `time_range` and/or `bbox` field to the plan. `time_range`
+contains `valid_from` and `valid_to` timestamps. `bbox` should follow the
+`min_lon,min_lat,max_lon,max_lat` ordering.
+
 ## Scratchpad Usage
 You may write intermediate data to the shared scratchpad under the key `<topic>`.
 Example write:

--- a/docs/usage/spatio_temporal_examples.md
+++ b/docs/usage/spatio_temporal_examples.md
@@ -1,0 +1,34 @@
+# Spatio-Temporal Examples
+
+This guide demonstrates how research plans and the memory manager handle
+queries with explicit time ranges or locations.
+
+## Planning with Time and Location
+
+When a user asks:
+
+```
+Wildfire reports in Europe from 2010 to 2020
+```
+
+the Supervisor includes temporal and spatial fields in the YAML plan:
+
+```yaml
+bbox: [-10.0, 35.0, 30.0, 60.0]
+time_range:
+  valid_from: 2010
+  valid_to: 2020
+```
+
+## Memory Retrieval
+
+The MemoryManager reads these parameters and issues a request to the LTM
+service:
+
+```
+GET /spatial_query?bbox=-10.0,35.0,30.0,60.0&valid_from=2010&valid_to=2020
+```
+
+Results from the service are placed under `spatial_context` in the state
+for downstream agents to use. A snapshot query can be specified with a
+`snapshot` mapping containing `valid_at` and `tx_at` values.

--- a/services/ltm_service/api.py
+++ b/services/ltm_service/api.py
@@ -207,7 +207,6 @@ class LTMService:
             location=fact.get("location"),
         )
 
-
     def spatial_query(
         self, bbox: List[float], valid_from: float, valid_to: float
     ) -> List[Dict[str, Any]]:

--- a/services/ltm_service/openapi_app.py
+++ b/services/ltm_service/openapi_app.py
@@ -173,7 +173,6 @@ def create_app(service: LTMService) -> FastAPI:
         )
         return TemporalConsolidateResponse(id=fid)
 
-
     @app.get("/spatial_query", summary="Query facts by bounding box")
     async def spatial_query(
         bbox: str = Query(..., description="min_lon,min_lat,max_lon,max_lat"),

--- a/tests/test_spatio_temporal_retrieval.py
+++ b/tests/test_spatio_temporal_retrieval.py
@@ -1,0 +1,65 @@
+from threading import Thread
+
+import requests
+
+from agents.memory_manager import MemoryManagerAgent
+from engine.orchestration_engine import GraphState
+from services.ltm_service.api import LTMService, LTMServiceServer
+from services.ltm_service.episodic_memory import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.semantic_memory import SpatioTemporalMemoryService
+
+
+def _start_server():
+    service = LTMService(
+        EpisodicMemoryService(InMemoryStorage()),
+        semantic_memory=SpatioTemporalMemoryService(),
+    )
+    server = LTMServiceServer(service, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.httpd.server_port}"
+    return server, endpoint
+
+
+def test_memory_manager_spatial_query():
+    server, endpoint = _start_server()
+    mm = MemoryManagerAgent(endpoint=endpoint)
+
+    data1 = {
+        "subject": "S",
+        "predicate": "P",
+        "object": "O",
+        "value": "v1",
+        "valid_from": 0,
+        "valid_to": 20,
+        "location": {"lat": 1, "lon": 1},
+    }
+    requests.post(
+        f"{endpoint}/temporal_consolidate", json=data1, headers={"X-Role": "editor"}
+    )
+
+    data2 = {
+        "subject": "S",
+        "predicate": "P",
+        "object": "O",
+        "value": "v2",
+        "valid_from": 30,
+        "valid_to": 60,
+        "location": {"lat": 1.5, "lon": 1.5},
+    }
+    requests.post(
+        f"{endpoint}/temporal_consolidate", json=data2, headers={"X-Role": "editor"}
+    )
+
+    state = GraphState(
+        data={
+            "plan": {
+                "bbox": [0, 0, 2, 2],
+                "time_range": {"valid_from": 40, "valid_to": 50},
+            }
+        }
+    )
+    mm(state)
+    ctx = state.data.get("spatial_context")
+    assert ctx and ctx[0]["value"] == "v2"
+    server.httpd.shutdown()

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -298,3 +298,10 @@ def test_plan_includes_citation_agent():
     nodes = plan["graph"]["nodes"]
     assert nodes[-1]["agent"] == "CitationAgent"
     assert {"from": "synthesis", "to": "citation"} in plan["graph"]["edges"]
+
+
+def test_plan_contains_spatio_temporal_params():
+    agent = SupervisorAgent()
+    plan = agent.plan_research_task("Flooding in Europe from 2000 to 2010")
+    assert plan.get("time_range") == {"valid_from": 2000, "valid_to": 2010}
+    assert plan.get("bbox") == [-10.0, 35.0, 30.0, 60.0]


### PR DESCRIPTION
## Summary
- update Planner and Supervisor prompts for time & location fields
- support spatio-temporal queries in MemoryManager
- document usage examples
- add tests for new plan fields and location-aware retrieval

## Testing
- `pre-commit run --files agents/Planner/prompt.tpl.md agents/Supervisor/prompt.tpl.md agents/memory_manager.py agents/supervisor.py tests/test_supervisor.py tests/test_spatio_temporal_retrieval.py services/ltm_service/api.py services/ltm_service/openapi_app.py docs/usage/spatio_temporal_examples.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685173be5a28832a96e31d9cbc32d667