### PR TITLE
Implement LLM skill spec generator

### DIFF
--- a/agents/SkillSpecAgent/config.yml
+++ b/agents/SkillSpecAgent/config.yml
@@ -1,0 +1,4 @@
+agent_name: "SkillSpecAgent"
+role: "LLM-based skill decomposer"
+max_retries: 2
+rbac: []

--- a/agents/SkillSpecAgent/prompt.tpl.md
+++ b/agents/SkillSpecAgent/prompt.tpl.md
@@ -1,0 +1,11 @@
+# SkillSpec Prompt
+
+You are the SkillSpecAgent leveraging L2S/LDSC techniques.
+Given the TASK below, output a JSON object with a top-level `sub_tasks` list.
+Each sub-task entry must include:
+- `name`: sub-task label
+- `termination_condition`: Python boolean expression
+- `reward_function`: Python code snippet returning a float reward
+Respond with JSON only and no commentary.
+
+TASK: {{task}}

--- a/services/learning/__init__.py
+++ b/services/learning/__init__.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .ppo_policy_optimizer import PPOPolicyOptimizer
     from .rlaif_system import RLAIFSystem
     from .skill_discovery import SkillDiscoveryModule
+    from .skill_spec import SkillSpec, generate_skill_specs, store_skill_specs
 
 
 def __getattr__(name: str):
@@ -20,6 +21,12 @@ def __getattr__(name: str):
         return import_module(".marl_trainer", __name__).MARLTrainer
     if name == "SkillDiscoveryModule":
         return import_module(".skill_discovery", __name__).SkillDiscoveryModule
+    if name == "SkillSpec":
+        return import_module(".skill_spec", __name__).SkillSpec
+    if name == "generate_skill_specs":
+        return import_module(".skill_spec", __name__).generate_skill_specs
+    if name == "store_skill_specs":
+        return import_module(".skill_spec", __name__).store_skill_specs
     if name == "ConfigurationError":
         return import_module(".exceptions", __name__).ConfigurationError
     raise AttributeError(name)
@@ -30,5 +37,8 @@ __all__ = [
     "PPOPolicyOptimizer",
     "MARLTrainer",
     "SkillDiscoveryModule",
+    "SkillSpec",
+    "generate_skill_specs",
+    "store_skill_specs",
     "ConfigurationError",
 ]

--- a/services/learning/skill_spec.py
+++ b/services/learning/skill_spec.py
@@ -1,0 +1,61 @@
+"""Generate and parse skill specifications via LLM prompts."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import List
+
+from services.llm_client import LLMClient
+from services.ltm_service.skill_library import SkillLibrary
+
+
+@dataclass
+class SkillSpec:
+    """Structured description of a skill."""
+
+    name: str
+    termination_condition: str
+    reward_function: str
+
+
+def parse_skill_specs(text: str) -> List[SkillSpec]:
+    """Parse JSON text into a list of :class:`SkillSpec`."""
+    data = json.loads(text)
+    specs: List[SkillSpec] = []
+    for item in data.get("sub_tasks", []):
+        specs.append(
+            SkillSpec(
+                name=item.get("name", ""),
+                termination_condition=item.get("termination_condition", ""),
+                reward_function=item.get("reward_function", ""),
+            )
+        )
+    return specs
+
+
+def generate_skill_specs(
+    task: str, *, llm: LLMClient, template: str
+) -> List[SkillSpec]:
+    """Use ``llm`` and ``template`` to produce skill specs for ``task``."""
+    prompt = template.format(task=task)
+    text = llm.invoke([{"role": "user", "content": prompt}])
+    return parse_skill_specs(text)
+
+
+def store_skill_specs(specs: List[SkillSpec], library: SkillLibrary) -> List[str]:
+    """Persist specs in ``library`` as skills with metadata."""
+    ids: List[str] = []
+    for spec in specs:
+        sid = library.add_skill(
+            {"policy": []},
+            spec.name,
+            {
+                "skill_spec": {
+                    "name": spec.name,
+                    "termination_condition": spec.termination_condition,
+                    "reward_function": spec.reward_function,
+                }
+            },
+        )
+        ids.append(sid)
+    return ids

--- a/tests/test_skill_spec_generation.py
+++ b/tests/test_skill_spec_generation.py
@@ -1,0 +1,53 @@
+import json
+import types
+
+from services.learning.skill_spec import (
+    generate_skill_specs,
+    parse_skill_specs,
+    store_skill_specs,
+)
+from services.ltm_service.skill_library import SkillLibrary
+
+
+def test_parse_skill_specs():
+    text = json.dumps(
+        {
+            "sub_tasks": [
+                {
+                    "name": "move block",
+                    "termination_condition": "position == target",
+                    "reward_function": "return float(position==target)",
+                }
+            ]
+        }
+    )
+    specs = parse_skill_specs(text)
+    assert len(specs) == 1
+    assert specs[0].name == "move block"
+
+
+def test_generate_and_store_specs():
+    # fake llm returning deterministic specs
+    def fake_llm(msgs):
+        return json.dumps(
+            {
+                "sub_tasks": [
+                    {
+                        "name": "pick up",
+                        "termination_condition": "holding == True",
+                        "reward_function": "return 1.0 if holding else 0.0",
+                    }
+                ]
+            }
+        )
+
+    llm = types.SimpleNamespace(invoke=fake_llm)
+    template = "TASK: {task}"
+    specs = generate_skill_specs("stack blocks", llm=llm, template=template)
+    assert specs and specs[0].termination_condition
+
+    lib = SkillLibrary()
+    ids = store_skill_specs(specs, lib)
+    assert ids
+    stored = lib.get_skill(ids[0])
+    assert stored["skill_metadata"]["skill_spec"]["name"] == "pick up"


### PR DESCRIPTION
## Summary
- add SkillSpecAgent with prompt template
- implement `skill_spec` utilities to parse and store skill metadata
- expose skill spec helpers in `services.learning`
- test skill spec parsing and persistence

## Testing
- `pre-commit run --files agents/SkillSpecAgent/config.yml agents/SkillSpecAgent/prompt.tpl.md services/learning/skill_spec.py services/learning/__init__.py tests/test_skill_spec_generation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517f40b18c832abe4d1a31e812d03a