### PR TITLE
Add evaluator critique long-term memory

### DIFF
--- a/agents/critique.py
+++ b/agents/critique.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from jsonschema import validate
 
@@ -18,15 +18,25 @@ with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
 class Critique:
     """Structured critique produced by the Evaluator agent."""
 
+    prompt: str
+    outcome: str
+    risk_categories: List[str]
     overall_score: float
     criteria_breakdown: Dict[str, float]
     feedback_text: str
+    created_at: float
+    updated_at: float
 
     def to_dict(self) -> Dict[str, Any]:
         return {
+            "prompt": self.prompt,
+            "outcome": self.outcome,
+            "risk_categories": self.risk_categories,
             "overall_score": self.overall_score,
             "criteria_breakdown": self.criteria_breakdown,
             "feedback_text": self.feedback_text,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
         }
 
     def validate(self) -> None:

--- a/agents/evaluator/config/critique_schema.json
+++ b/agents/evaluator/config/critique_schema.json
@@ -2,8 +2,22 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Evaluator Critique",
   "type": "object",
-  "required": ["overall_score", "criteria_breakdown", "feedback_text"],
+  "required": [
+    "prompt",
+    "outcome",
+    "risk_categories",
+    "created_at",
+    "updated_at",
+    "overall_score",
+    "criteria_breakdown",
+    "feedback_text"
+  ],
   "properties": {
+    "prompt": {"type": "string"},
+    "outcome": {"type": "string"},
+    "risk_categories": {"type": "array", "items": {"type": "string"}},
+    "created_at": {"type": "number"},
+    "updated_at": {"type": "number"},
     "overall_score": {
       "type": "number",
       "minimum": 0,

--- a/services/ltm_service/skill_library.py
+++ b/services/ltm_service/skill_library.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List
 
 from .embedding_client import EmbeddingClient, SimpleEmbeddingClient
 from .vector_store import InMemoryVectorStore, VectorStore
+
+
+@dataclass
+class Skill:
+    policy: Dict[str, Any]
+    embedding: List[float]
+    metadata: Dict[str, Any]
 
 
 class SkillLibrary:

--- a/tests/services/test_evaluator_memory.py
+++ b/tests/services/test_evaluator_memory.py
@@ -1,0 +1,57 @@
+from fastapi.testclient import TestClient
+
+from services.ltm_service.api import LTMService
+from services.ltm_service.episodic_memory import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.openapi_app import create_app
+
+
+class DummyProcedural:
+    def __init__(self) -> None:
+        self.storage = InMemoryStorage()
+
+
+def _create_client():
+    service = LTMService(
+        EpisodicMemoryService(InMemoryStorage()),
+        procedural_memory=DummyProcedural(),
+    )
+    app = create_app(service)
+    client = TestClient(app)
+    return client, service
+
+
+def test_store_and_retrieve_critique():
+    client, service = _create_client()
+    critique = {
+        "prompt": "Q?",
+        "outcome": "fail",
+        "risk_categories": ["bias"],
+        "overall_score": 0.4,
+        "criteria_breakdown": {"accuracy": 0.3},
+        "feedback_text": "bad",
+        "created_at": 1.0,
+        "updated_at": 1.0,
+    }
+    resp = client.post(
+        "/evaluator_memory", json={"critique": critique}, headers={"X-Role": "editor"}
+    )
+    assert resp.status_code == 200 or resp.status_code == 201
+    cid = resp.json()["id"]
+
+    resp = client.request(
+        "GET",
+        "/evaluator_memory",
+        json={"query": {"prompt": "Q?"}},
+        headers={"X-Role": "viewer"},
+    )
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert results
+    assert any(
+        r.get("prompt") == "Q?" or r.get("task_context", {}).get("prompt") == "Q?"
+        for r in results
+    )
+
+    direct = service.retrieve_evaluator_memory({"prompt": "Q?"}, limit=1)
+    assert direct
+    assert cid == direct[0].get("id")

--- a/tests/test_critique_schema.py
+++ b/tests/test_critique_schema.py
@@ -12,6 +12,11 @@ def test_schema_file_fields():
     with path.open("r", encoding="utf-8") as f:
         data = json.load(f)
     assert set(data.get("required", [])) == {
+        "prompt",
+        "outcome",
+        "risk_categories",
+        "created_at",
+        "updated_at",
         "overall_score",
         "criteria_breakdown",
         "feedback_text",
@@ -24,9 +29,14 @@ def test_schema_file_fields():
 
 def test_critique_validation_passes():
     crit = Critique(
+        prompt="p",
+        outcome="pass",
+        risk_categories=["test"],
         overall_score=0.8,
         criteria_breakdown={"accuracy": 0.9},
         feedback_text="ok",
+        created_at=1.0,
+        updated_at=1.0,
     )
     crit.validate()
 


### PR DESCRIPTION
## Summary
- extend Critique schema with prompt, outcome, risk categories and timestamps
- expose evaluator memory endpoints in the LTM service
- store critiques via EvaluatorAgent after each evaluation
- add helper for retrieving past critiques
- unit tests for evaluator memory

## Testing
- `pre-commit run --files tests/services/test_evaluator_memory.py services/ltm_service/skill_library.py agents/evaluator.py agents/critique.py agents/evaluator/config/critique_schema.json services/ltm_service/api.py services/ltm_service/openapi_app.py tests/test_critique_schema.py`
- `pytest -q tests/services/test_evaluator_memory.py tests/test_critique_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_6851850ba788832ab8e0503ee211fd82