### PR TITLE
Enhance Evaluator with risk case recall

### DIFF
--- a/agents/Evaluator/prompt.tpl.md
+++ b/agents/Evaluator/prompt.tpl.md
@@ -1,6 +1,10 @@
 # Evaluator System Prompt
 
 You are the **Skeptical Critic**, a meticulous reviewer who challenges every claim.
+First examine any similar risk cases retrieved from long-term memory.
+{{risk_cases}}
+
+Then follow a step-by-step process referencing these cases.
 For each piece of text you evaluate you must:
 1. Score each criterion between 0 and 1.
 2. Provide a short explanation of any issues.
@@ -23,6 +27,8 @@ The critique schema:
   "feedback_text": "Claim about dataset size lacks support; missing limitations section."
 }
 ```
+
+Reference the retrieved cases while reasoning through each criterion in numbered steps.
 
 ### Bad Critique Example
 Do NOT include prose outside the JSON object or omit required fields.

--- a/agents/evaluator.py
+++ b/agents/evaluator.py
@@ -359,3 +359,15 @@ class EvaluatorAgent:
             except Exception:
                 logging.exception("Failed to retrieve critiques")
         return []
+
+    def query_risk_cases(self, prompt: str, limit: int = 5) -> List[Dict]:
+        """Retrieve similar risk cases from LTM sorted by relevance."""
+
+        results = self.fetch_past_critiques(prompt, limit=limit)
+
+        if any("relevance" in r or "similarity" in r for r in results):
+            results.sort(
+                key=lambda r: r.get("relevance", r.get("similarity", 0)),
+                reverse=True,
+            )
+        return results

--- a/services/learning/transfer_eval.py
+++ b/services/learning/transfer_eval.py
@@ -7,7 +7,9 @@ from typing import Dict, Iterable
 from .feudal_network import Manager
 
 
-def evaluate_transfer(tasks: Iterable[Dict[str, any]], manager: Manager) -> Dict[str, float]:
+def evaluate_transfer(
+    tasks: Iterable[Dict[str, any]], manager: Manager
+) -> Dict[str, float]:
     """Return success rate across tasks using the given manager."""
 
     total = 0

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,6 +1,8 @@
 import pytest
 
 from agents.evaluator import EvaluatorAgent
+from services.ltm_service import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.api import LTMService
 
 pytestmark = pytest.mark.core
 
@@ -45,3 +47,49 @@ def test_assess_source_quality_rewards_allowlist():
     results = agent.evaluate_research_output(output, {"source_quality": {}})
     score = results["source_quality"]["scores"]["https://jstor.org/paper"]
     assert score > 0
+
+
+class _DummyProcedural:
+    def __init__(self) -> None:
+        self.storage = InMemoryStorage()
+
+
+def test_query_risk_cases_returns_similar_first():
+    service = LTMService(
+        EpisodicMemoryService(InMemoryStorage()),
+        procedural_memory=_DummyProcedural(),
+    )
+    agent = EvaluatorAgent(ltm_service=service)
+
+    critique1 = {
+        "prompt": "How to make a cake",
+        "outcome": "risk",
+        "risk_categories": ["harm"],
+        "overall_score": 0.2,
+        "criteria_breakdown": {"accuracy": 0.2},
+        "feedback_text": "danger",
+        "created_at": 1.0,
+        "updated_at": 1.0,
+    }
+    critique2 = {
+        "prompt": "Tell me a joke",
+        "outcome": "ok",
+        "risk_categories": ["none"],
+        "overall_score": 0.9,
+        "criteria_breakdown": {"accuracy": 1.0},
+        "feedback_text": "good",
+        "created_at": 1.0,
+        "updated_at": 1.0,
+    }
+    service.store_evaluator_memory(critique1)
+    service.store_evaluator_memory(critique2)
+
+    results = agent.query_risk_cases("How can I make a cake step by step?", limit=2)
+    assert results
+    prompts = [
+        r.get("prompt")
+        or r.get("task_context", {}).get("prompt")
+        or r.get("outcome", {}).get("prompt")
+        for r in results
+    ]
+    assert any("cake" in (p or "").lower() for p in prompts)

--- a/tests/test_multi_context_env.py
+++ b/tests/test_multi_context_env.py
@@ -1,6 +1,6 @@
 from services.learning import MultiContextEnv
-from services.learning.skill_discovery import SkillDiscoveryModule
-from services.ltm_service.skill_library import SkillLibrary
+from services.learning.skill_discovery import SkillDiscoveryModule  # noqa: F401
+from services.ltm_service.skill_library import SkillLibrary  # noqa: F401
 
 
 class DummyEnv:

--- a/tests/test_transfer_eval.py
+++ b/tests/test_transfer_eval.py
@@ -1,5 +1,5 @@
-from services.learning import Manager, Worker, MultiContextEnv, evaluate_transfer
-from services.ltm_service.skill_library import SkillLibrary
+from services.learning import Manager, MultiContextEnv, Worker, evaluate_transfer
+from services.ltm_service.skill_library import SkillLibrary  # noqa: F401
 
 
 class TinyEnv:
@@ -27,7 +27,7 @@ def test_evaluate_transfer():
     mc = MultiContextEnv(envs)
     worker = Worker(mc)
     lib = SkillLibrary()
-    sid = lib.add_skill({"actions": [1]}, "inc")
+    sid = lib.add_skill({"actions": [1]}, "inc")  # noqa: F841
     mgr = Manager(lib, worker)
     tasks = [
         {"goal": 1, "description": "inc"},


### PR DESCRIPTION
## Summary
- implement `query_risk_cases` in `EvaluatorAgent`
- sort retrieved cases by similarity or relevance
- update Evaluator prompt to include past cases and step‑by‑step guidance
- adjust tests and add new test for risk case retrieval
- apply linting fixes

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `pytest tests/test_evaluator.py::test_query_risk_cases_returns_similar_first -q`

------
https://chatgpt.com/codex/tasks/task_e_6852036fd140832a88f4a4141a29333f