### PR TITLE
Add OAuth authentication for evaluator service

### DIFF
--- a/agents/evaluator.py
+++ b/agents/evaluator.py
@@ -69,6 +69,7 @@ class EvaluatorAgent:
             "http://localhost:8000/api/v1/evaluations",
         )
         self.reputation_token = os.getenv("REPUTATION_API_TOKEN", "evaluator-token")
+        self.evaluation_token = os.getenv("EVALUATION_API_TOKEN", "eval-token")
         self.endpoint = endpoint
         self.ltm_service = ltm_service
 
@@ -325,7 +326,7 @@ class EvaluatorAgent:
                 resp = requests.post(
                     f"{self.endpoint}/evaluator_memory",
                     json={"critique": data},
-                    headers={"X-Role": "editor"},
+                    headers={"Authorization": f"Bearer {self.evaluation_token}"},
                     timeout=10,
                 )
                 resp.raise_for_status()
@@ -345,7 +346,7 @@ class EvaluatorAgent:
                     f"{self.endpoint}/evaluator_memory",
                     params={"limit": str(limit)},
                     json={"query": query},
-                    headers={"X-Role": "viewer"},
+                    headers={"Authorization": f"Bearer {self.evaluation_token}"},
                     timeout=10,
                 )
                 resp.raise_for_status()

--- a/services/evaluation/__init__.py
+++ b/services/evaluation/__init__.py
@@ -1,3 +1,4 @@
+from .app import app
 from .comm_metrics import compute_cic, compute_interpretability, compute_zsc_score
 from .specialization_metrics import average_pairwise_divergence, cosine_distance
 
@@ -7,4 +8,5 @@ __all__ = [
     "compute_interpretability",
     "cosine_distance",
     "average_pairwise_divergence",
+    "app",
 ]

--- a/services/evaluation/app.py
+++ b/services/evaluation/app.py
@@ -1,0 +1,78 @@
+import os
+import uuid
+from typing import Any, Dict, List, Optional
+
+from fastapi import Body, Depends, FastAPI, Header, HTTPException, Query
+from pydantic import BaseModel
+
+
+def _parse_api_keys(raw: str) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    for pair in raw.split(","):
+        if not pair:
+            continue
+        role, token = pair.split(":", 1)
+        mapping[token.strip()] = role.strip()
+    return mapping
+
+
+API_KEYS = _parse_api_keys(
+    os.getenv("EVALUATION_API_KEYS", "editor:eval-token,viewer:view-token")
+)
+
+
+app = FastAPI(title="Evaluation Service", version="1.0.0")
+
+_STORE: Dict[str, Dict[str, Any]] = {}
+
+
+class CritiqueIn(BaseModel):
+    critique: Dict[str, Any]
+
+
+class CritiqueQuery(BaseModel):
+    query: Optional[Dict[str, Any]] = None
+
+
+def get_role(authorization: str = Header(None)) -> str:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="unauthorized")
+    token = authorization.split()[1]
+    role = API_KEYS.get(token)
+    if not role:
+        raise HTTPException(status_code=401, detail="unauthorized")
+    return role
+
+
+def require_role(allowed: List[str]):
+    def _inner(role: str = Depends(get_role)) -> str:
+        if role not in allowed:
+            raise HTTPException(status_code=403, detail="forbidden")
+        return role
+
+    return _inner
+
+
+@app.post("/evaluator_memory", dependencies=[Depends(require_role(["editor"]))])
+def store_critique(req: CritiqueIn) -> Dict[str, str]:
+    cid = str(uuid.uuid4())
+    record = dict(req.critique)
+    record["id"] = cid
+    _STORE[cid] = record
+    return {"id": cid}
+
+
+@app.get(
+    "/evaluator_memory",
+    dependencies=[Depends(require_role(["viewer", "editor"]))],
+)
+def get_critiques(
+    limit: int = Query(5, ge=1, le=50),
+    body: CritiqueQuery = Body(default_factory=CritiqueQuery),
+) -> Dict[str, List[Dict[str, Any]]]:
+    query = body.query or {}
+    results = []
+    for rec in _STORE.values():
+        if all(rec.get(k) == v for k, v in query.items()):
+            results.append(rec)
+    return {"results": results[:limit]}

--- a/tests/test_evaluator_api.py
+++ b/tests/test_evaluator_api.py
@@ -1,0 +1,56 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from services.evaluation.app import _STORE, app
+
+
+@pytest.fixture(autouse=True)
+def clear_store():
+    _STORE.clear()
+    yield
+    _STORE.clear()
+
+
+@pytest.mark.asyncio
+async def test_auth_required():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/evaluator_memory", json={"critique": {"a": 1}})
+        assert resp.status_code == 401
+
+        resp = await client.get("/evaluator_memory")
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_invalid_token():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer wrong"}
+        resp = await client.post(
+            "/evaluator_memory", json={"critique": {"a": 1}}, headers=headers
+        )
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_store_and_retrieve():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer eval-token"}
+        resp = await client.post(
+            "/evaluator_memory", json={"critique": {"a": 1}}, headers=headers
+        )
+        assert resp.status_code in (200, 201)
+        cid = resp.json()["id"]
+
+        resp = await client.request(
+            "GET",
+            "/evaluator_memory",
+            params={"limit": 1},
+            json={"query": {"id": cid}},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert results and results[0]["id"] == cid


### PR DESCRIPTION
## Summary
- secure evaluator service with bearer token auth middleware
- export FastAPI app from evaluation service
- add Authorization header usage in EvaluatorAgent
- implement auth failure tests for evaluator API

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_evaluator_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68520c0dba8c832a82ce27cd3825d23c