### PR TITLE
Add Security Agent with credibility scores

### DIFF
--- a/services/security_agent/__init__.py
+++ b/services/security_agent/__init__.py
@@ -1,0 +1,5 @@
+"""Security Agent service FastAPI app."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/services/security_agent/app.py
+++ b/services/security_agent/app.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+
+from fastapi import APIRouter, FastAPI, HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.monitoring.events import event_stream
+from services.reputation.models import Base
+
+from .service import SecurityAgentService
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./security.db")
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+Base.metadata.create_all(engine)
+
+service = SecurityAgentService(SessionLocal)
+
+app = FastAPI(title="Security Agent Service", version="1.0.0")
+router = APIRouter(prefix="/v1")
+
+
+@app.on_event("startup")
+async def _start_listener() -> None:
+    async def _run() -> None:
+        async for evt in event_stream():
+            service.handle_evaluation_event(evt)
+
+    app.state.listener = asyncio.create_task(_run())
+
+
+@app.on_event("shutdown")
+async def _stop_listener() -> None:
+    task = getattr(app.state, "listener", None)
+    if task:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+@router.get("/credibility/{agent_id}")
+def get_credibility(agent_id: str) -> dict:
+    score = service.get_score(agent_id)
+    if score is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return {"agent_id": agent_id, "credibility": score}
+
+
+app.include_router(router)

--- a/services/security_agent/models.py
+++ b/services/security_agent/models.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Float, ForeignKey, String
+from sqlalchemy.orm import relationship
+
+from services.reputation.models import Agent, Base
+
+
+class CredibilityScore(Base):
+    """Persisted credibility score for an agent."""
+
+    __tablename__ = "credibility_scores"
+
+    agent_id = Column(String, ForeignKey("agents.agent_id"), primary_key=True)
+    score = Column(Float, default=0.0)
+    last_updated = Column(DateTime, default=datetime.utcnow)
+
+    agent = relationship(Agent)

--- a/services/security_agent/service.py
+++ b/services/security_agent/service.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from services.monitoring.events import EvaluationCompletedEvent
+from services.reputation.service import ReputationService
+
+from .models import CredibilityScore
+
+
+class SecurityAgentService:
+    """Maintain per-agent credibility scores based on reputation."""
+
+    def __init__(
+        self, session_factory, *, reputation_service: ReputationService | None = None
+    ) -> None:
+        self._session_factory = session_factory
+        self._reputation = reputation_service or ReputationService(session_factory)
+
+    def _calc_score(self, rep: Dict[str, Any] | None) -> float:
+        if not rep:
+            return 0.0
+        values = [float(v) for v in rep.values() if isinstance(v, (int, float))]
+        return sum(values) / len(values) if values else 0.0
+
+    def update_score(self, agent_id: str) -> float:
+        rep_vec = self._reputation.get_reputation(agent_id)
+        score = self._calc_score(rep_vec)
+        with self._session_factory() as session:
+            record = session.get(CredibilityScore, agent_id)
+            if record is None:
+                record = CredibilityScore(agent_id=agent_id, score=score)
+                session.add(record)
+            else:
+                record.score = score
+                record.last_updated = datetime.utcnow()
+            session.commit()
+        return score
+
+    def handle_evaluation_event(self, event: EvaluationCompletedEvent) -> None:
+        self._reputation.handle_evaluation_event(event)
+        self.update_score(event.worker_agent_id)
+
+    def get_score(self, agent_id: str) -> Optional[float]:
+        with self._session_factory() as session:
+            record = session.get(CredibilityScore, agent_id)
+            return record.score if record else None

--- a/tests/test_security_agent_integration.py
+++ b/tests/test_security_agent_integration.py
@@ -1,0 +1,47 @@
+from datetime import timedelta
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.monitoring.events import EvaluationCompletedEvent
+from services.reputation.models import Base
+from services.security_agent.service import SecurityAgentService
+
+
+def setup_service():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return SecurityAgentService(Session)
+
+
+def test_credibility_updates_on_events():
+    service = setup_service()
+    agent_id = service._reputation.add_agent("worker")
+    task_id = service._reputation.add_task("research")
+    assign_id = service._reputation.assign(task_id, agent_id)
+
+    vec1 = {"accuracy_score": 0.9}
+    event1 = EvaluationCompletedEvent(
+        task_id=task_id,
+        worker_agent_id=agent_id,
+        evaluator_id="e1",
+        performance_vector=vec1,
+        task_type="research",
+    )
+    service.handle_evaluation_event(event1)
+    score1 = service.get_score(agent_id)
+    assert score1 == 0.9
+
+    vec2 = {"accuracy_score": 0.3}
+    event2 = EvaluationCompletedEvent(
+        task_id=task_id,
+        worker_agent_id=agent_id,
+        evaluator_id="e1",
+        performance_vector=vec2,
+        task_type="research",
+        timestamp=event1.timestamp + timedelta(days=1),
+    )
+    service.handle_evaluation_event(event2)
+    score2 = service.get_score(agent_id)
+    assert score2 != score1


### PR DESCRIPTION
## Summary
- implement Security Agent service deriving credibility from reputation
- expose `/v1/credibility/<agent_id>` endpoint
- persist credibility scores in shared DB
- test updates when new evaluations arrive

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520ead79f8832a8d74a6fe609167d8