### PR TITLE
Implement credibility-aware aggregation

### DIFF
--- a/docs/epics/security_architecture_enhancement.md
+++ b/docs/epics/security_architecture_enhancement.md
@@ -16,7 +16,16 @@ This epic consolidates change requests aimed at strengthening the system's defen
 
 ### P3-02: Dedicated Security Agent
 - **Dynamic credibility scoring** – compute reputation vectors in real time and weight agent output accordingly【F:docs/research/2025-dynamic-trust-reputation-system.md†L149-L158】.
+- **Credibility-aware aggregation** – final decisions combine agent contributions using a weighted average of their credibility scores.
 - **Anomaly monitoring** – watch inter-agent traffic for suspicious patterns; communication must remain LLM-grounded for auditability【F:docs/architecture/llm_grounded_guided_evolution.md†L1-L11】.
+
+Weighted aggregation uses the formula:
+
+```
+result = sum(contribution_i * credibility_i) / sum(credibility_i)
+```
+
+If all credibility scores are zero, the system falls back to an unweighted mean.
 
 ### P2-01: LTM Hardening
 - **Source credibility verification** – evaluate the trustworthiness of new data before ingestion【F:docs/research/2025-agent-introspection-toolkit.md†L51-L63】.

--- a/engine/collaboration/__init__.py
+++ b/engine/collaboration/__init__.py
@@ -1,4 +1,10 @@
+from .credibility_aggregator import CredibilityAwareAggregator
 from .group_chat import DynamicGroupChat, GroupChatManager
 from .message_protocol import ChatMessage
 
-__all__ = ["DynamicGroupChat", "GroupChatManager", "ChatMessage"]
+__all__ = [
+    "DynamicGroupChat",
+    "GroupChatManager",
+    "ChatMessage",
+    "CredibilityAwareAggregator",
+]

--- a/engine/collaboration/credibility_aggregator.py
+++ b/engine/collaboration/credibility_aggregator.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Aggregate agent contributions using credibility weights."""
+
+from typing import Callable, Dict, Mapping
+
+
+class CredibilityAwareAggregator:
+    """Combine numeric contributions weighted by agent credibility."""
+
+    def __init__(self, score_provider: Callable[[str], float]) -> None:
+        self._score_provider = score_provider
+
+    def aggregate(self, contributions: Mapping[str, float]) -> float:
+        """Return weighted average of contributions using credibility scores."""
+        if not contributions:
+            return 0.0
+        weights: Dict[str, float] = {
+            aid: float(self._score_provider(aid)) for aid in contributions
+        }
+        total_weight = sum(weights.values())
+        if total_weight == 0.0:
+            return sum(contributions.values()) / len(contributions)
+        return (
+            sum(contributions[aid] * weights[aid] for aid in contributions)
+            / total_weight
+        )

--- a/tests/test_credibility_aggregator.py
+++ b/tests/test_credibility_aggregator.py
@@ -1,0 +1,22 @@
+from engine.collaboration.credibility_aggregator import CredibilityAwareAggregator
+
+
+def test_weighted_aggregation():
+    scores = {"A": 0.9, "B": 0.1}
+    contributions = {"A": 10.0, "B": 20.0}
+
+    aggregator = CredibilityAwareAggregator(lambda aid: scores.get(aid, 0.0))
+    result = aggregator.aggregate(contributions)
+
+    expected = (10.0 * 0.9 + 20.0 * 0.1) / (0.9 + 0.1)
+    assert result == expected
+
+
+def test_zero_scores_fallback():
+    scores = {"A": 0.0, "B": 0.0}
+    contributions = {"A": 1.0, "B": 3.0}
+
+    aggregator = CredibilityAwareAggregator(lambda aid: scores.get(aid, 0.0))
+    result = aggregator.aggregate(contributions)
+
+    assert result == 2.0

--- a/tests/test_security_agent_integration.py
+++ b/tests/test_security_agent_integration.py
@@ -19,7 +19,7 @@ def test_credibility_updates_on_events():
     service = setup_service()
     agent_id = service._reputation.add_agent("worker")
     task_id = service._reputation.add_task("research")
-    assign_id = service._reputation.assign(task_id, agent_id)
+    service._reputation.assign(task_id, agent_id)
 
     vec1 = {"accuracy_score": 0.9}
     event1 = EvaluationCompletedEvent(


### PR DESCRIPTION
## Summary
- add `CredibilityAwareAggregator` for weighting agent contributions
- document weighted aggregation formula in Security Architecture epic
- export new aggregator
- fix linter error in `test_security_agent_integration`
- test aggregator weighting behavior

## Testing
- `pre-commit run --files engine/collaboration/credibility_aggregator.py engine/collaboration/__init__.py docs/epics/security_architecture_enhancement.md tests/test_credibility_aggregator.py tests/test_security_agent_integration.py`
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852100701e8832a9f28d1fc5a785659