### PR TITLE
Implement SkillSpecAgent interface

### DIFF
--- a/agents/SkillSpecAgent/prompt.tpl.md
+++ b/agents/SkillSpecAgent/prompt.tpl.md
@@ -1,11 +1,15 @@
 # SkillSpec Prompt
 
 You are the SkillSpecAgent leveraging L2S/LDSC techniques.
-Given the TASK below, output a JSON object with a top-level `sub_tasks` list.
-Each sub-task entry must include:
-- `name`: sub-task label
-- `termination_condition`: Python boolean expression
-- `reward_function`: Python code snippet returning a float reward
+Break the TASK into reusable `sub_tasks`.
+Return a JSON object strictly matching this structure:
+
+```
+{{"sub_tasks": [{{"name": "...", "termination_condition": "...", "reward_function": "..."}}]}}
+```
+
+Each `termination_condition` must be a Python boolean expression and each
+`reward_function` a Python snippet returning a float.
 Respond with JSON only and no commentary.
 
-TASK: {{task}}
+TASK: {task}

--- a/services/learning/skill_spec.py
+++ b/services/learning/skill_spec.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List
 
 from services.llm_client import LLMClient
@@ -59,3 +60,26 @@ def store_skill_specs(specs: List[SkillSpec], library: SkillLibrary) -> List[str
         )
         ids.append(sid)
     return ids
+
+
+def load_default_template() -> str:
+    """Return the built-in SkillSpecAgent prompt template."""
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "agents"
+        / "SkillSpecAgent"
+        / "prompt.tpl.md"
+    )
+    return path.read_text()
+
+
+def generate_skill_specs_from_agent(
+    task: str, *, llm: LLMClient, template_path: str | None = None
+) -> List[SkillSpec]:
+    """Convenience wrapper that loads the default template and parses specs."""
+
+    if template_path:
+        template = Path(template_path).read_text()
+    else:
+        template = load_default_template()
+    return generate_skill_specs(task, llm=llm, template=template)

--- a/tests/test_security_agent_integration.py
+++ b/tests/test_security_agent_integration.py
@@ -19,7 +19,7 @@ def test_credibility_updates_on_events():
     service = setup_service()
     agent_id = service._reputation.add_agent("worker")
     task_id = service._reputation.add_task("research")
-    assign_id = service._reputation.assign(task_id, agent_id)
+    service._reputation.assign(task_id, agent_id)
 
     vec1 = {"accuracy_score": 0.9}
     event1 = EvaluationCompletedEvent(

--- a/tests/test_skill_spec_generation.py
+++ b/tests/test_skill_spec_generation.py
@@ -1,8 +1,79 @@
 import json
+import sys
 import types
+
+# flake8: noqa: E402
+
+sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=types.SimpleNamespace()))
+sys.modules.setdefault("requests", types.SimpleNamespace(post=lambda *a, **k: None))
+
+# minimal stubs for optional deps imported by ltm_service
+splitter_mod = types.ModuleType("langchain.text_splitter")
+splitter_mod.RecursiveCharacterTextSplitter = lambda **_: types.SimpleNamespace(
+    split_text=lambda text: [text]
+)
+langchain_mod = types.ModuleType("langchain")
+sys.modules.setdefault("langchain", langchain_mod)
+sys.modules.setdefault("langchain.text_splitter", splitter_mod)
+
+fastapi_mod = types.ModuleType("fastapi")
+fastapi_mod.FastAPI = object
+fastapi_mod.Body = object
+fastapi_mod.Header = object
+fastapi_mod.HTTPException = Exception
+fastapi_mod.Query = object
+responses_mod = types.ModuleType("fastapi.responses")
+responses_mod.RedirectResponse = object
+sys.modules.setdefault("fastapi.responses", responses_mod)
+sys.modules.setdefault("fastapi", fastapi_mod)
+
+otel_mod = types.ModuleType("opentelemetry")
+trace_mod = types.ModuleType("opentelemetry.trace")
+trace_mod.get_tracer = lambda *_, **__: types.SimpleNamespace(
+    start_as_current_span=lambda *a, **k: types.SimpleNamespace(
+        __enter__=lambda *a2, **k2: None, __exit__=lambda *a2, **k2: None
+    )
+)
+otel_mod.trace = trace_mod
+otel_mod.metrics = types.SimpleNamespace()
+sys.modules.setdefault("opentelemetry", otel_mod)
+sys.modules.setdefault("opentelemetry.trace", trace_mod)
+sys.modules.setdefault(
+    "opentelemetry.exporter", types.ModuleType("opentelemetry.exporter")
+)
+sys.modules.setdefault(
+    "opentelemetry.exporter.otlp", types.ModuleType("opentelemetry.exporter.otlp")
+)
+sys.modules.setdefault(
+    "opentelemetry.exporter.otlp.proto",
+    types.ModuleType("opentelemetry.exporter.otlp.proto"),
+)
+sys.modules.setdefault(
+    "opentelemetry.exporter.otlp.proto.grpc",
+    types.ModuleType("opentelemetry.exporter.otlp.proto.grpc"),
+)
+sys.modules.setdefault(
+    "opentelemetry.exporter.otlp.proto.grpc.metric_exporter",
+    types.ModuleType("opentelemetry.exporter.otlp.proto.grpc.metric_exporter"),
+)
+sys.modules[
+    "opentelemetry.exporter.otlp.proto.grpc.metric_exporter"
+].OTLPMetricExporter = object
+
+pydantic_mod = types.ModuleType("pydantic")
+pydantic_mod.BaseModel = type(
+    "BaseModel", (), {"model_rebuild": classmethod(lambda cls: None)}
+)
+pydantic_mod.Field = lambda *args, **kwargs: None
+sys.modules.setdefault("pydantic", pydantic_mod)
+sys.modules.setdefault(
+    "services.monitoring.system_monitor",
+    types.SimpleNamespace(SystemMonitor=object),
+)
 
 from services.learning.skill_spec import (
     generate_skill_specs,
+    generate_skill_specs_from_agent,
     parse_skill_specs,
     store_skill_specs,
 )
@@ -51,3 +122,32 @@ def test_generate_and_store_specs():
     assert ids
     stored = lib.get_skill(ids[0])
     assert stored["skill_metadata"]["skill_spec"]["name"] == "pick up"
+
+
+def test_generate_skill_specs_from_agent():
+    calls = []
+
+    def fake_llm(msgs):
+        calls.append(msgs[0]["content"])
+        return json.dumps(
+            {
+                "sub_tasks": [
+                    {
+                        "name": "demo",
+                        "termination_condition": "done",
+                        "reward_function": "return 1.0",
+                    }
+                ]
+            }
+        )
+
+    llm = types.SimpleNamespace(invoke=fake_llm)
+    specs = generate_skill_specs_from_agent("demo task", llm=llm)
+    assert calls and "demo task" in calls[0]
+
+    lib = SkillLibrary()
+    sid = store_skill_specs(specs, lib)[0]
+    stored = lib.get_skill(sid)
+    meta = stored["skill_metadata"]["skill_spec"]
+    assert meta["termination_condition"] == "done"
+    assert meta["reward_function"] == "return 1.0"


### PR DESCRIPTION
## Summary
- add SkillSpecAgent template for L2S/LDSC style subtasks
- expose helper functions for loading templates and calling the agent
- store subtask specs and reward functions in SkillLibrary
- fix lint error in security agent test
- expand skill spec tests with new interface

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `pytest tests/test_skill_spec_generation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685210e37918832a95cd0c755aac47b4