### PR TITLE
Implement security telemetry for group chat

### DIFF
--- a/services/monitoring/events.py
+++ b/services/monitoring/events.py
@@ -18,7 +18,18 @@ class EvaluationCompletedEvent:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass
+class MessageMetadataEvent:
+    """Metadata about a single chat message."""
+
+    sender: str
+    size: int
+    timestamp: float
+
+
 _event_queue: asyncio.Queue[EvaluationCompletedEvent] = asyncio.Queue()
+# message metadata events
+_message_queue: asyncio.Queue[MessageMetadataEvent] = asyncio.Queue()
 
 
 def publish_event(event: EvaluationCompletedEvent) -> None:
@@ -26,8 +37,20 @@ def publish_event(event: EvaluationCompletedEvent) -> None:
     _event_queue.put_nowait(event)
 
 
+def publish_message_event(event: MessageMetadataEvent) -> None:
+    """Publish a chat message metadata event."""
+    _message_queue.put_nowait(event)
+
+
 async def event_stream() -> AsyncIterator[EvaluationCompletedEvent]:
     """Yield events as they are published."""
     while True:
         event = await _event_queue.get()
+        yield event
+
+
+async def message_event_stream() -> AsyncIterator[MessageMetadataEvent]:
+    """Yield chat message metadata events as they are published."""
+    while True:
+        event = await _message_queue.get()
         yield event

--- a/tests/test_message_anomaly.py
+++ b/tests/test_message_anomaly.py
@@ -1,0 +1,36 @@
+import logging
+from datetime import datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.monitoring.events import MessageMetadataEvent
+from services.reputation.models import Base
+from services.security_agent.service import SecurityAgentService
+
+
+def setup_service():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return SecurityAgentService(Session)
+
+
+def test_anomaly_detection_triggers_alert(caplog):
+    service = setup_service()
+    caplog.set_level(logging.WARNING)
+    ts = datetime.utcnow().timestamp()
+
+    # Oversized message
+    service.handle_message_event(
+        MessageMetadataEvent(sender="A", size=2000, timestamp=ts)
+    )
+    assert any("Oversized" in r.message for r in caplog.records)
+
+    caplog.clear()
+
+    for _ in range(service.max_rate + 1):
+        service.handle_message_event(
+            MessageMetadataEvent(sender="B", size=10, timestamp=ts)
+        )
+    assert any("Traffic spike" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- emit message metadata from DynamicGroupChat and GroupChatManager
- add new `MessageMetadataEvent` and streaming helpers
- extend SecurityAgentService with anomaly detection
- run listeners for message events in `security_agent` service
- test spike and oversize message alerts

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685212df8644832a9195844fc4937ebf