### PR TITLE
Add episodic memory anomaly monitor

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -36,4 +36,5 @@ pgtest==1.3.2
 SQLAlchemy==2.0.29
 asyncpg==0.29.0
 neo4j==5.19.0
+scikit-learn==1.4.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,5 @@ pgtest==1.3.2
 SQLAlchemy==2.0.29
 asyncpg==0.29.0
 neo4j==5.19.0
+scikit-learn==1.4.2
 

--- a/tests/services/test_anomaly_detection.py
+++ b/tests/services/test_anomaly_detection.py
@@ -1,0 +1,42 @@
+# flake8: noqa: E402
+import sys
+import types
+
+sys.modules.setdefault(
+    "services.monitoring.system_monitor",
+    types.SimpleNamespace(SystemMonitor=object),
+)  # noqa: E402
+
+from services.ltm_service.episodic_memory import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.vector_store import InMemoryVectorStore
+
+
+def test_outlier_detection_flagged():
+    storage = InMemoryStorage()
+    vector_store = InMemoryVectorStore()
+    service = EpisodicMemoryService(storage, vector_store=vector_store)
+
+    embeds = [[0.1 * i, 0.1 * i] for i in range(5)] + [[10.0, 10.0]]
+
+    def _fake_embed(_texts, *, attempts=3):
+        return [embeds.pop(0)]
+
+    service._embed_with_retry = _fake_embed
+
+    for i in range(5):
+        rec_id = storage.save({"task_context": {"i": i}})
+        vector_store.add(
+            [0.1 * i, 0.1 * i],
+            {"id": rec_id, "chunk_index": 0, "text": "", "categories": []},
+        )
+
+    outlier_id = storage.save({"task_context": {"i": "out"}})
+    vector_store.add(
+        [10.0, 10.0], {"id": outlier_id, "chunk_index": 0, "text": "", "categories": []}
+    )
+
+    service._cluster_and_detect(n_clusters=1, z_thresh=1.0)
+    flagged = service.review_anomalies()
+    assert outlier_id in flagged
+    metrics = service.get_anomaly_metrics()
+    assert metrics["anomalies_detected"] >= 1


### PR DESCRIPTION
## Summary
- monitor embeddings for outliers in episodic memory
- log and expose anomaly metrics
- allow manual review of flagged records
- add scikit-learn dependency
- test anomaly detection on synthetic embeddings

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68521d84ba70832aa6244aa73596c7bc