### PR TITLE
Use timezone-aware timestamps

### DIFF
--- a/services/monitoring/events.py
+++ b/services/monitoring/events.py
@@ -14,7 +14,7 @@ class EvaluationCompletedEvent:
     performance_vector: Dict[str, Any]
     task_type: Optional[str] = None
     is_final: bool = False
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(datetime.UTC))
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 

--- a/services/reputation/models.py
+++ b/services/reputation/models.py
@@ -29,7 +29,7 @@ class Agent(Base):
     agent_id = Column(String, primary_key=True, default=_uuid)
     agent_type = Column(String, nullable=False)
     model_base = Column(String, nullable=True)
-    creation_timestamp = Column(DateTime, default=datetime.utcnow)
+    creation_timestamp = Column(DateTime, default=lambda: datetime.now(datetime.UTC))
     status = Column(String, nullable=False, default="active")
 
     assignments = relationship("Assignment", back_populates="agent")
@@ -42,7 +42,7 @@ class Task(Base):
     parent_task_id = Column(String, ForeignKey("tasks.task_id"), nullable=True)
     task_type = Column(String, nullable=False)
     query_text = Column(Text, nullable=True)
-    creation_timestamp = Column(DateTime, default=datetime.utcnow)
+    creation_timestamp = Column(DateTime, default=lambda: datetime.now(datetime.UTC))
 
     assignments = relationship("Assignment", back_populates="task")
 
@@ -53,7 +53,7 @@ class Assignment(Base):
     assignment_id = Column(String, primary_key=True, default=_uuid)
     task_id = Column(String, ForeignKey("tasks.task_id"), nullable=False)
     agent_id = Column(String, ForeignKey("agents.agent_id"), nullable=False)
-    assignment_timestamp = Column(DateTime, default=datetime.utcnow)
+    assignment_timestamp = Column(DateTime, default=lambda: datetime.now(datetime.UTC))
 
     agent = relationship("Agent", back_populates="assignments")
     task = relationship("Task", back_populates="assignments")
@@ -68,7 +68,7 @@ class Evaluation(Base):
         String, ForeignKey("assignments.assignment_id"), nullable=False
     )
     evaluator_id = Column(String, nullable=False)
-    evaluation_timestamp = Column(DateTime, default=datetime.utcnow)
+    evaluation_timestamp = Column(DateTime, default=lambda: datetime.now(datetime.UTC))
     performance_vector = Column(JSON, nullable=False)
     is_final = Column(Boolean, default=False)
 
@@ -84,6 +84,8 @@ class ReputationScore(Base):
     context = Column(String, nullable=True)
     reputation_vector = Column(JSON, nullable=False)
     confidence_score = Column(Float, default=0.0)
-    last_updated_timestamp = Column(DateTime, default=datetime.utcnow)
+    last_updated_timestamp = Column(
+        DateTime, default=lambda: datetime.now(datetime.UTC)
+    )
 
     agent = relationship("Agent")

--- a/services/security_agent/models.py
+++ b/services/security_agent/models.py
@@ -15,6 +15,6 @@ class CredibilityScore(Base):
 
     agent_id = Column(String, ForeignKey("agents.agent_id"), primary_key=True)
     score = Column(Float, default=0.0)
-    last_updated = Column(DateTime, default=datetime.utcnow)
+    last_updated = Column(DateTime, default=lambda: datetime.now(datetime.UTC))
 
     agent = relationship(Agent)

--- a/services/security_agent/service.py
+++ b/services/security_agent/service.py
@@ -40,7 +40,7 @@ class SecurityAgentService:
                 session.add(record)
             else:
                 record.score = score
-                record.last_updated = datetime.utcnow()
+                record.last_updated = datetime.now(datetime.UTC)
             session.commit()
         return score
 


### PR DESCRIPTION
## Summary
- prefer timezone-aware `datetime.now(datetime.UTC)` for events and models

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685220719224832ab8123b83adce71b6