### PR TITLE
Expose suggested tasks via CLI and API

### DIFF
--- a/agentic_index_cli/task_suggestions.py
+++ b/agentic_index_cli/task_suggestions.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+DEFAULT_QUEUE = Path(".codex/queue.yml")
+
+
+def load_suggested_tasks(path: str | Path = DEFAULT_QUEUE) -> List[Dict[str, str]]:
+    """Return tasks without a 'done' status from the queue."""
+    queue_path = Path(path)
+    if not queue_path.exists():
+        return []
+
+    with queue_path.open() as f:
+        data = yaml.safe_load(f) or []
+
+    tasks: List[Dict[str, str]] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        status = str(entry.get("status", "")).lower()
+        if status == "done":
+            continue
+        tid = entry.get("id")
+        title = entry.get("title")
+        if tid and title:
+            tasks.append({"id": tid, "title": title})
+    return tasks
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Print suggested Codex tasks")
+    parser.add_argument("--queue", default=str(DEFAULT_QUEUE))
+    args = parser.parse_args(argv)
+    tasks = load_suggested_tasks(args.queue)
+    json.dump(tasks, fp=sys.stdout)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,3 +14,31 @@ This site contains design docs, research papers, and project reports for the Age
 ## Epics
 
 - [Interactive Agent Cockpit](epics/interactive_agent_cockpit_epic.md)
+
+## Suggested Tasks
+
+<ul id="suggested-tasks"></ul>
+
+<script>
+async function loadTasks() {
+  try {
+    const resp = await fetch('/suggested_tasks');
+    if (!resp.ok) return;
+    const data = await resp.json();
+    const list = document.getElementById('suggested-tasks');
+    data.forEach(t => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = '#';
+      a.textContent = `${t.id}: ${t.title}`;
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+  } catch (e) {
+    console.error(e);
+  }
+}
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', loadTasks);
+}
+</script>

--- a/services/task_suggestions/__init__.py
+++ b/services/task_suggestions/__init__.py
@@ -1,0 +1,3 @@
+from .api import TaskSuggestionServer
+
+__all__ = ["TaskSuggestionServer"]

--- a/services/task_suggestions/api.py
+++ b/services/task_suggestions/api.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Dict, List
+
+from agentic_index_cli.task_suggestions import load_suggested_tasks
+
+
+class TaskSuggestionServer:
+    """Minimal HTTP API exposing suggested Codex tasks."""
+
+    def __init__(
+        self,
+        queue_path: str = ".codex/queue.yml",
+        host: str = "127.0.0.1",
+        port: int = 0,
+    ) -> None:
+        self.queue_path = queue_path
+        self.httpd = HTTPServer((host, port), self._handler())
+
+    def _handler(self):
+        queue_path = self.queue_path
+
+        class Handler(BaseHTTPRequestHandler):
+            def _send_json(self, status: int, payload: List[Dict[str, str]]) -> None:
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(payload).encode())
+
+            def do_GET(self) -> None:
+                if self.path != "/suggested_tasks":
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                tasks = load_suggested_tasks(queue_path)
+                self._send_json(200, tasks)
+
+        return Handler
+
+    def serve_forever(self) -> None:  # pragma: no cover - manual run
+        self.httpd.serve_forever()

--- a/tests/test_task_suggestions.py
+++ b/tests/test_task_suggestions.py
@@ -1,0 +1,45 @@
+import threading
+
+import pytest
+import requests
+import yaml
+
+from agentic_index_cli.task_suggestions import load_suggested_tasks
+from services.task_suggestions import TaskSuggestionServer
+
+pytestmark = pytest.mark.core
+
+
+def test_load_suggested_tasks(tmp_path):
+    queue = tmp_path / "queue.yml"
+    queue.write_text(
+        yaml.safe_dump(
+            [
+                {"id": "A", "title": "done", "status": "done"},
+                {"id": "B", "title": "todo"},
+                {"id": "C", "title": "open", "status": "open"},
+            ]
+        )
+    )
+    tasks = load_suggested_tasks(queue)
+    assert tasks == [
+        {"id": "B", "title": "todo"},
+        {"id": "C", "title": "open"},
+    ]
+
+
+def test_task_suggestion_api(tmp_path):
+    queue = tmp_path / "queue.yml"
+    queue.write_text(yaml.safe_dump([{"id": "T1", "title": "demo"}]))
+
+    server = TaskSuggestionServer(str(queue), host="127.0.0.1", port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.httpd.server_port}/suggested_tasks"
+        resp = requests.get(url)
+        assert resp.status_code == 200
+        assert resp.json() == [{"id": "T1", "title": "demo"}]
+    finally:
+        server.httpd.shutdown()
+        thread.join()


### PR DESCRIPTION
## Summary
- add `load_suggested_tasks` helper and CLI entrypoint
- serve tasks from new `TaskSuggestionServer`
- list suggestions on the docs homepage
- test queue parsing and API output

## Testing
- `pre-commit run --files agentic_index_cli/task_suggestions.py services/task_suggestions/api.py services/task_suggestions/__init__.py docs/index.md tests/test_task_suggestions.py`
- `pytest -q tests/test_task_suggestions.py`

------
https://chatgpt.com/codex/tasks/task_e_6852209aa028832a866dfb877887153d