### PR TITLE
Implement quarantine routing

### DIFF
--- a/docs/architecture/dual_llm_sandbox.md
+++ b/docs/architecture/dual_llm_sandbox.md
@@ -1,0 +1,20 @@
+# Dual LLM Sandbox Pattern
+
+High-risk tasks are executed by a quarantined agent inside a sandbox, while privileged agents remain isolated from untrusted input. The orchestrator inspects `state.data['risk_level']` before invoking privileged nodes.
+
+## Example Flow
+
+1. **Start** – the workflow begins and evaluates the request.
+2. **Privileged** – normally performs sensitive actions.
+3. **Quarantine** – sandboxed agent used when `risk_level` is `"high"`.
+4. **Complete** – final step after either path.
+
+```mermaid
+graph TD
+    Start -->|risk: low| Privileged
+    Start -->|risk: high| Quarantine
+    Privileged --> Complete
+    Quarantine --> Complete
+```
+
+The orchestration engine is configured with `set_quarantine_node("Quarantine")`. During execution, if a privileged node would receive high‑risk input, the engine automatically skips to the quarantine node. Privileged nodes also raise a `PermissionError` if invoked directly with high‑risk state, ensuring isolation even when misconfigured.

--- a/tests/test_quarantine_routing.py
+++ b/tests/test_quarantine_routing.py
@@ -1,0 +1,86 @@
+import asyncio
+
+import pytest
+
+from engine.orchestration_engine import (
+    GraphState,
+    Node,
+    NodeType,
+    create_orchestration_engine,
+)
+
+pytestmark = pytest.mark.core
+
+
+def test_high_risk_routes_to_quarantine():
+    calls = []
+
+    def start(state: GraphState, _):
+        return state
+
+    def privileged(state: GraphState, _):
+        calls.append("privileged")
+        return state
+
+    def quarantine(state: GraphState, _):
+        calls.append("quarantine")
+        return state
+
+    def complete(state: GraphState, _):
+        calls.append("complete")
+        return state
+
+    engine = create_orchestration_engine()
+    engine.add_node("Start", start)
+    engine.add_node("Quarantine", quarantine, node_type=NodeType.QUARANTINED)
+    engine.add_node("Privileged", privileged, node_type=NodeType.PRIVILEGED)
+    engine.add_node("Complete", complete)
+    engine.add_edge("Start", "Privileged")
+    engine.add_edge("Privileged", "Complete")
+    engine.add_edge("Quarantine", "Complete")
+    engine.set_quarantine_node("Quarantine")
+
+    state = GraphState(data={"risk_level": "high"})
+    result = asyncio.run(engine.run_async(state))
+    assert result == state
+    assert calls == ["quarantine", "complete"]
+
+
+def test_low_risk_allows_privileged():
+    calls = []
+
+    def start(state: GraphState, _):
+        return state
+
+    def privileged(state: GraphState, _):
+        calls.append("privileged")
+        return state
+
+    def quarantine(state: GraphState, _):
+        calls.append("quarantine")
+        return state
+
+    def complete(state: GraphState, _):
+        calls.append("complete")
+        return state
+
+    engine = create_orchestration_engine()
+    engine.add_node("Start", start)
+    engine.add_node("Quarantine", quarantine, node_type=NodeType.QUARANTINED)
+    engine.add_node("Privileged", privileged, node_type=NodeType.PRIVILEGED)
+    engine.add_node("Complete", complete)
+    engine.add_edge("Start", "Privileged")
+    engine.add_edge("Privileged", "Complete")
+    engine.add_edge("Quarantine", "Complete")
+    engine.set_quarantine_node("Quarantine")
+
+    state = GraphState(data={"risk_level": "low"})
+    asyncio.run(engine.run_async(state))
+    assert calls == ["privileged", "complete"]
+
+
+def test_privileged_node_rejects_high_risk():
+    node = Node("P", lambda s, _: s, node_type=NodeType.PRIVILEGED)
+    state = GraphState(data={"risk_level": "high"})
+    with pytest.raises(PermissionError):
+        asyncio.run(node.run(state))


### PR DESCRIPTION
## Summary
- orchestrator isolates privileged nodes from high-risk input
- designate quarantine nodes in orchestration engine
- describe Dual LLM sandbox pattern
- add tests for quarantine routing

## Testing
- `pre-commit run --files engine/orchestration_engine.py docs/architecture/dual_llm_sandbox.md tests/test_quarantine_routing.py`
- `pytest -q tests/test_quarantine_routing.py` *(fails: execution hang)*

------
https://chatgpt.com/codex/tasks/task_e_6852213485f8832a9c8fca460cfac4f3