### PR TITLE
Improve sync tasks script error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Each agent resides in a folder under `agents/`. Every folder contains:
 ## Codex Queue Synchronization
 - The file `.codex/queue.yml` must reflect the latest open change requests.
 - Run `python scripts/sync_codex_tasks.py` to compare open issues with queued tasks.
+- The environment variable `GITHUB_REPOSITORY` must be set to `owner/repo` when running this script. Optionally set `GITHUB_TOKEN` for authenticated API access.
 - Address any reported discrepancies before committing.
 
 ## Codex Issue Workflows

--- a/scripts/sync_codex_tasks.py
+++ b/scripts/sync_codex_tasks.py
@@ -1,3 +1,13 @@
+"""Validate that .codex/queue.yml matches open Codex issues on GitHub.
+
+Environment Variables
+---------------------
+GITHUB_REPOSITORY
+    Repository in the form ``owner/repo``. Required.
+GITHUB_TOKEN
+    Optional token used for authenticated API requests.
+"""
+
 import os
 import re
 import sys
@@ -40,7 +50,11 @@ def main() -> int:
     repo = os.environ.get("GITHUB_REPOSITORY")
     token = os.environ.get("GITHUB_TOKEN")
     if not repo:
-        print("GITHUB_REPOSITORY not set", file=sys.stderr)
+        print(
+            "GITHUB_REPOSITORY not set. "
+            "Set this to 'owner/repo' to check open Codex issues.",
+            file=sys.stderr,
+        )
         return 1
 
     queue_ids = load_queue_ids(os.path.join(".codex", "queue.yml"))

--- a/tests/test_sync_codex_tasks.py
+++ b/tests/test_sync_codex_tasks.py
@@ -28,3 +28,11 @@ def test_sync_detects_mismatch(tmp_path):
         with mock.patch("builtins.open", mock.mock_open(read_data=queue.read_text())):
             exitcode = sync_codex_tasks.main()
     assert exitcode == 1
+
+
+def test_sync_requires_repo(capsys):
+    with mock.patch.dict(os.environ, {}, clear=True):
+        exitcode = sync_codex_tasks.main()
+    captured = capsys.readouterr()
+    assert exitcode == 1
+    assert "GITHUB_REPOSITORY" in captured.err


### PR DESCRIPTION
## Summary
- add environment variable documentation
- clarify GITHUB_REPOSITORY requirement in `sync_codex_tasks.py`
- test missing GITHUB_REPOSITORY case

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `python scripts/sync_codex_tasks.py` *(fails: GitHub API error 404)*

------
https://chatgpt.com/codex/tasks/task_e_68522b0d1698832aac92f66695337035