### PR TITLE
Improve sync tasks script error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,9 @@ Each agent resides in a folder under `agents/`. Every folder contains:
 ## Codex Queue Synchronization
 - The file `.codex/queue.yml` must reflect the latest open change requests.
 - Run `python scripts/sync_codex_tasks.py` to compare open issues with queued tasks.
+- Set `GITHUB_REPOSITORY` to `owner/repo` when running this script if it cannot
+  be inferred from the current Git remote. Optionally set `GITHUB_TOKEN` for
+  authenticated API access.
 - Address any reported discrepancies before committing.
 
 ## Codex Issue Workflows

--- a/tests/test_sync_codex_tasks.py
+++ b/tests/test_sync_codex_tasks.py
@@ -28,3 +28,37 @@ def test_sync_detects_mismatch(tmp_path):
         with mock.patch("builtins.open", mock.mock_open(read_data=queue.read_text())):
             exitcode = sync_codex_tasks.main()
     assert exitcode == 1
+
+
+def test_sync_uses_git_repo(tmp_path):
+    queue = tmp_path / "queue.yml"
+    queue.write_text("- id: CR-1\n")
+
+    def fake_get(url, headers=None, timeout=10):
+        resp = mock.Mock(status_code=200)
+        resp.json.return_value = [
+            {"title": "CR-2", "labels": [{"name": "Codex Task"}]},
+        ]
+        resp.links = {}
+        return resp
+
+    with mock.patch.object(
+        sync_codex_tasks.requests, "get", fake_get
+    ), mock.patch.object(
+        sync_codex_tasks, "guess_repo_from_git", return_value="u/r"
+    ), mock.patch.dict(
+        os.environ, {}, clear=True
+    ):
+        with mock.patch("builtins.open", mock.mock_open(read_data=queue.read_text())):
+            exitcode = sync_codex_tasks.main()
+    assert exitcode == 1
+
+
+def test_sync_requires_repo_when_unknown(capsys):
+    with mock.patch.object(
+        sync_codex_tasks, "guess_repo_from_git", return_value=None
+    ), mock.patch.dict(os.environ, {}, clear=True):
+        exitcode = sync_codex_tasks.main()
+    captured = capsys.readouterr()
+    assert exitcode == 1
+    assert "GITHUB_REPOSITORY" in captured.err


### PR DESCRIPTION
## Summary
- add environment variable documentation
- clarify GITHUB_REPOSITORY requirement in `sync_codex_tasks.py`
- test missing GITHUB_REPOSITORY case
- fallback to the current Git remote when env var is unset

## Testing
- `pre-commit run --files scripts/sync_codex_tasks.py tests/test_sync_codex_tasks.py AGENTS.md`
- `pytest -q`
- `python scripts/sync_codex_tasks.py` *(fails: GITHUB_REPOSITORY not set)*
- `GITHUB_REPOSITORY=openai/agentic-research-engine python scripts/sync_codex_tasks.py` *(fails: GitHub API error 404)*

------
https://chatgpt.com/codex/tasks/task_e_68522b0d1698832aac92f66695337035