### PR TITLE
Fix Codex task links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ async function loadTasks() {
     data.forEach(t => {
       const li = document.createElement('li');
       const a = document.createElement('a');
-      a.href = '#';
+      a.href = 'https://chatgpt.com/codex/tasks/' + t.id;
       a.textContent = `${t.id}: ${t.title}`;
       li.appendChild(a);
       list.appendChild(li);


### PR DESCRIPTION
## Summary
- link suggested tasks to the Codex task UI

## Testing
- `pre-commit run --files docs/index.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522e5de454832a919e7c054eb90757