### PR TITLE
Add RE tasks to codex queue

### DIFF
--- a/.codex/queue.yml
+++ b/.codex/queue.yml
@@ -423,22 +423,22 @@
   - Schedule quarterly reviews and update evidence mapping
   - Document risk management decisions
   title: Adopt Formal AI Assurance Lifecycle
-- id: RE-06
+- acceptance_criteria:
+  - given multilingual data
+  - when ingested
+  - then equivalent entities are linked via owl:sameAs
+  id: RE-06
+  priority: medium
+  steps:
+  - implement translation layer in KG ingestion
+  - align entities across languages
   title: Enable Cross-Lingual Knowledge-Graph Support
+- acceptance_criteria:
+  - memory writes add calibrated noise
+  - integration tests verify privacy budget accounting
+  id: RE-07
   priority: medium
   steps:
-    - implement translation layer in KG ingestion
-    - align entities across languages
-  acceptance_criteria:
-    - given multilingual data
-    - when ingested
-    - then equivalent entities are linked via owl:sameAs
-- id: RE-07
+  - add DP mechanisms to LTM writes
+  - expose configuration for epsilon values
   title: Deploy Differential-Privacy LTM Architecture
-  priority: medium
-  steps:
-    - add DP mechanisms to LTM writes
-    - expose configuration for epsilon values
-  acceptance_criteria:
-    - memory writes add calibrated noise
-    - integration tests verify privacy budget accounting

--- a/codex_tasks.md
+++ b/codex_tasks.md
@@ -1815,3 +1815,28 @@ acceptance_criteria:
   - Assurance plan stored in docs/governance contains evidence map
   - Review log shows at least one completed assurance meeting
 ```
+```codex-task
+id: RE-06
+title: Enable Cross-Lingual Knowledge-Graph Support
+priority: medium
+steps:
+  - implement translation layer in KG ingestion
+  - align entities across languages
+acceptance_criteria:
+  - given multilingual data
+  - when ingested
+  - then equivalent entities are linked via owl:sameAs
+```
+
+```codex-task
+id: RE-07
+title: Deploy Differential-Privacy LTM Architecture
+priority: medium
+steps:
+  - add DP mechanisms to LTM writes
+  - expose configuration for epsilon values
+acceptance_criteria:
+  - memory writes add calibrated noise
+  - integration tests verify privacy budget accounting
+```
+


### PR DESCRIPTION
## Summary
- define tasks RE-06 and RE-07 in `codex_tasks.md`
- regenerate `.codex/queue.yml`
- remove old manual entries for these tasks

## Testing
- `pre-commit run --files codex_tasks.md .codex/queue.yml`
- `pytest -q`
- `python scripts/sync_codex_tasks.py` *(fails: GitHub API error 404)*

------
https://chatgpt.com/codex/tasks/task_e_68522e6d700c832ab502a342a586a046