### PR TITLE
Add content sanitization to LTM retrievals

### DIFF
--- a/tests/services/test_api.py
+++ b/tests/services/test_api.py
@@ -209,3 +209,19 @@ def test_retrieval_filters_trigger_phrases():
     payload = json.dumps(results[0])
     assert "AGENTPOISON" not in payload
     assert service.quarantine_log
+
+
+def test_skill_queries_filter_trigger_phrases():
+    client, service = _create_client()
+
+    sid = service.add_skill(
+        {"steps": ["a"]},
+        "use skill TRIGGER PHRASE",
+        {"domain": "demo"},
+    )
+
+    results = service.skill_vector_query("use skill", limit=1)
+    assert results
+    assert results[0]["id"] == sid
+    assert "TRIGGER PHRASE" not in json.dumps(results[0])
+    assert service.quarantine_log


### PR DESCRIPTION
## Summary
- sanitize and log suspicious records retrieved from LTM
- sanitize records returned by spatial, skill, and evaluator queries
- add tests for evaluator memory and skill sanitization

## Testing
- `pre-commit run --files services/ltm_service/api.py tests/services/test_api.py tests/services/test_evaluator_memory.py`
- `pytest -q`
- `pytest -q tests/services/test_api.py tests/services/test_evaluator_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_68525a2ec360832a9d3240127b128427