### PR TITLE
Add quarantine routing logic

### DIFF
--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -34,3 +34,17 @@ engine.add_router("start", router)
 ```
 
 When `state.data['path']` equals `"fail"`, the engine will traverse the edge labelled `fail`.
+
+## Quarantining High-Risk Tasks
+
+Use `NodeType.PRIVILEGED` for nodes that perform sensitive actions. If `state.data['risk_level']` is set to "high", the engine automatically routes execution to the node registered via `set_quarantine_node()` instead of invoking the privileged node.
+
+```mermaid
+graph TD
+    Start -->|risk: high| Quarantine
+    Start -->|risk: low| Privileged
+    Quarantine --> Complete
+    Privileged --> Complete
+```
+
+This ensures untrusted input never reaches privileged code paths, even if the graph edges would normally lead there.


### PR DESCRIPTION
## Summary
- quarantine high-risk tasks by checking risk level before running privileged nodes
- document quarantining flow in orchestration docs

## Testing
- `pre-commit run --files docs/architecture/orchestration.md engine/orchestration_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68525dc24e04832a8081cbf166612756