### PR TITLE
Enforce schema validation for chat messages

### DIFF
--- a/engine/collaboration/group_chat.py
+++ b/engine/collaboration/group_chat.py
@@ -103,11 +103,13 @@ class DynamicGroupChat:
         recipient: Optional[str] = None,
     ) -> None:
         """Send a message to the chat."""
-        msg = ChatMessage(
-            sender=sender,
-            content=content,
-            type=message_type,
-            recipient=recipient,
+        msg = ChatMessage.validate_message(
+            {
+                "sender": sender,
+                "content": content,
+                "message_type": message_type,
+                "recipient": recipient,
+            }
         ).model_dump()
         publish_message_event(
             MessageMetadataEvent(
@@ -141,7 +143,7 @@ class DynamicGroupChat:
                 msgs = self.inboxes.pop(agent_id, [])
         else:
             msgs = self.inboxes.pop(agent_id, [])
-        return [ChatMessage.model_validate(m).model_dump() for m in msgs]
+        return [ChatMessage.validate_message(m).model_dump() for m in msgs]
 
     def update_workspace(self, agent_id: str, key: str, value: Any) -> None:
         """Update the shared workspace if permitted."""

--- a/engine/collaboration/message_protocol.py
+++ b/engine/collaboration/message_protocol.py
@@ -2,10 +2,29 @@ from __future__ import annotations
 
 """Message schema for group chat communication."""
 
+import logging
+import re
 import time
+from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+logger = logging.getLogger(__name__)
+
+
+class MessageType(str, Enum):
+    """Allowed categories of chat messages."""
+
+    message = "message"
+    question = "question"
+    finding = "finding"
+    proposal = "proposal"
+    command = "command"
+    finish = "finish"
+
+
+_PRIVATE_LANG_RE = re.compile(r"[A-Za-z0-9+/]{20,}=?")
 
 
 class ChatMessage(BaseModel):
@@ -13,8 +32,10 @@ class ChatMessage(BaseModel):
 
     sender: str = Field(..., description="ID of the sending agent")
     content: str = Field(..., description="Message text")
-    type: str = Field(
-        "message", alias="message_type", description="Category of the message"
+    type: MessageType = Field(
+        default=MessageType.message,
+        alias="message_type",
+        description="Category of the message",
     )
     recipient: Optional[str] = Field(
         None, description="Optional ID of the intended recipient"
@@ -22,3 +43,27 @@ class ChatMessage(BaseModel):
     timestamp: float = Field(default_factory=time.time, description="Message timestamp")
 
     model_config = {"populate_by_name": True}
+
+    @field_validator("content")
+    @classmethod
+    def _check_private_language(cls, value: str) -> str:
+        if not value:
+            raise ValueError("content must not be empty")
+        if _PRIVATE_LANG_RE.search(value):
+            logger.warning(
+                "Potential private language detected in message: %s", value[:30]
+            )
+        return value
+
+    @classmethod
+    def validate_message(cls, message: dict | "ChatMessage") -> "ChatMessage":
+        """Validate and return a ``ChatMessage`` instance."""
+        try:
+            if isinstance(message, cls):
+                obj = message
+            else:
+                obj = cls.model_validate(message)
+        except ValidationError as exc:
+            logger.error("Schema violation: %s", exc)
+            raise
+        return obj

--- a/tests/test_message_protocol.py
+++ b/tests/test_message_protocol.py
@@ -1,0 +1,31 @@
+import logging
+
+import pytest
+from pydantic import ValidationError
+
+from engine.collaboration.message_protocol import ChatMessage
+
+pytestmark = pytest.mark.core
+
+
+def test_valid_message():
+    msg = ChatMessage.validate_message({"sender": "A", "content": "hi"})
+    assert msg.sender == "A"
+    assert msg.content == "hi"
+
+
+def test_invalid_type_logs_error(caplog):
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(ValidationError):
+        ChatMessage.validate_message(
+            {"sender": "A", "content": "hi", "message_type": "bad"}
+        )
+    assert any("Schema violation" in r.message for r in caplog.records)
+
+
+def test_private_language_warning(caplog):
+    caplog.set_level(logging.WARNING)
+    ChatMessage.validate_message(
+        {"sender": "A", "content": "dGhpcyBpcyBiYXNlNjQgdGV4dA=="}
+    )
+    assert any("private language" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## Summary
- validate message type and content via new helper
- warn on private language usage
- apply schema checks when posting and retrieving chat messages
- test protocol compliance and logging behavior

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68525f98865c832a8e3804494573cb38