### PR TITLE
Add background anomaly monitor test

### DIFF
--- a/tests/services/test_anomaly_monitor_thread.py
+++ b/tests/services/test_anomaly_monitor_thread.py
@@ -1,0 +1,57 @@
+# flake8: noqa: E402
+import sys
+import time
+import types
+
+sys.modules.setdefault(
+    "services.monitoring.system_monitor", types.SimpleNamespace(SystemMonitor=object)
+)
+
+from services.ltm_service.episodic_memory import EpisodicMemoryService, InMemoryStorage
+from services.ltm_service.vector_store import InMemoryVectorStore
+
+
+def test_anomaly_monitor_background_job():
+    storage = InMemoryStorage()
+    vector_store = InMemoryVectorStore()
+    service = EpisodicMemoryService(storage, vector_store=vector_store)
+
+    embeds = [[0.1 * i, 0.1 * i] for i in range(5)] + [[10.0, 10.0]]
+    idx = 0
+
+    def _fake_embed(_texts, *, attempts=3):
+        nonlocal idx
+        if idx < len(embeds):
+            vec = embeds[idx]
+            idx += 1
+        else:
+            vec = embeds[-1]
+        return [vec]
+
+    service._embed_with_retry = _fake_embed
+
+    orig_cluster = service._cluster_and_detect
+
+    def _patched_cluster():
+        orig_cluster(n_clusters=1, z_thresh=1.0)
+
+    service._cluster_and_detect = _patched_cluster
+
+    for i in range(5):
+        rid = storage.save({"task_context": {"i": i}})
+        vector_store.add(
+            [0.1 * i, 0.1 * i],
+            {"id": rid, "chunk_index": 0, "text": "", "categories": []},
+        )
+
+    outlier_id = storage.save({"task_context": {"i": "out"}})
+    vector_store.add(
+        [10.0, 10.0], {"id": outlier_id, "chunk_index": 0, "text": "", "categories": []}
+    )
+
+    service.start_anomaly_monitor(0.1)
+    time.sleep(0.3)
+    service.stop_anomaly_monitor()
+
+    flagged = service.review_anomalies()
+    assert outlier_id in flagged


### PR DESCRIPTION
## Summary
- verify the episodic memory anomaly monitor runs in background
- add synthetic outlier dataset to trigger detection

## Testing
- `pre-commit run --files tests/services/test_anomaly_monitor_thread.py`
- `pytest -q tests/services/test_anomaly_detection.py tests/services/test_anomaly_monitor_thread.py`


------
https://chatgpt.com/codex/tasks/task_e_68525a2a831c832a9f3e57475ee93183