### PR TITLE
Add provenance metadata to LTM service

### DIFF
--- a/services/ltm_service/episodic_memory.py
+++ b/services/ltm_service/episodic_memory.py
@@ -230,7 +230,12 @@ class EpisodicMemoryService:
         return {"anomalies_detected": self.anomaly_metrics["anomalies_detected"]}
 
     def store_experience(
-        self, task_context: Dict, execution_trace: Dict, outcome: Dict
+        self,
+        task_context: Dict,
+        execution_trace: Dict,
+        outcome: Dict,
+        *,
+        provenance: Dict | None = None,
     ) -> str:
         """Store complete task experience for future reference."""
 
@@ -242,6 +247,7 @@ class EpisodicMemoryService:
             "last_accessed": now,
             "last_accessed_timestamp": now,
             "relevance_score": 1.0,
+            "provenance": provenance or {},
         }
         categories = set(task_context.get("tags", []))
         cat = task_context.get("category")
@@ -357,6 +363,13 @@ class EpisodicMemoryService:
                 except Exception:  # pragma: no cover - best effort
                     pass
         return True
+
+    def get_provenance(self, record_id: str) -> Dict:
+        """Return provenance metadata for a memory item."""
+        rec = self.storage._data.get(record_id)
+        if rec is None or rec.get("deleted_at"):
+            raise KeyError("record not found")
+        return rec.get("provenance", {})
 
     def prune_stale_memories(self, ttl_seconds: float) -> int:
         """Delete memories not accessed within the TTL."""

--- a/services/ltm_service/procedural_memory.py
+++ b/services/ltm_service/procedural_memory.py
@@ -37,13 +37,19 @@ class ProceduralMemoryService(EpisodicMemoryService):
         self.logger = logging.getLogger(__name__)
 
     def store_procedure(
-        self, task_context: Dict, procedure: Iterable[Dict], outcome: Dict
+        self,
+        task_context: Dict,
+        procedure: Iterable[Dict],
+        outcome: Dict,
+        *,
+        provenance: Dict | None = None,
     ) -> str:
         """Persist a procedure for later reuse."""
         return super().store_experience(
             task_context,
             {"procedure": list(procedure)},
             outcome,
+            provenance=provenance,
         )
 
     # --------------------------------------------------------------

--- a/tests/test_ltm_service_api.py
+++ b/tests/test_ltm_service_api.py
@@ -151,3 +151,21 @@ def test_propagate_subgraph_endpoint():
     )
     assert stored
     server.httpd.shutdown()
+
+
+def test_provenance_endpoint():
+    server, endpoint = _start_server()
+    record = {
+        "task_context": {"description": "prov"},
+        "execution_trace": {},
+        "outcome": {},
+        "source": "tester",
+    }
+    resp = requests.post(f"{endpoint}/memory", json={"record": record})
+    assert resp.status_code == 201
+    rid = resp.json()["id"]
+
+    resp = requests.get(f"{endpoint}/provenance/episodic/{rid}")
+    assert resp.status_code == 200
+    assert resp.json()["provenance"]["source"] == "tester"
+    server.httpd.shutdown()


### PR DESCRIPTION
## Summary
- record provenance in episodic, semantic and procedural memories
- expose provenance through new LTMService methods and endpoints
- return provenance data in retrieval APIs
- test provenance metadata via FastAPI and HTTP server clients

## Testing
- `pre-commit run --files services/ltm_service/episodic_memory.py services/ltm_service/procedural_memory.py services/ltm_service/semantic_memory.py services/ltm_service/api.py services/ltm_service/openapi_app.py tests/services/test_api.py tests/test_ltm_service_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685266342b78832a919f17efa1fce696