### PR TITLE
Ensure timezone-aware timestamps

### DIFF
--- a/services/monitoring/events.py
+++ b/services/monitoring/events.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, AsyncIterator, Dict, Optional
 
 
@@ -14,7 +14,7 @@ class EvaluationCompletedEvent:
     performance_vector: Dict[str, Any]
     task_type: Optional[str] = None
     is_final: bool = False
-    timestamp: datetime = field(default_factory=lambda: datetime.now(datetime.UTC))
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 

--- a/services/reputation/models.py
+++ b/services/reputation/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import (
     JSON,
@@ -29,7 +29,7 @@ class Agent(Base):
     agent_id = Column(String, primary_key=True, default=_uuid)
     agent_type = Column(String, nullable=False)
     model_base = Column(String, nullable=True)
-    creation_timestamp = Column(DateTime, default=lambda: datetime.now(datetime.UTC))
+    creation_timestamp = Column(DateTime, default=lambda: datetime.now(UTC))
     status = Column(String, nullable=False, default="active")
 
     assignments = relationship("Assignment", back_populates="agent")
@@ -42,7 +42,7 @@ class Task(Base):
     parent_task_id = Column(String, ForeignKey("tasks.task_id"), nullable=True)
     task_type = Column(String, nullable=False)
     query_text = Column(Text, nullable=True)
-    creation_timestamp = Column(DateTime, default=lambda: datetime.now(datetime.UTC))
+    creation_timestamp = Column(DateTime, default=lambda: datetime.now(UTC))
 
     assignments = relationship("Assignment", back_populates="task")
 
@@ -53,7 +53,7 @@ class Assignment(Base):
     assignment_id = Column(String, primary_key=True, default=_uuid)
     task_id = Column(String, ForeignKey("tasks.task_id"), nullable=False)
     agent_id = Column(String, ForeignKey("agents.agent_id"), nullable=False)
-    assignment_timestamp = Column(DateTime, default=lambda: datetime.now(datetime.UTC))
+    assignment_timestamp = Column(DateTime, default=lambda: datetime.now(UTC))
 
     agent = relationship("Agent", back_populates="assignments")
     task = relationship("Task", back_populates="assignments")
@@ -68,7 +68,7 @@ class Evaluation(Base):
         String, ForeignKey("assignments.assignment_id"), nullable=False
     )
     evaluator_id = Column(String, nullable=False)
-    evaluation_timestamp = Column(DateTime, default=lambda: datetime.now(datetime.UTC))
+    evaluation_timestamp = Column(DateTime, default=lambda: datetime.now(UTC))
     performance_vector = Column(JSON, nullable=False)
     is_final = Column(Boolean, default=False)
 
@@ -84,8 +84,6 @@ class ReputationScore(Base):
     context = Column(String, nullable=True)
     reputation_vector = Column(JSON, nullable=False)
     confidence_score = Column(Float, default=0.0)
-    last_updated_timestamp = Column(
-        DateTime, default=lambda: datetime.now(datetime.UTC)
-    )
+    last_updated_timestamp = Column(DateTime, default=lambda: datetime.now(UTC))
 
     agent = relationship("Agent")

--- a/services/security_agent/models.py
+++ b/services/security_agent/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import Column, DateTime, Float, ForeignKey, String
 from sqlalchemy.orm import relationship
@@ -15,6 +15,6 @@ class CredibilityScore(Base):
 
     agent_id = Column(String, ForeignKey("agents.agent_id"), primary_key=True)
     score = Column(Float, default=0.0)
-    last_updated = Column(DateTime, default=lambda: datetime.now(datetime.UTC))
+    last_updated = Column(DateTime, default=lambda: datetime.now(UTC))
 
     agent = relationship(Agent)

--- a/services/security_agent/service.py
+++ b/services/security_agent/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from services.monitoring.events import EvaluationCompletedEvent, MessageMetadataEvent
@@ -40,7 +40,7 @@ class SecurityAgentService:
                 session.add(record)
             else:
                 record.score = score
-                record.last_updated = datetime.now(datetime.UTC)
+                record.last_updated = datetime.now(UTC)
             session.commit()
         return score
 

--- a/tests/test_message_anomaly.py
+++ b/tests/test_message_anomaly.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -19,7 +19,7 @@ def setup_service():
 def test_anomaly_detection_triggers_alert(caplog):
     service = setup_service()
     caplog.set_level(logging.WARNING)
-    ts = datetime.utcnow().timestamp()
+    ts = datetime.now(UTC).timestamp()
 
     # Oversized message
     service.handle_message_event(


### PR DESCRIPTION
## Summary
- use `UTC` constant with `datetime.now()` across services and tests
- update tests accordingly

## Testing
- `pre-commit run --files services/monitoring/events.py services/reputation/models.py services/security_agent/models.py services/security_agent/service.py tests/test_message_anomaly.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527a8e8944832a95c389c348c9d5aa