### PR TITLE
Add state tests and improve dependency scanning

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -20,10 +20,17 @@ jobs:
           cache-dependency-path: requirements.txt
       - name: Install pip-audit
         run: pip install pip-audit
+      - name: Install safety
+        run: pip install safety
       - name: Run pip-audit
         id: audit
         run: |
           pip-audit -r requirements.txt -f json -o pip_audit_report.json
+        continue-on-error: true
+      - name: Run safety
+        id: safety
+        run: |
+          safety check -r requirements.txt --json > safety_report.json
         continue-on-error: true
       - name: Create issue if vulnerabilities found
         if: steps.audit.outcome == 'failure'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # **agentic-research-engine: A Self-Improving Multi-Agent Research System**
 
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/actions)
-[![Coverage](https://img.shields.io/badge/coverage-86%25-brightgreen)](https://codecov.io)
+[![Coverage](https://img.shields.io/badge/coverage-20%25-red)](https://codecov.io)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 ## **1. Vision & Mission**

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,14 +21,14 @@ opentelemetry-sdk==1.24.0
 opentelemetry-exporter-otlp==1.24.0
 langchain==0.1.15
 langgraph==0.0.24
-langsmith==0.1.18
-weaviate-client==3.26.7
+langsmith==0.4.1
+weaviate-client==4.15.1
 googletrans==4.0.2
 openai==1.3.5
 trl==0.7.10
 pytest-asyncio==0.23.6
-torch==2.2.2
-sentence-transformers==2.6.1
+torch==2.7.1
+sentence-transformers==4.1.0
 tenacity==8.2.3
 datasets==3.6.0
 lxml_html_clean==0.4.2
@@ -38,5 +38,5 @@ pgtest==1.3.2
 SQLAlchemy==2.0.29
 asyncpg==0.29.0
 neo4j==5.19.0
-scikit-learn==1.4.2
+scikit-learn==1.7.0
 

--- a/tests/test_state_extra.py
+++ b/tests/test_state_extra.py
@@ -1,0 +1,34 @@
+import pytest
+
+from engine.state import State
+
+pytestmark = pytest.mark.core
+
+
+def test_getitem_returns_attribute():
+    state = State(data={"foo": 1})
+    assert state["data"] == {"foo": 1}
+
+
+def test_update_records_history_order():
+    state = State()
+    state.update({"a": 1})
+    state.update({"b": 2})
+    assert state.history == [
+        {"action": "update", "data": {"a": 1}},
+        {"action": "update", "data": {"b": 2}},
+    ]
+
+
+def test_add_message_appends():
+    state = State()
+    state.add_message({"content": "hi"})
+    state.add_message({"content": "there"})
+    assert state.messages == [
+        {"content": "hi"},
+        {"content": "there"},
+    ]
+    assert state.history[-1] == {
+        "action": "add_message",
+        "message": {"content": "there"},
+    }


### PR DESCRIPTION
## Summary
- add new tests for the `State` model
- run Safety during weekly dependency audit
- update vulnerable packages
- fix coverage badge in README

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685282287158832ab5d0031e8666ddbc