### PR TITLE
Mock googletrans in test

### DIFF
--- a/tests/test_back_translation_pipeline.py
+++ b/tests/test_back_translation_pipeline.py
@@ -3,11 +3,21 @@ import json
 from pipelines.back_translation.pipeline import BackTranslationPipeline
 
 
-def test_back_translation_pipeline(tmp_path):
+class DummyTranslation:
+    """Simple object to mimic googletrans translation result."""
+
+    def __init__(self, text: str):
+        self.text = text
+
+
+def test_back_translation_pipeline(monkeypatch, tmp_path):
     input_file = tmp_path / "input.jsonl"
     input_file.write_text(json.dumps({"corrected_solution": "Hello world"}) + "\n")
     output_file = tmp_path / "out.jsonl"
 
+    monkeypatch.setattr(
+        BackTranslationPipeline, "_back_translate", lambda self, text: "Hallo Welt"
+    )
     pipeline = BackTranslationPipeline(pivot_lang="de")
     pipeline.augment_file(input_file, output_file)
 
@@ -15,5 +25,5 @@ def test_back_translation_pipeline(tmp_path):
     assert len(out_records) == 1
     out = out_records[0]
     assert out["corrected_solution"] == "Hello world"
-    assert out["flawed_output"] != "Hello world"
+    assert out["flawed_output"] == "Hallo Welt"
     assert "critique" in out


### PR DESCRIPTION
## Summary
- mock `googletrans` in back-translation test so network isn't needed

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_back_translation_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_6852b08ffa94832a94ee4f47b855f774