### PR TITLE
Add Minimal Setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,17 @@ This is a mono-repo containing all services, agent definitions, and infrastructu
    ```bash
    pip install langsmith trl
    ```
-   For a lean environment run `bash scripts/bootstrap_minimal.sh`. See
-   [docs/onboarding.md](docs/onboarding.md) for troubleshooting tips.
+   For a lean environment run `bash scripts/bootstrap_minimal.sh`. See the
+   [Minimal Setup section](docs/onboarding.md#minimal-setup) for troubleshooting
+   tips.
 
 3. **Configure environment variables:** Copy the example environment file and populate it with the necessary API keys and configuration values.
    ```bash
    cp .env.example .env
    # Now, edit .env with your credentials
    ```
+   If you're behind a proxy set `HTTP_PROXY` and `HTTPS_PROXY`. To target a
+   specific GPU use `CUDA_VISIBLE_DEVICES`.
 
 4. **Launch core services:** The repository provides a `docker-compose.yml` that
    starts an OpenTelemetry collector, a Weaviate vector database, and a Jaeger backend.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -16,6 +16,15 @@ This guide helps new contributors set up the development environment quickly.
   The setup script installs packages using the pre-generated `constraints.txt` file
   to ensure deterministic versions and avoid pip resolver loops.
 
+## Minimal Setup
+For a lightweight environment, you can run only the minimal bootstrap script:
+```bash
+bash scripts/bootstrap_minimal.sh
+```
+The script installs the core dependencies while respecting environment variables
+like `HTTP_PROXY`, `HTTPS_PROXY`, and `CUDA_VISIBLE_DEVICES` for proxy routing
+and GPU selection. Use this when you don't need the full toolchain.
+
 ## Troubleshooting
 
 ### pip network timeouts
@@ -38,4 +47,5 @@ This guide helps new contributors set up the development environment quickly.
 - Install the latest NVIDIA drivers and confirm with `nvidia-smi`.
 - CUDA 11.8 or newer is recommended for GPU acceleration.
 - Match the CUDA version with any local PyTorch or TensorFlow builds if used.
+- Set `CUDA_VISIBLE_DEVICES` to control which GPU the processes use.
 


### PR DESCRIPTION
## Summary
- add Minimal Setup section in `docs/onboarding.md`
- link to that section in README Quick Start instructions
- mention proxy and GPU environment variables in both docs

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bab38da8832a930c29d6396bb590