### PR TITLE
Save CI summary artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,13 @@ jobs:
           path: tests.log
       - name: Summarize failures
         if: always()
-        run: python scripts/ci_summary.py tests.log coverage.xml
+        run: python scripts/ci_summary.py tests.log coverage.xml ci_summary.md
+      - name: Upload CI summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-summary
+          path: ci_summary.md
       - name: Check validation errors
         run: python scripts/check_validation_errors.py tests.log
       - name: Fail if tests failed

--- a/.github/workflows/judge-pipeline.yml
+++ b/.github/workflows/judge-pipeline.yml
@@ -47,7 +47,13 @@ jobs:
           path: judge.log
       - name: Summarize failures
         if: always()
-        run: python scripts/ci_summary.py judge.log coverage.xml
+        run: python scripts/ci_summary.py judge.log coverage.xml ci_summary.md
+      - name: Upload CI summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-summary
+          path: ci_summary.md
       - name: Fail if tests failed
         if: steps.run-judge.outputs.exitcode != '0'
         run: exit 1

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -39,3 +39,13 @@ Example:
 Download the `coverage-html` artifact from the run and open `index.html` locally
 to view detailed coverage results.
 
+## CI Summary Artifact
+
+Every workflow run also saves the generated failure summary as an artifact named
+"CI Summary". It contains the `ci_summary.md` file with links to failing steps,
+coverage reports and the full log. To retrieve it:
+
+1. Open the GitHub Actions run for your commit.
+2. Expand the **Artifacts** section and download **CI Summary**.
+3. View `ci_summary.md` locally for quick links to the coverage HTML and log.
+

--- a/scripts/ci_summary.py
+++ b/scripts/ci_summary.py
@@ -22,7 +22,9 @@ def tail_lines(log_path: str, num: int = 20) -> str:
     return "\n".join(path.read_text().splitlines()[-num:])
 
 
-def main(log_path: str = "tests.log", cov_path: str = "coverage.xml") -> int:
+def main(
+    log_path: str = "tests.log", cov_path: str = "coverage.xml", output_path: str | None = None
+) -> int:
     summary_file = Path(os.environ.get("GITHUB_STEP_SUMMARY", ""))
     cov = coverage_percent(cov_path)
     tail = tail_lines(log_path)
@@ -44,12 +46,17 @@ def main(log_path: str = "tests.log", cov_path: str = "coverage.xml") -> int:
             f"actions/runs/{os.environ.get('GITHUB_RUN_ID')})"
         ),
     ]
+    summary = "\n".join(text)
+
     if summary_file:
-        summary_file.write_text("\n".join(text))
+        summary_file.write_text(summary)
     else:
-        print("\n".join(text))
+        print(summary)
+
+    if output_path:
+        Path(output_path).write_text(summary)
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main(*(sys.argv[1:3])))
+    sys.exit(main(*(sys.argv[1:4])))


### PR DESCRIPTION
## Summary
- add optional output path for `ci_summary.py`
- upload `ci_summary.md` from CI and Judge workflows
- document new artifact in CI guide

## Testing
- `pytest -q`
- ❌ `pre-commit run --files .github/workflows/ci.yml .github/workflows/judge-pipeline.yml scripts/ci_summary.py docs/ci.md` *(failed: environment took too long to install pre-commit dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6852bac8bab4832aae149f75a9b2c705