### PR TITLE
Enhance graph dashboard with confidence styling

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -40,11 +40,13 @@ def dashboard_server(tmp_path_factory):
 
     dashboard_path = str(tmp_path_factory.mktemp("dash"))
     from shutil import copytree
+
     copytree("dashboard", dashboard_path, dirs_exist_ok=True)
 
     app = create_app(exporter, dashboard_path=dashboard_path)
 
     import uvicorn
+
     config = uvicorn.Config(app, host="127.0.0.1", port=8787, log_level="error")
     server = uvicorn.Server(config)
 
@@ -57,7 +59,6 @@ def dashboard_server(tmp_path_factory):
 
 
 def test_dashboard_loads_nodes_and_edges(dashboard_server):
-    exporter = dashboard_server
     with sync_playwright() as p:
         browser = p.chromium.launch()
         page = browser.new_page()

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -80,3 +80,9 @@ def test_graph_encodes_confidence_and_belief_provenance():
     belief = resp.json()
     assert belief["value"] == 0.75
     assert belief["history"]
+
+    resp = client.get("/belief/A/intent")
+    assert resp.status_code == 200
+    belief = resp.json()
+    assert belief["value"] == "B"
+    assert belief["history"]


### PR DESCRIPTION
## Summary
- style graph nodes based on confidence and highlight intent-driven edges
- add click handlers to fetch belief provenance
- test confidence and intent in Graph API

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c012e030832ab5bb8de00b8df624