### PR TITLE
Document core tests marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ This is a mono-repo containing all services, agent definitions, and infrastructu
 
 A comprehensive test suite is crucial for maintaining system quality.
 
+For a quick subset run only the core tests:
+
+```bash
+pytest -m "core"
+```
+See [docs/testing.md#running-core-tests-only](docs/testing.md#running-core-tests-only) for more details.
+
 ### **Unit Tests**
 
 Unit tests verify individual components in isolation. They are located in `tests/unit/`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,6 +16,16 @@ Run linters with `pre-commit`:
 pre-commit run --all-files
 ```
 
+## Running Core Tests Only
+
+To quickly verify essential functionality, run only the tests marked `core`:
+
+```bash
+pytest -m "core"
+```
+
+This skips any tests labeled `optional` and the heavier integration suite.
+
 ## Contract Tests
 
 Contract tests live in `tests/test_ltm_contract.py` and load scenarios from JSON fixtures in `tests/fixtures/ltm_contract/`. Each fixture defines the request headers, body and the expected response. The helper `_assert_contract` checks that status codes and response fields match the fixture.

--- a/scripts/ci_summary.py
+++ b/scripts/ci_summary.py
@@ -23,7 +23,9 @@ def tail_lines(log_path: str, num: int = 20) -> str:
 
 
 def main(
-    log_path: str = "tests.log", cov_path: str = "coverage.xml", output_path: str | None = None
+    log_path: str = "tests.log",
+    cov_path: str = "coverage.xml",
+    output_path: str | None = None,
 ) -> int:
     summary_file = Path(os.environ.get("GITHUB_STEP_SUMMARY", ""))
     cov = coverage_percent(cov_path)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -40,11 +40,13 @@ def dashboard_server(tmp_path_factory):
 
     dashboard_path = str(tmp_path_factory.mktemp("dash"))
     from shutil import copytree
+
     copytree("dashboard", dashboard_path, dirs_exist_ok=True)
 
     app = create_app(exporter, dashboard_path=dashboard_path)
 
     import uvicorn
+
     config = uvicorn.Config(app, host="127.0.0.1", port=8787, log_level="error")
     server = uvicorn.Server(config)
 
@@ -57,7 +59,6 @@ def dashboard_server(tmp_path_factory):
 
 
 def test_dashboard_loads_nodes_and_edges(dashboard_server):
-    exporter = dashboard_server
     with sync_playwright() as p:
         browser = p.chromium.launch()
         page = browser.new_page()


### PR DESCRIPTION
## Summary
- document running core tests with pytest markers
- note this option in README
- clean up dashboard test variable

## Testing
- `pre-commit run --files docs/testing.md README.md tests/test_dashboard.py scripts/ci_summary.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c074166c832aa71cea9e0ee93fb8