### PR TITLE
Implement sandbox simulation runner

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -3,6 +3,7 @@ const { useState, useEffect, useRef } = React;
 function Dashboard() {
   const graphRef = useRef(null);
   const [graphData, setGraphData] = useState({nodes: [], edges: []});
+  const [comparison, setComparison] = useState(null);
 
   useEffect(() => {
     fetch('/graph').then(r => r.json()).then(data => {
@@ -64,9 +65,18 @@ function Dashboard() {
     return () => fg && fg._destructor && fg._destructor();
   }, [graphData]);
 
+  const runSimulation = () => {
+    fetch('/simulate', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({})})
+      .then(() => fetch('/compare/simulation'))
+      .then(r => r.json())
+      .then(setComparison);
+  };
+
   return React.createElement('div', null,
+    React.createElement('button', {onClick: runSimulation}, 'Run Simulation'),
     React.createElement('div', {id: 'graph', ref: graphRef}),
-    React.createElement('div', {id: 'gantt'}, 'Gantt view TBD')
+    React.createElement('div', {id: 'gantt'}, 'Gantt view TBD'),
+    comparison && React.createElement('pre', null, JSON.stringify(comparison, null, 2))
   );
 }
 

--- a/services/tracing/simulations.py
+++ b/services/tracing/simulations.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Utilities for persisting simulation runs."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+try:  # optional dependency
+    from opentelemetry.sdk.trace import ReadableSpan
+except Exception:  # pragma: no cover - fallback
+    ReadableSpan = Any
+
+from engine.state import State
+
+from .graph_api import spans_to_graph
+
+_SIM_DIR = Path(__file__).with_name("simulations")
+_SIM_DIR.mkdir(exist_ok=True)
+
+
+def save_simulation(
+    run_id: str, state: State, metrics: Dict[str, float], spans: List[ReadableSpan]
+) -> None:
+    """Persist a simulation result to a JSON file."""
+    data = {
+        "state": state.model_dump(),
+        "metrics": metrics,
+        "graph": spans_to_graph(spans),
+    }
+    path = _SIM_DIR / f"{run_id}.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def load_simulation(run_id: str) -> Dict[str, Any]:
+    """Load a previously saved simulation."""
+    path = _SIM_DIR / f"{run_id}.json"
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)


### PR DESCRIPTION
## Summary
- add sandbox mode to orchestration engine
- persist simulation traces separately
- expose `/simulate` and `/compare` API routes
- update dashboard to trigger simulations and show metrics

## Testing
- `pre-commit run --files engine/orchestration_engine.py services/tracing/simulations.py services/tracing/graph_api.py dashboard/app.js dashboard/index.html`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c3b79bc4832a906dcdda0891b285