### PR TITLE
Enforce coverage check in PR workflow

### DIFF
--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -59,4 +59,14 @@ jobs:
         run: pre-commit run --all-files
 
       - name: Run tests
-        run: pytest -q
+        run: pytest --cov=./ --cov-report=xml --cov-report=html --cov-fail-under=80 -v
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+      - name: Upload coverage html
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: htmlcov/


### PR DESCRIPTION
## Summary
- enable pytest coverage checking in `minimal-ci.yml`
- upload coverage artifacts for PRs

## Testing
- `pre-commit run --all-files` *(fails: ForwardRef._evaluate() missing 1 required keyword-only argument)*
- `pytest -q` *(fails: ForwardRef._evaluate() missing 1 required keyword-only argument)*

------
https://chatgpt.com/codex/tasks/task_e_6852c73937b0832a91e14ed5dfbeda0d