### PR TITLE
Improve OCR in pdf reader

### DIFF
--- a/tools/pdf_reader.py
+++ b/tools/pdf_reader.py
@@ -64,20 +64,20 @@ def pdf_extract(
 
     try:
         with pdfplumber.open(file_obj) as pdf:
-            text_parts = [page.extract_text() or "" for page in pdf.pages]
-            text = "\n".join(text_parts)
-            if not text.strip() and use_ocr:
-                try:  # pragma: no cover - optional OCR path
-                    import pytesseract
+            text_parts: list[str] = []
+            for page in pdf.pages:
+                page_text = page.extract_text()
+                if not page_text and use_ocr:
+                    try:  # pragma: no cover - optional OCR path
+                        import pytesseract
 
-                    text_parts = []
-                    for page in pdf.pages:
                         img = page.to_image(resolution=300).original
                         page_text = pytesseract.image_to_string(img)
-                        text_parts.append(page_text)
-                    text = "\n".join(text_parts)
-                except Exception:  # pragma: no cover - OCR failures
-                    use_ocr = False
+                    except Exception:  # pragma: no cover - OCR failures
+                        page_text = ""
+                        use_ocr = False
+                text_parts.append(page_text or "")
+            text = "\n".join(text_parts)
     except FileNotFoundError as exc:
         raise FileNotFoundError(validated) from exc
     except PDFSyntaxError as exc:


### PR DESCRIPTION
## Summary
- add per-page OCR fallback in `pdf_extract`
- create helper for mixed-image PDF in tests
- test OCR on partially scanned PDFs

## Testing
- `pre-commit run --files tools/pdf_reader.py tests/test_pdf_reader_tool.py`
- `pytest tests/test_pdf_reader_tool.py -k mixed -q`
- `pytest -q tests/test_pdf_reader_tool.py`

------
https://chatgpt.com/codex/tasks/task_e_6852c7433d7c832aaa7f0edaefceeb7a