### PR TITLE
Add adjustable autonomy and pause controls

### DIFF
--- a/engine/orchestration_engine.py
+++ b/engine/orchestration_engine.py
@@ -208,6 +208,10 @@ class OrchestrationEngine:
         tuple[str, Callable[[State], str | Iterable[str]], Dict[str, str] | None]
     ] = field(default_factory=list)
 
+    default_autonomy_level: State.AutonomyLevel = State.AutonomyLevel.AUTONOMOUS
+    current_state: State | None = field(init=False, default=None)
+    current_next_node: str | None = field(init=False, default=None)
+
     # Using ``Any`` here avoids importing optional dependencies for the dummy
     # checkpointer implementation used in tests.
     checkpointer: Any = field(default_factory=dict)
@@ -224,6 +228,24 @@ class OrchestrationEngine:
     on_complete: Callable[[State], Awaitable[State] | State] | None = None
     error_logger: Callable[[Exception, str, State], None] | None = None
     last_metrics: Dict[str, float] | None = field(init=False, default=None)
+
+    # runtime tracking for pause/resume and autonomy
+    def set_autonomy_level(self, level: State.AutonomyLevel) -> None:
+        self.default_autonomy_level = level
+        if self.current_state is not None:
+            self.current_state.autonomy_level = level
+
+    def pause(self, run_id: str = "default") -> None:
+        if self.current_state is not None:
+            self.current_state.update({"status": "PAUSED"})
+
+    async def resume_async(self, run_id: str = "default") -> State:
+        if self.current_state is None:
+            raise ValueError("No task to resume")
+        state = self.current_state
+        next_node = self.current_next_node
+        state.update({"status": None})
+        return await self.run_async(state, thread_id=run_id, start_at=next_node)
 
     def add_node(
         self,
@@ -303,6 +325,10 @@ class OrchestrationEngine:
             if self.entry is None:
                 self.build()
             self._last_node = None
+            self.current_state = state
+            state.autonomy_level = getattr(
+                state, "autonomy_level", self.default_autonomy_level
+            )
             if hasattr(self.checkpointer, "start"):
                 try:
                     self.checkpointer.start(thread_id, state)
@@ -310,7 +336,11 @@ class OrchestrationEngine:
                     pass
 
             node_name = start_at or self.entry
+            self.current_next_node = node_name
             while node_name:
+                if state.status == "PAUSED":
+                    self.current_next_node = node_name
+                    return state
                 node = self.nodes[node_name]
                 if self._should_quarantine(node, state):
                     node_name = self.quarantine_node
@@ -330,6 +360,15 @@ class OrchestrationEngine:
                         pass
                 self._on_node_finished(node_name)
 
+                if state.autonomy_level == State.AutonomyLevel.MANUAL:
+                    state.update({"status": "PAUSED"})
+                    self.current_next_node = self.order.get(node_name)
+                    if hasattr(self.review_queue, "enqueue"):
+                        self.review_queue.enqueue(
+                            thread_id, state, self.current_next_node
+                        )
+                    return state
+
             if node_name in self.routers_map:
                 router, path_map = self.routers_map[node_name]
                 dest = router(state)
@@ -345,13 +384,18 @@ class OrchestrationEngine:
             else:
                 next_node = self.order.get(node_name)
 
-            if node.node_type == NodeType.HUMAN_IN_THE_LOOP_BREAKPOINT:
+            if (
+                node.node_type == NodeType.HUMAN_IN_THE_LOOP_BREAKPOINT
+                and state.autonomy_level != State.AutonomyLevel.AUTONOMOUS
+            ):
                 state.update({"status": "PAUSED"})
+                self.current_next_node = next_node
                 if hasattr(self.review_queue, "enqueue"):
                     self.review_queue.enqueue(thread_id, state, next_node)
                 return state
 
             node_name = next_node
+            self.current_next_node = node_name
         if self.on_complete:
             try:
                 if asyncio.iscoroutinefunction(self.on_complete):
@@ -401,6 +445,8 @@ class OrchestrationEngine:
             "self_correction_loops": float(self_corrections),
             "communication_overhead": float(communication_tokens),
         }
+        self.current_state = None
+        self.current_next_node = None
 
         return state
 

--- a/engine/state.py
+++ b/engine/state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any, Dict, List
 
 try:  # optional dependency
@@ -35,11 +36,18 @@ except Exception:  # pragma: no cover - simple fallbacks
 class State(BaseModel):
     """Central state passed between orchestration nodes."""
 
+    class AutonomyLevel(str, Enum):
+        MANUAL = "MANUAL"
+        ASSISTIVE = "ASSISTIVE"
+        SUPERVISORY = "SUPERVISORY"
+        AUTONOMOUS = "AUTONOMOUS"
+
     data: Dict[str, Any] = Field(default_factory=dict)
     messages: List[Dict[str, Any]] = Field(default_factory=list)
     history: List[Dict[str, Any]] = Field(default_factory=list)
     scratchpad: Dict[str, Any] = Field(default_factory=dict)
     status: str | None = None
+    autonomy_level: AutonomyLevel = AutonomyLevel.AUTONOMOUS
     evaluator_feedback: Dict[str, Any] | None = None
     retry_count: int = 0
 

--- a/tests/test_autonomy.py
+++ b/tests/test_autonomy.py
@@ -1,0 +1,64 @@
+import asyncio
+
+import pytest
+
+from engine.orchestration_engine import GraphState, create_orchestration_engine
+from engine.state import State
+from services.hitl_review import InMemoryReviewQueue
+
+
+def _build_engine(queue):
+    engine = create_orchestration_engine()
+    engine.review_queue = queue
+
+    def node_a(state: GraphState, scratchpad: dict) -> GraphState:
+        state.update({"a": 1})
+        return state
+
+    def node_b(state: GraphState, scratchpad: dict) -> GraphState:
+        state.update({"b": 2})
+        return state
+
+    engine.add_node("A", node_a)
+    engine.add_node("B", node_b)
+    engine.add_edge("A", "B")
+    return engine
+
+
+def test_manual_autonomy_pauses():
+    queue = InMemoryReviewQueue()
+    engine = _build_engine(queue)
+    state = GraphState()
+    state.autonomy_level = State.AutonomyLevel.MANUAL
+    result = asyncio.run(engine.run_async(state, thread_id="t1"))
+    assert result.status == "PAUSED"
+    assert queue.pending() == ["t1"]
+    resumed = asyncio.run(engine.resume_from_queue_async("t1"))
+    assert resumed.data["b"] == 2
+    assert resumed.status is None
+
+
+@pytest.mark.asyncio
+async def test_pause_method_halts_execution():
+    engine = create_orchestration_engine()
+
+    async def node_a(state: GraphState, _):
+        state.update({"count": 1})
+        return state
+
+    async def node_b(state: GraphState, _):
+        await asyncio.sleep(0.05)
+        state.update({"count": state.data["count"] + 1})
+        return state
+
+    engine.add_node("A", node_a)
+    engine.add_node("B", node_b)
+    engine.add_edge("A", "B")
+
+    state = GraphState()
+    task = asyncio.create_task(engine.run_async(state, thread_id="t"))
+    await asyncio.sleep(0.02)
+    engine.pause("t")
+    result = await task
+    assert result.status == "PAUSED"
+    assert result.data["count"] == 1


### PR DESCRIPTION
## Summary
- introduce `AutonomyLevel` enum on `State`
- track current task in `OrchestrationEngine` and honor manual level
- expose `/autonomy`, `/pause` and `/resume` endpoints
- add dashboard controls for autonomy slider and pause/resume buttons
- test manual mode and pause functionality

## Testing
- `pre-commit run --files engine/state.py engine/orchestration_engine.py services/tracing/graph_api.py dashboard/app.js tests/test_autonomy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c7748e24832a943812b9b151d2c7