### PR TITLE
Implement preference logging and active querying

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -74,6 +74,14 @@ function Dashboard() {
       .then(setComparison);
   };
 
+  const logPreference = preferred => {
+    if (!comparison) return;
+    const better = preferred === 'simulation' ? comparison.simulation : comparison.live;
+    const worse = preferred === 'simulation' ? comparison.live : comparison.simulation;
+    fetch('/preferences', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({better, worse})})
+      .then(() => setComparison(null));
+  };
+
   const updateAutonomy = e => {
     const level = e.target.value;
     fetch('/autonomy', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({level})})
@@ -98,7 +106,13 @@ function Dashboard() {
     ),
     React.createElement('div', {id: 'graph', ref: graphRef}),
     React.createElement('div', {id: 'gantt'}, 'Gantt view TBD'),
-    comparison && React.createElement('pre', null, JSON.stringify(comparison, null, 2))
+    comparison && React.createElement(
+      React.Fragment,
+      null,
+      React.createElement('pre', null, JSON.stringify(comparison, null, 2)),
+      React.createElement('button', {onClick: () => logPreference('live')}, 'Prefer Live'),
+      React.createElement('button', {onClick: () => logPreference('simulation')}, 'Prefer Simulation')
+    )
   );
 }
 

--- a/pipelines/reward_model/__init__.py
+++ b/pipelines/reward_model/__init__.py
@@ -4,10 +4,13 @@ from .composite_reward import (
     LinearPreferenceModel,
 )
 from .pipeline import RewardModelTrainer
+from .preferences import preferences_to_records, train_from_preferences
 
 __all__ = [
     "RewardModelTrainer",
     "CompositeRewardFunction",
     "CompositeRewardConfig",
     "LinearPreferenceModel",
+    "preferences_to_records",
+    "train_from_preferences",
 ]

--- a/pipelines/reward_model/preferences.py
+++ b/pipelines/reward_model/preferences.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .pipeline import RewardModelTrainer
+
+
+def preferences_to_records(path: str | Path) -> List[Dict[str, Any]]:
+    p = Path(path)
+    text = p.read_text(encoding="utf-8")
+    if text.lstrip().startswith("["):
+        prefs = json.loads(text)
+    else:
+        prefs = [json.loads(line) for line in text.splitlines() if line.strip()]
+
+    records: List[Dict[str, Any]] = []
+    for pref in prefs:
+        better = pref.get("better") or pref.get("preferred")
+        worse = pref.get("worse") or pref.get("other")
+        if better is not None:
+            records.append({"trace": better, "score": 1.0})
+        if worse is not None:
+            records.append({"trace": worse, "score": 0.0})
+    return records
+
+
+def train_from_preferences(pref_path: str | Path, out_dir: str | Path) -> RewardModelTrainer:
+    """Train a reward model using logged preference pairs."""
+    records = preferences_to_records(pref_path)
+    temp = Path(out_dir) / "_prefs.jsonl"
+    temp.parent.mkdir(parents=True, exist_ok=True)
+    with temp.open("w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+    trainer = RewardModelTrainer(temp, out_dir)
+    trainer.run()
+    temp.unlink()
+    return trainer

--- a/services/learning/preferences.py
+++ b/services/learning/preferences.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+PREFERENCE_LOG = Path("data/preferences.jsonl")
+
+
+def log_preference(pref: Dict[str, Any], path: str | Path = PREFERENCE_LOG) -> None:
+    """Append a preference record to ``path`` as JSONL."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(pref) + "\n")

--- a/services/tracing/graph_api.py
+++ b/services/tracing/graph_api.py
@@ -190,6 +190,14 @@ def create_app(
                 "simulation": sim.get("metrics", {}),
             }
 
+        @app.post("/preferences")
+        def record_preference(payload: Dict[str, Any]) -> Dict[str, str]:
+            """Log operator preference pairs for reward model training."""
+            from services.learning.preferences import log_preference
+
+            log_preference(payload)
+            return {"status": "logged"}
+
         @app.get("/autonomy")
         def get_autonomy() -> Dict[str, str]:
             level = (

--- a/tests/test_preferences_training.py
+++ b/tests/test_preferences_training.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from pipelines.reward_model import train_from_preferences, LinearPreferenceModel
+from services.learning.rlaif_system import RLAIFSystem
+
+
+class CountingOptimizer:
+    def __init__(self):
+        self.total = 0.0
+
+    def update(self, experience, reward):
+        self.total += reward
+        return -reward
+
+
+def test_preference_training_updates_policy(tmp_path):
+    pref = {"better": "long answer", "worse": "short"}
+    pref_file = tmp_path / "prefs.jsonl"
+    pref_file.write_text(json.dumps(pref) + "\n", encoding="utf-8")
+    out_dir = tmp_path / "model"
+    train_from_preferences(pref_file, out_dir)
+    model = LinearPreferenceModel.from_file(out_dir / "preference_model.json")
+    opt = CountingOptimizer()
+    rlaif = RLAIFSystem(model, opt)
+    rlaif.update_agent_policies([{"prompt": "Q", "response": "short"}])
+    before = opt.total
+    rlaif.update_agent_policies([{"prompt": "Q", "response": "long answer"}])
+    after = opt.total
+    assert after > before
+
+
+def test_active_querying_triggers_callback():
+    called = []
+
+    class ZeroReward:
+        def score(self, exp):
+            return 0.0
+
+    class DummyOpt:
+        def update(self, exp, reward):
+            return 0.0
+
+    def cb(exp):
+        called.append(exp)
+
+    rlaif = RLAIFSystem(ZeroReward(), DummyOpt(), feedback_callback=cb, active_query_threshold=0.5)
+    rlaif.update_agent_policies([{"prompt": "p", "response": "r"}])
+    assert called


### PR DESCRIPTION
## Summary
- log preferences from the UI via new API endpoint
- convert preference logs into reward model training data
- update RLAIF system with active querying support
- wire up dashboard buttons to send preferences
- add tests for preference training and active querying

## Testing
- `pytest -q`
- `pre-commit run --all-files` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852cc4dc4a8832a895f2b1eeec43743