### PR TITLE
Add OpenAPI spec validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,20 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
 
+  api-spec:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install dependencies
+        run: pip install fastapi pydantic PyYAML
+      - name: Check OpenAPI spec
+        run: python scripts/validate_openapi.py
+
   integration:
     needs: changes
     if: |

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,10 +8,10 @@ Run the FastAPI app and navigate to `http://localhost:8081/docs` to access the i
 
 ## Regenerating the spec
 
-After modifying the API, run the following command from the repository root to regenerate `docs/openapi.yaml`:
+After modifying the API, run the following command from the repository root to regenerate `docs/api/openapi.yaml`:
 
 ```bash
 python -m services.ltm_service.generate_spec
 ```
 
-This will output the current OpenAPI schema to `docs/openapi.yaml` so it can be committed to version control.
+This will output the current OpenAPI schema to `docs/api/openapi.yaml` so it can be committed to version control.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -10,6 +10,7 @@ components:
           title: Memory Type
           type: string
         record:
+          additionalProperties: true
           description: Record to store
           title: Record
           type: object
@@ -27,6 +28,27 @@ components:
       - id
       title: ConsolidateResponse
       type: object
+    CritiqueQuery:
+      properties:
+        query:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Query
+      title: CritiqueQuery
+      type: object
+    CritiqueRequest:
+      properties:
+        critique:
+          additionalProperties: true
+          description: Critique record
+          title: Critique
+          type: object
+      required:
+      - critique
+      title: CritiqueRequest
+      type: object
     HTTPValidationError:
       properties:
         detail:
@@ -40,11 +62,13 @@ components:
       properties:
         entities:
           items:
+            additionalProperties: true
             type: object
           title: Entities
           type: array
         relations:
           items:
+            additionalProperties: true
             type: object
           title: Relations
           type: array
@@ -62,17 +86,30 @@ components:
       - ids
       title: PropagateSubgraphResponse
       type: object
+    ProvenanceResponse:
+      properties:
+        provenance:
+          additionalProperties: true
+          description: Provenance metadata
+          title: Provenance
+          type: object
+      required:
+      - provenance
+      title: ProvenanceResponse
+      type: object
     RetrieveBody:
       properties:
         query:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           description: Query to match
           title: Query
         task_context:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           description: Deprecated alternative query field
           title: Task Context
@@ -83,6 +120,7 @@ components:
         results:
           description: Matching records
           items:
+            additionalProperties: true
             type: object
           title: Results
           type: array
@@ -99,7 +137,8 @@ components:
           type: string
         payload:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: string
           description: JSON-LD object or Cypher string
           title: Payload
@@ -118,11 +157,58 @@ components:
       - result
       title: SemanticConsolidateResponse
       type: object
+    SkillQuery:
+      properties:
+        limit:
+          default: 5
+          description: Max results
+          title: Limit
+          type: integer
+        query:
+          anyOf:
+          - type: string
+          - items:
+              type: number
+            type: array
+          - additionalProperties: true
+            type: object
+          description: Vector or metadata
+          title: Query
+      required:
+      - query
+      title: SkillQuery
+      type: object
+    SkillRequest:
+      properties:
+        skill_metadata:
+          additionalProperties: true
+          description: Arbitrary metadata
+          title: Skill Metadata
+          type: object
+        skill_policy:
+          additionalProperties: true
+          description: Skill policy data
+          title: Skill Policy
+          type: object
+        skill_representation:
+          anyOf:
+          - type: string
+          - items:
+              type: number
+            type: array
+          description: Vector or text rep
+          title: Skill Representation
+      required:
+      - skill_policy
+      - skill_representation
+      title: SkillRequest
+      type: object
     TemporalConsolidateRequest:
       properties:
         location:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           description: Location context
           title: Location
@@ -197,6 +283,77 @@ info:
   version: 1.0.0
 openapi: 3.1.0
 paths:
+  /evaluator_memory:
+    get:
+      operationId: evaluator_memory_get_evaluator_memory_get
+      parameters:
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 5
+          maximum: 50
+          minimum: 1
+          title: Limit
+          type: integer
+      - in: header
+        name: x-role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CritiqueQuery'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetrieveResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Retrieve evaluator critiques
+    post:
+      operationId: evaluator_memory_store_evaluator_memory_post
+      parameters:
+      - in: header
+        name: x-role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CritiqueRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConsolidateResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Store evaluator critique
   /memory:
     get:
       operationId: get_memory_memory_get
@@ -307,6 +464,44 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Propagate a completed subgraph
+  /provenance/{memory_type}/{record_id}:
+    get:
+      operationId: get_provenance_provenance__memory_type___record_id__get
+      parameters:
+      - in: path
+        name: memory_type
+        required: true
+        schema:
+          title: Memory Type
+          type: string
+      - in: path
+        name: record_id
+        required: true
+        schema:
+          title: Record Id
+          type: string
+      - in: header
+        name: x-role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Role
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProvenanceResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get provenance
   /semantic_consolidate:
     post:
       operationId: semantic_consolidate_semantic_consolidate_post
@@ -339,6 +534,102 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Store facts in the knowledge graph
+  /skill:
+    post:
+      operationId: store_skill_skill_post
+      parameters:
+      - in: header
+        name: x-role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SkillRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConsolidateResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Store a skill
+  /skill_metadata_query:
+    post:
+      operationId: skill_metadata_query_skill_metadata_query_post
+      parameters:
+      - in: header
+        name: x-role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SkillQuery'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetrieveResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Query skills by metadata
+  /skill_vector_query:
+    post:
+      operationId: skill_vector_query_skill_vector_query_post
+      parameters:
+      - in: header
+        name: x-role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SkillQuery'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetrieveResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Query skills by vector
   /spatial_query:
     get:
       operationId: spatial_query_spatial_query_get

--- a/scripts/validate_openapi.py
+++ b/scripts/validate_openapi.py
@@ -1,0 +1,41 @@
+import importlib.util
+import pathlib
+
+import yaml
+
+root = pathlib.Path(__file__).resolve().parents[1]
+spec_path = root / "docs" / "api" / "openapi.yaml"
+
+spec = importlib.util.spec_from_file_location(
+    "openapi_app", root / "services" / "ltm_service" / "openapi_app.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class Dummy:
+    def consolidate(self, memory_type, record):
+        return "1"
+
+    def retrieve(self, memory_type, query, limit=5):
+        return []
+
+    def semantic_consolidate(self, payload, fmt="jsonld"):
+        return []
+
+
+def main() -> int:
+    app = module.create_app(Dummy())
+    generated = app.openapi()
+    existing = yaml.safe_load(spec_path.read_text())
+    if generated != existing:
+        print(
+            "OpenAPI specification is outdated. Run 'python services/ltm_service/generate_spec.py'."
+        )
+        return 1
+    print("OpenAPI specification is up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/ltm_service/generate_spec.py
+++ b/services/ltm_service/generate_spec.py
@@ -26,6 +26,6 @@ class Dummy:
 
 
 app = module.create_app(Dummy())
-path = pathlib.Path(__file__).resolve().parents[2] / "docs" / "openapi.yaml"
+path = pathlib.Path(__file__).resolve().parents[2] / "docs" / "api" / "openapi.yaml"
 path.write_text(yaml.dump(app.openapi()))
 print(f"Wrote {path}")


### PR DESCRIPTION
## Summary
- generate OpenAPI spec into `docs/api/openapi.yaml`
- document regeneration path
- add script to verify the spec matches implementation
- check spec in CI

## Testing
- `pre-commit run --files docs/api.md services/ltm_service/generate_spec.py scripts/validate_openapi.py .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852cd3a0fec832abeed0ef27cd6a0fe