### PR TITLE
Add draft constitution and governance integration

### DIFF
--- a/constitution.yaml
+++ b/constitution.yaml
@@ -1,0 +1,14 @@
+version: 0.1
+principles:
+  - id: P-HELPFULNESS
+    description: Provide accurate and relevant information.
+  - id: P-HARMLESSNESS
+    description: Avoid harmful or offensive content.
+  - id: P-TRANSPARENCY
+    description: Disclose limitations and sources when appropriate.
+  - id: P-ACCOUNTABILITY
+    description: Log decisions for audit and oversight.
+policies:
+  banned_terms:
+    - forbidden
+    - malicious

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -1,0 +1,17 @@
+# Governance Process
+
+This repository uses a lightweight governance model centered on an **AI Safety Council**. The council drafts and approves the system constitution stored at the repository root as `constitution.yaml`.
+
+## Constitution Management
+
+1. Proposed changes to the constitution are submitted as pull requests.
+2. Each proposal must include rationale and be approved by a majority of the council.
+3. Approved versions are tagged and referenced in pipeline metadata.
+
+## Change Requests
+
+All major architectural or policy updates are tracked as change requests in `docs/change_request_ledger.md`. Contributors open a CR with the proposed modification and the council reviews it during scheduled meetings.
+
+## Reward Model Alignment
+
+Training pipelines consume the active constitution to generate self‑critique scores and preference labels. Metadata for each reward model release records the constitution version used so future audits can reproduce training conditions.

--- a/scripts/train_reward_model.py
+++ b/scripts/train_reward_model.py
@@ -9,6 +9,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Train Reward Model")
     parser.add_argument("--data-path", type=Path, required=True)
     parser.add_argument("--out-root", type=Path, default=Path("models/reward_model"))
+    parser.add_argument("--constitution", type=Path, required=True)
     parser.add_argument("--version", default=None)
     args = parser.parse_args()
 
@@ -17,7 +18,12 @@ def main() -> None:
     )
     out_dir = args.out_root / version
 
-    trainer = RewardModelTrainer(args.data_path, out_dir)
+    trainer = RewardModelTrainer(
+        args.data_path,
+        out_dir,
+        constitution_path=args.constitution,
+        version=version,
+    )
     mse = trainer.run()
     print(f"Saved model to {out_dir}")
     print(f"Eval MSE: {mse:.3f}")


### PR DESCRIPTION
## Summary
- add `constitution.yaml` with initial principles
- document governance workflow
- integrate constitution-based self-critique into reward model trainer
- version reward model artifacts and expose constitution path
- update training script to require constitution file

## Testing
- `pre-commit run --files constitution.yaml docs/governance/README.md pipelines/reward_model/pipeline.py scripts/train_reward_model.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852db3b07e0832a8732e139a10dc747