### PR TITLE
Add Safeguard monitoring agent

### DIFF
--- a/agents/SafeguardAgent/config.yml
+++ b/agents/SafeguardAgent/config.yml
@@ -1,0 +1,4 @@
+agent_name: "SafeguardAgent"
+role: "Monitor policy compliance and block unsafe actions"
+max_retries: 0
+rbac: []

--- a/agents/SafeguardAgent/prompt.tpl.md
+++ b/agents/SafeguardAgent/prompt.tpl.md
@@ -1,0 +1,6 @@
+# Safeguard Agent Prompt
+You observe all inter-agent messages and tool calls.
+Flag any action that violates the system policy:
+- Disallowed tools: {{policy.blocked_tools}}
+- Banned keywords: {{policy.blocked_keywords}}
+Respond only with a JSON object `{"alert": "<description>"}` when you detect a violation.

--- a/engine/collaboration/group_chat.py
+++ b/engine/collaboration/group_chat.py
@@ -103,6 +103,12 @@ class DynamicGroupChat:
         recipient: Optional[str] = None,
     ) -> None:
         """Send a message to the chat."""
+        from services.policy_monitor import get_monitor
+
+        monitor = get_monitor()
+        if monitor is not None:
+            monitor.check_message(sender, content)
+
         msg = ChatMessage.validate_message(
             {
                 "sender": sender,

--- a/engine/orchestration_engine.py
+++ b/engine/orchestration_engine.py
@@ -228,6 +228,7 @@ class OrchestrationEngine:
     on_complete: Callable[[State], Awaitable[State] | State] | None = None
     error_logger: Callable[[Exception, str, State], None] | None = None
     last_metrics: Dict[str, float] | None = field(init=False, default=None)
+    policy_monitor: Any | None = None
 
     # runtime tracking for pause/resume and autonomy
     def set_autonomy_level(self, level: State.AutonomyLevel) -> None:
@@ -583,8 +584,16 @@ class OrchestrationEngine:
 
 
 def create_orchestration_engine(
-    *, memory_manager: Callable[[State], Awaitable[State] | State] | None = None
+    *,
+    memory_manager: Callable[[State], Awaitable[State] | State] | None = None,
+    monitor: Any | None = None,
 ) -> OrchestrationEngine:
     """Factory function for the core orchestration engine."""
 
-    return OrchestrationEngine(on_complete=memory_manager)
+    eng = OrchestrationEngine(on_complete=memory_manager)
+    eng.policy_monitor = monitor
+    if monitor is not None:
+        from services.policy_monitor import set_monitor
+
+        set_monitor(monitor)
+    return eng

--- a/services/policy_monitor.py
+++ b/services/policy_monitor.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+class PolicyViolation(Exception):
+    """Raised when an action violates the policy."""
+
+class PolicyMonitor:
+    def __init__(self, policy: Dict[str, List[str]] | None = None) -> None:
+        self.policy = policy or {"blocked_tools": [], "blocked_keywords": []}
+        self.events: List[Dict[str, Any]] = []
+
+    def check_tool(self, role: str, name: str) -> None:
+        allowed = name not in self.policy.get("blocked_tools", [])
+        event = {"type": "tool", "role": role, "tool": name, "allowed": allowed}
+        self.events.append(event)
+        if not allowed:
+            logger.warning("Policy blocked tool %s for role %s", name, role)
+            raise PolicyViolation(f"tool {name} blocked")
+
+    def check_message(self, sender: str, content: str) -> None:
+        blocked = False
+        for word in self.policy.get("blocked_keywords", []):
+            if word.lower() in content.lower():
+                blocked = True
+                reason = word
+                break
+        event = {
+            "type": "message",
+            "sender": sender,
+            "content": content,
+            "allowed": not blocked,
+        }
+        self.events.append(event)
+        if blocked:
+            logger.warning("Policy blocked message from %s", sender)
+            raise PolicyViolation(f"message contains banned term '{reason}'")
+
+_MONITOR: PolicyMonitor | None = None
+
+
+def set_monitor(monitor: PolicyMonitor | None) -> None:
+    global _MONITOR
+    _MONITOR = monitor
+
+
+def get_monitor() -> PolicyMonitor | None:
+    return _MONITOR

--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -118,6 +118,9 @@ class ToolRegistry:
         """Invoke a tool via the registry enforcing RBAC."""
 
         timestamp = datetime.datetime.now(datetime.UTC).isoformat()
+        from services.policy_monitor import get_monitor
+
+        monitor = get_monitor()
         try:
             tool = self.get_tool(role, name)
         except AccessDeniedError:
@@ -141,6 +144,9 @@ class ToolRegistry:
                 intent=intent,
             ).record()
             raise
+
+        if monitor is not None:
+            monitor.check_tool(role, name)
 
         result = tool(*args, **kwargs)
         logger.info(

--- a/tests/test_safeguard_monitor.py
+++ b/tests/test_safeguard_monitor.py
@@ -1,0 +1,34 @@
+import logging
+import pytest
+
+from engine.collaboration.group_chat import DynamicGroupChat
+from services.tool_registry import ToolRegistry
+from services.policy_monitor import PolicyMonitor, set_monitor, PolicyViolation
+
+
+def dummy_tool():
+    return "ok"
+
+
+def test_blocked_tool_raises_and_logged(caplog):
+    monitor = PolicyMonitor({"blocked_tools": ["dummy"]})
+    set_monitor(monitor)
+    registry = ToolRegistry()
+    registry.register_tool("dummy", dummy_tool)
+    caplog.set_level(logging.WARNING)
+    with pytest.raises(PolicyViolation):
+        registry.invoke("A", "dummy")
+    assert any("blocked" in r.message for r in caplog.records)
+    assert any(e["type"] == "tool" and not e["allowed"] for e in monitor.events)
+
+
+def test_blocked_message_raises_and_logged(caplog):
+    monitor = PolicyMonitor({"blocked_keywords": ["bad"]})
+    set_monitor(monitor)
+    chat = DynamicGroupChat({})
+    caplog.set_level(logging.WARNING)
+    chat.post_message("A", "hello")
+    with pytest.raises(PolicyViolation):
+        chat.post_message("A", "this is bad")
+    assert any("blocked" in r.message for r in caplog.records)
+    assert any(e["type"] == "message" and not e["allowed"] for e in monitor.events)


### PR DESCRIPTION
## Summary
- introduce `SafeguardAgent` config and prompt
- add `PolicyMonitor` service for runtime policy enforcement
- integrate policy checks into group chat and tool registry
- expose monitor via `create_orchestration_engine`
- test that blocked actions raise alerts and are logged

## Testing
- `pre-commit run --all-files` *(fails: flake8 and isort modified unrelated files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852dab3e3d4832a8fd62826e5b026cf