### PR TITLE
Add AI assurance plan with review schedule

### DIFF
--- a/docs/change_request_ledger.md
+++ b/docs/change_request_ledger.md
@@ -30,7 +30,7 @@ This ledger tracks open change requests across the project. Each entry lists the
 | CR-EA-03 | Machine-readable ethical constitution | Open |
 | CR-EA-04 | Constitutionally aligned RL loop | Open |
 | CR-EA-05 | Continuous adversarial benchmarking pipeline | Open |
-| CR-EA-06 | AI assurance lifecycle framework | Open |
+| CR-EA-06 | AI assurance lifecycle framework | Implemented |
 | CR-2.1 | AgentAuditor experiential memory | Open |
 | CR-2.2 | RAG-based recall in Evaluator | Open |
 | CR-2.3 | Secure Evaluator API authentication | Open |

--- a/docs/governance/ai_assurance_plan.md
+++ b/docs/governance/ai_assurance_plan.md
@@ -1,0 +1,18 @@
+# AI Assurance Plan
+
+This document outlines the assurance activities used to demonstrate that the agentic-research-engine operates within defined safety and policy constraints. Evidence from implemented components is mapped to each activity and reviewed on a recurring basis.
+
+## Assurance Activities and Evidence
+
+| Activity | Evidence |
+|---------|---------|
+| **Input/Output Guardrails** | Guardrail orchestration service validates prompts and logs moderation decisions. Implementation in `GuardrailService` shows checks for prompt injection and PII【F:services/guardrail_orchestrator/service.py†L15-L35】. |
+| **Policy Enforcement** | `SafeguardAgent` monitors agent communication and emits alerts for violations. Prompt template defines how violations are reported【F:agents/SafeguardAgent/prompt.tpl.md†L1-L8】 with configuration in `config.yml`【F:agents/SafeguardAgent/config.yml†L1-L4】. |
+| **Ethical Constitution** | Repository root `constitution.yaml` enumerates principles and banned terms that drive policy checks【F:constitution.yaml†L1-L14】. |
+| **Benchmarking** | Performance and forgetting benchmarks validate system behavior under load and memory pruning strategies. Example benchmark located at `benchmarks/ltm_pruning_benchmark.py`【F:benchmarks/ltm_pruning_benchmark.py†L1-L15】. |
+
+All evidence references are version controlled to preserve traceability.
+
+## Review Schedule
+
+Assurance artifacts are reviewed quarterly by the AI Safety Council. Each session logs discussion topics, outcomes, and action items in [review_log.md](review_log.md). The first review occurs within one month of adopting this plan.

--- a/docs/governance/review_log.md
+++ b/docs/governance/review_log.md
@@ -1,0 +1,7 @@
+# Assurance Review Log
+
+This log records periodic reviews of the AI assurance plan.
+
+| Date | Participants | Summary |
+|------|--------------|---------|
+| _TBD_ | AI Safety Council | Initial adoption of AI assurance plan. |


### PR DESCRIPTION
## Summary
- create `ai_assurance_plan.md` with evidence mapping to guardrails, safeguard agent, constitution and benchmarks
- log quarterly reviews in `review_log.md`
- mark `CR-EA-06` as implemented in the change request ledger

## Testing
- `bash scripts/agent-setup.sh` *(failed: dependency resolution issue)*
- `pre-commit run --all-files` *(failed: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e5929ff4832aa1626e040a079ad2