### PR TITLE
Add episodic forgetting cron job

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ The architecture of the agentic-research-engine is founded on four key pillars t
    * **Episodic Memory**: For learning from past tasks and experiences.
    * **Semantic Memory**: A trusted internal knowledge graph of verified facts.
    * **Procedural Memory**: For acquiring and reusing successful "skills" or action sequences.
-   * A scheduled Kubernetes CronJob prunes stale episodic records nightly to keep retrieval efficient.
+  * A scheduled Kubernetes CronJob calls the LTM `forget` API nightly to remove
+    stale episodic records based on stored timestamps. The job emits a
+    `ltm.deletions` metric for monitoring.
 3. **Institutionalized Self-Correction Loop**: Moving beyond ineffective self-reflection, the system institutionalizes a formal critique-and-refinement process. A dedicated Evaluator agent provides external feedback on agent outputs, driving an iterative correction cycle to ensure high-quality, reliable results.[1]
 4. **Multi-Faceted Evaluation Framework**: System performance is measured through a comprehensive framework that assesses not only task accuracy (via a BrowseComp-style benchmark) but also output quality, source fidelity, and collaboration efficiency. This data feeds a Reinforcement Learning from AI Feedback (RLAIF) loop, enabling the system to continuously improve its own policies.[1]
 

--- a/docs/architecture/ltm_forgetting_cronjob.md
+++ b/docs/architecture/ltm_forgetting_cronjob.md
@@ -11,4 +11,11 @@ forgetting:
   ttlDays: "180"
 ```
 
-The CronJob times out after five minutes and retries once if it fails, ensuring transient database issues do not leave stale data behind. Job output is captured in the cluster logs so operations can audit how many records were pruned each run.
+The CronJob calls the LTM service's HTTP API. It fetches episodic memories via
+`/memory` and deletes stale ones with the `/forget` endpoint. The service URL is
+configured via the `LTM_BASE_URL` environment variable and defaults to the
+`agent-services` service. The CronJob times out after five minutes and retries
+once if it fails, ensuring transient database issues do not leave stale data
+behind. Job output is captured in the cluster logs so operations can audit how
+many records were pruned each run. A metric `ltm.deletions` is emitted for
+monitoring.

--- a/infra/helm/agent-services/templates/forgetting-cronjob.yaml
+++ b/infra/helm/agent-services/templates/forgetting-cronjob.yaml
@@ -20,4 +20,6 @@ spec:
             env:
             - name: LTM_TTL_DAYS
               value: "{{ .Values.forgetting.ttlDays }}"
+            - name: LTM_BASE_URL
+              value: "http://agent-services"
 {{- end }}

--- a/scripts/episodic_forgetting_job.py
+++ b/scripts/episodic_forgetting_job.py
@@ -1,18 +1,51 @@
 import os
+import time
+from typing import List
 
+import requests
 from opentelemetry import trace
 
-from services.ltm_service import EpisodicMemoryService, InMemoryStorage
+from services.monitoring.system_monitor import SystemMonitor
 
 TTL_DAYS = float(os.getenv("LTM_TTL_DAYS", "30"))
 TTL_SECONDS = TTL_DAYS * 24 * 3600
+LTM_BASE_URL = os.getenv("LTM_BASE_URL", "http://agent-services")
+OTEL_ENDPOINT = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 
 
 def main() -> None:
-    storage = InMemoryStorage()
-    service = EpisodicMemoryService(storage)
-    pruned = service.prune_stale_memories(TTL_SECONDS)
+    monitor = SystemMonitor.from_otlp(OTEL_ENDPOINT)
     tracer = trace.get_tracer(__name__)
+
+    try:
+        resp = requests.get(
+            f"{LTM_BASE_URL}/memory",
+            params={"memory_type": "episodic", "limit": 10000},
+            timeout=10,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - network error
+        print(f"failed to fetch memories: {exc}")
+        return
+    records: List[dict] = resp.json().get("results", [])
+    cutoff = time.time() - TTL_SECONDS
+    pruned = 0
+    for rec in records:
+        last = rec.get("last_accessed") or rec.get("last_accessed_timestamp", 0)
+        if last < cutoff and rec.get("id"):
+            try:
+                r = requests.delete(
+                    f"{LTM_BASE_URL}/forget/{rec['id']}",
+                    params={"memory_type": "episodic"},
+                    json={"hard": True},
+                    timeout=10,
+                )
+                if r.status_code == 200:
+                    pruned += 1
+            except requests.RequestException:
+                continue  # best effort
+
+    monitor.record_ltm_deletions(pruned)
     with tracer.start_as_current_span(
         "forget_job", attributes={"pruned": pruned, "ttl_days": TTL_DAYS}
     ):

--- a/services/monitoring/system_monitor.py
+++ b/services/monitoring/system_monitor.py
@@ -65,6 +65,9 @@ class SystemMonitor:
         self._ltm_miss_counter = self._meter.create_counter(
             "ltm.misses", description="LTM retrieval misses"
         )
+        self._ltm_delete_counter = self._meter.create_counter(
+            "ltm.deletions", description="LTM records deleted"
+        )
 
     @classmethod
     def from_otlp(cls, endpoint: str = "http://localhost:4317") -> "SystemMonitor":
@@ -112,3 +115,8 @@ class SystemMonitor:
             self._ltm_hit_counter.add(1, attributes)
         else:
             self._ltm_miss_counter.add(1, attributes)
+
+    def record_ltm_deletions(self, count: int) -> None:
+        """Record how many LTM records were deleted."""
+        if count:
+            self._ltm_delete_counter.add(count)

--- a/tests/test_ltm_metrics.py
+++ b/tests/test_ltm_metrics.py
@@ -50,3 +50,27 @@ def test_ltm_hit_and_miss_metrics(monkeypatch):
     }
     assert "ltm.hits" in names
     assert "ltm.misses" in names
+
+
+def test_ltm_deletion_metric(monkeypatch):
+    import importlib
+
+    import opentelemetry.metrics._internal as metrics_internal
+    import opentelemetry.trace as trace
+
+    importlib.reload(trace)
+    importlib.reload(metrics_internal)
+    metric_reader = InMemoryMetricReader()
+    span_exporter = InMemorySpanExporter()
+    monitor = SystemMonitor(metric_reader, span_exporter)
+
+    monitor.record_ltm_deletions(3)
+
+    data = metric_reader.get_metrics_data()
+    names = {
+        m.name
+        for rm in data.resource_metrics
+        for sm in rm.scope_metrics
+        for m in sm.metrics
+    }
+    assert "ltm.deletions" in names


### PR DESCRIPTION
## Summary
- call LTM `forget` API in periodic forgetting job
- record deletion count in SystemMonitor
- surface new deletion metric in docs and README
- configure CronJob to pass `LTM_BASE_URL`
- test new metric functionality

## Testing
- `pre-commit run --files services/monitoring/system_monitor.py scripts/episodic_forgetting_job.py infra/helm/agent-services/templates/forgetting-cronjob.yaml docs/architecture/ltm_forgetting_cronjob.md README.md tests/test_ltm_metrics.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e601ae3c832ab29da0f47793ef5b