### PR TITLE
Add edge metadata support

### DIFF
--- a/engine/orchestration_engine.py
+++ b/engine/orchestration_engine.py
@@ -161,6 +161,7 @@ class Edge:
     start: str
     end: str
     edge_type: str | None = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 async def parallel_subgraphs(
@@ -266,8 +267,22 @@ class OrchestrationEngine:
             name, subgraph, retries, NodeType.SUBGRAPH, self.error_logger
         )
 
-    def add_edge(self, start: str, end: str, *, edge_type: str | None = None) -> None:
-        self.edges.append(Edge(start=start, end=end, edge_type=edge_type))
+    def add_edge(
+        self,
+        start: str,
+        end: str,
+        *,
+        edge_type: str | None = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Create a connection between two nodes with optional metadata."""
+
+        data = metadata.copy() if metadata else {}
+        if edge_type is not None:
+            data.setdefault("edge_type", edge_type)
+        self.edges.append(
+            Edge(start=start, end=end, edge_type=edge_type, metadata=data)
+        )
 
     def add_router(
         self,

--- a/tests/unit/test_edge_metadata.py
+++ b/tests/unit/test_edge_metadata.py
@@ -1,0 +1,26 @@
+from engine.orchestration_engine import create_orchestration_engine
+
+
+def test_add_edge_with_metadata():
+    eng = create_orchestration_engine()
+    eng.add_node("A", lambda s, sp: s)
+    eng.add_node("B", lambda s, sp: s)
+
+    eng.add_edge("A", "B", edge_type="ok", metadata={"custom": 1})
+
+    assert eng.edges[0].edge_type == "ok"
+    assert eng.edges[0].metadata["custom"] == 1
+    eng.build()
+    edges = eng.get_edges("A", "ok")
+    assert len(edges) == 1
+    assert edges[0].metadata["custom"] == 1
+
+
+def test_labeled_edge_export_dot():
+    eng = create_orchestration_engine()
+    eng.add_node("A", lambda s, sp: s)
+    eng.add_node("B", lambda s, sp: s)
+    eng.add_edge("A", "B", edge_type="label")
+    eng.build()
+    dot = eng.export_dot()
+    assert '"A" -> "B" [label="label"];' in dot


### PR DESCRIPTION
## Summary
- allow edges to store metadata
- keep edge type info when adding edges
- test metadata persistence and DOT export

## Testing
- `pre-commit run --files engine/orchestration_engine.py tests/unit/test_edge_metadata.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535dd21298832aa21d328674833914