### PR TITLE
Enforce RBAC with tool registry

### DIFF
--- a/agents/supervisor.py
+++ b/agents/supervisor.py
@@ -57,11 +57,10 @@ class SupervisorAgent:
         self.tool_registry = tool_registry or create_default_registry()
         self.procedural_memory = procedural_memory
         try:
-            self.knowledge_graph_search = self.tool_registry.get_tool(
-                "Supervisor", "knowledge_graph_search"
-            )
+            self.tool_registry.get_tool("Supervisor", "knowledge_graph_search")
+            self.has_knowledge_graph_search = True
         except Exception:
-            self.knowledge_graph_search = None
+            self.has_knowledge_graph_search = False
         if use_plan_templates is None:
             env_val = os.getenv("USE_PLAN_TEMPLATES")
             use_plan_templates = True if env_val is None else bool(env_val)
@@ -283,9 +282,11 @@ class SupervisorAgent:
 
         cleaned = query.strip()
         facts: List[Dict[str, Any]] = []
-        if self.knowledge_graph_search:
+        if self.has_knowledge_graph_search:
             try:
-                facts = self.knowledge_graph_search({"text": cleaned})
+                facts = self.tool_registry.invoke(
+                    "Supervisor", "knowledge_graph_search", {"text": cleaned}
+                )
             except Exception:
                 facts = []
         plan = self.plan_research_task(cleaned)

--- a/tests/test_agent_rbac.py
+++ b/tests/test_agent_rbac.py
@@ -1,0 +1,25 @@
+import pytest
+
+from agents.code_researcher import CodeResearcherAgent
+from agents.web_researcher import WebResearcherAgent
+from services.tool_registry import AccessDeniedError, ToolRegistry
+
+
+@pytest.mark.core
+def test_webresearcher_blocked_tool():
+    registry = ToolRegistry()
+    registry.register_tool("web_search", lambda q: [], allowed_roles=["Supervisor"])
+    registry.register_tool("summarize", lambda t: "", allowed_roles=["WebResearcher"])
+    with pytest.raises(AccessDeniedError):
+        WebResearcherAgent(registry).research_topic("topic", {})
+
+
+@pytest.mark.core
+def test_code_researcher_blocked_tool():
+    registry = ToolRegistry()
+    registry.register_tool(
+        "code_interpreter", lambda c, args=None: {}, allowed_roles=["Supervisor"]
+    )
+    agent = CodeResearcherAgent(registry)
+    with pytest.raises(AccessDeniedError):
+        agent.analyze_code("print('hi')")

--- a/tests/test_code_researcher.py
+++ b/tests/test_code_researcher.py
@@ -2,6 +2,7 @@ import pytest
 
 from agents.code_researcher import CodeResearcherAgent
 from engine.orchestration_engine import GraphState
+from services.tool_registry import ToolRegistry
 
 pytestmark = pytest.mark.core
 
@@ -13,7 +14,11 @@ def test_analyze_code_invokes_interpreter():
         calls.append(code)
         return {"stdout": "ok", "stderr": "", "returncode": 0}
 
-    agent = CodeResearcherAgent({"code_interpreter": interpreter})
+    registry = ToolRegistry()
+    registry.register_tool(
+        "code_interpreter", interpreter, allowed_roles=["CodeResearcher"]
+    )
+    agent = CodeResearcherAgent(registry)
     result = agent.analyze_code("print('hi')")
 
     assert result["stdout"] == "ok"
@@ -24,7 +29,11 @@ def test_node_updates_state():
     def interpreter(code: str, *, args=None, timeout=5):
         return {"stdout": "done", "stderr": "", "returncode": 0}
 
-    agent = CodeResearcherAgent({"code_interpreter": interpreter})
+    registry = ToolRegistry()
+    registry.register_tool(
+        "code_interpreter", interpreter, allowed_roles=["CodeResearcher"]
+    )
+    agent = CodeResearcherAgent(registry)
     state = GraphState(data={"code": "print('x')", "code_args": []})
     out = agent(state, {})
 


### PR DESCRIPTION
## Summary
- route WebResearcherAgent, CodeResearcherAgent and SupervisorAgent tool calls through `ToolRegistry`
- add helper methods to check for and invoke tools
- update tests for new registry usage
- add RBAC regression tests

## Testing
- `pre-commit run --files agents/code_researcher.py agents/web_researcher.py agents/supervisor.py tests/test_web_researcher.py tests/test_code_researcher.py tests/test_agent_rbac.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535dc9932c832ab2a510e2640554fe