### PR TITLE
Add SQL connectors and registry tests

### DIFF
--- a/tools/postgres_query.py
+++ b/tools/postgres_query.py
@@ -1,28 +1,7 @@
 from __future__ import annotations
 
-"""PostgreSQL query helper returning pandas DataFrames."""
+"""Backward compatibility wrapper for PostgresQueryTool."""
 
-from typing import Sequence
+from tools.sql.postgres import PostgresQueryTool as PostgresQueryTool
 
-import asyncpg
-import pandas as pd
-
-
-class PostgresQueryTool:
-    """Execute SQL queries against a PostgreSQL database using asyncpg."""
-
-    def __init__(self, dsn: str) -> None:
-        self.dsn = dsn
-
-    async def run_query(self, sql: str, params: Sequence | None = None) -> pd.DataFrame:
-        """Run a SQL query and return the results as a DataFrame."""
-        conn = await asyncpg.connect(self.dsn)
-        try:
-            records = await conn.fetch(sql, *(params or []))
-        finally:
-            await conn.close()
-        if not records:
-            return pd.DataFrame()
-        columns = records[0].keys()
-        rows = [tuple(r.values()) for r in records]
-        return pd.DataFrame(rows, columns=columns)
+__all__ = ["PostgresQueryTool"]

--- a/tools/sql/__init__.py
+++ b/tools/sql/__init__.py
@@ -1,0 +1,4 @@
+from .postgres import PostgresQueryTool
+from .sqlite import SQLiteQueryTool
+
+__all__ = ["SQLiteQueryTool", "PostgresQueryTool"]

--- a/tools/sql/postgres.py
+++ b/tools/sql/postgres.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""PostgreSQL connector returning pandas DataFrames."""
+
+from typing import Sequence
+
+import asyncpg
+import pandas as pd
+
+
+class PostgresQueryTool:
+    """Execute SQL queries against a PostgreSQL database using asyncpg."""
+
+    def __init__(self, dsn: str) -> None:
+        self.dsn = dsn
+
+    async def run_query(self, sql: str, params: Sequence | None = None) -> pd.DataFrame:
+        """Run a SQL query and return the results as a DataFrame."""
+        conn = await asyncpg.connect(self.dsn)
+        try:
+            records = await conn.fetch(sql, *(params or []))
+        finally:
+            await conn.close()
+        if not records:
+            return pd.DataFrame()
+        columns = records[0].keys()
+        rows = [tuple(r.values()) for r in records]
+        return pd.DataFrame(rows, columns=columns)

--- a/tools/sql/sqlite.py
+++ b/tools/sql/sqlite.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""SQLite connector returning pandas DataFrames."""
+
+import sqlite3
+from typing import Sequence
+
+import pandas as pd
+
+
+class SQLiteQueryTool:
+    """Execute read-only SQL queries against a SQLite database."""
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    def run_query(self, sql: str, params: Sequence | None = None) -> pd.DataFrame:
+        """Run a SQL query and return the results as a DataFrame."""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(sql, params or [])
+            rows = cursor.fetchall()
+            columns = [desc[0] for desc in cursor.description or []]
+        return pd.DataFrame(rows, columns=columns)

--- a/tools/sqlite_query.py
+++ b/tools/sqlite_query.py
@@ -1,23 +1,7 @@
 from __future__ import annotations
 
-"""SQLite query helper returning pandas DataFrames."""
+"""Backward compatibility wrapper for SQLiteQueryTool."""
 
-import sqlite3
-from typing import Sequence
+from tools.sql.sqlite import SQLiteQueryTool as SqliteQueryTool
 
-import pandas as pd
-
-
-class SqliteQueryTool:
-    """Execute read-only SQL queries against a SQLite database."""
-
-    def __init__(self, db_path: str) -> None:
-        self.db_path = db_path
-
-    def run_query(self, sql: str, params: Sequence | None = None) -> pd.DataFrame:
-        """Run a SQL query and return the results as a DataFrame."""
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.execute(sql, params or [])
-            rows = cursor.fetchall()
-            columns = [desc[0] for desc in cursor.description or []]
-        return pd.DataFrame(rows, columns=columns)
+__all__ = ["SqliteQueryTool"]


### PR DESCRIPTION
## Summary
- add `tools/sql` module with SQLite and PostgreSQL connectors
- keep wrappers in `tools/sqlite_query.py` and `tools/postgres_query.py`
- test connector usage via the tool registry

## Testing
- `pre-commit run --files tools/postgres_query.py tools/sqlite_query.py tools/sql/postgres.py tools/sql/sqlite.py tools/sql/__init__.py tools/__init__.py tests/test_sql_connectors.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685361fad498832a928ed197b505c2d5