### PR TITLE
Add message bus support

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -37,4 +37,5 @@ SQLAlchemy==2.0.29
 asyncpg==0.29.0
 neo4j==5.19.0
 scikit-learn==1.7.0
+nats-py==2.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,4 +41,5 @@ neo4j==5.19.0
 scikit-learn==1.7.0
 playwright==1.52.0
 pytest-playwright==0.4.4
+nats-py==2.6.0
 

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -11,6 +11,10 @@ def __getattr__(name: str):
         from . import llm_client as _lc
 
         return getattr(_lc, name)
+    if name in {"MessageBus", "InMemoryMessageBus", "NATSMessageBus"}:
+        from . import message_bus as _mb
+
+        return getattr(_mb, name)
     raise AttributeError(name)
 
 
@@ -19,4 +23,7 @@ __all__ = [
     "OllamaClient",
     "OpenAICompatibleClient",
     "load_llm_client",
+    "MessageBus",
+    "InMemoryMessageBus",
+    "NATSMessageBus",
 ]

--- a/services/message_bus.py
+++ b/services/message_bus.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Dict, List
+
+
+class MessageBus:
+    """Abstract message bus interface."""
+
+    async def connect(self) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    async def close(self) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    async def publish(self, subject: str, data: bytes) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    async def subscribe(
+        self, subject: str, callback: Callable[[bytes], Awaitable[None]]
+    ) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class InMemoryMessageBus(MessageBus):
+    """Simple in-memory pub/sub bus used for testing."""
+
+    def __init__(self) -> None:
+        self._subs: Dict[str, List[Callable[[bytes], Awaitable[None]]]] = {}
+        self._lock = asyncio.Lock()
+
+    async def connect(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        async with self._lock:
+            callbacks = list(self._subs.get(subject, []))
+        for cb in callbacks:
+            await cb(data)
+
+    async def subscribe(
+        self, subject: str, callback: Callable[[bytes], Awaitable[None]]
+    ) -> None:
+        async with self._lock:
+            self._subs.setdefault(subject, []).append(callback)
+
+
+class NATSMessageBus(MessageBus):
+    """NATS-based message bus."""
+
+    def __init__(self, servers: str = "nats://127.0.0.1:4222") -> None:
+        self.servers = servers
+        self.nc: "NATS" | None = None
+
+    async def connect(self) -> None:
+        from nats.aio.client import Client as NATS
+
+        self.nc = NATS()
+        await self.nc.connect(servers=[self.servers])
+
+    async def close(self) -> None:
+        if self.nc is not None:
+            await self.nc.drain()
+            await self.nc.close()
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        if not self.nc:
+            raise RuntimeError("NATS not connected")
+        await self.nc.publish(subject, data)
+        await self.nc.flush()
+
+    async def subscribe(
+        self, subject: str, callback: Callable[[bytes], Awaitable[None]]
+    ) -> None:
+        if not self.nc:
+            raise RuntimeError("NATS not connected")
+
+        async def handler(msg):
+            await callback(msg.data)
+
+        await self.nc.subscribe(subject, cb=handler)

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -1,0 +1,59 @@
+import pytest
+
+from engine.orchestration_engine import GraphState, create_orchestration_engine
+from services import InMemoryMessageBus
+
+
+@pytest.mark.asyncio
+async def test_message_bus_event_delivery():
+    bus = InMemoryMessageBus()
+    received = []
+
+    async def handler(data: bytes) -> None:
+        received.append(data.decode())
+
+    await bus.subscribe("t.events", handler)
+
+    engine = create_orchestration_engine(message_bus=bus)
+
+    def node_a(state: GraphState, _):
+        state.update({"x": 1})
+        return state
+
+    engine.add_node("A", node_a)
+
+    await engine.run_async(GraphState(), thread_id="t")
+
+    assert received == ["start:A", "end:A", "complete"]
+
+
+class FlakyBus(InMemoryMessageBus):
+    def __init__(self):
+        super().__init__()
+        self.attempts = 0
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        self.attempts += 1
+        if self.attempts < 2:
+            raise RuntimeError("boom")
+        await super().publish(subject, data)
+
+
+@pytest.mark.asyncio
+async def test_message_bus_retry():
+    bus = FlakyBus()
+    received = []
+
+    async def handler(data: bytes) -> None:
+        received.append(data.decode())
+
+    await bus.subscribe("t.events", handler)
+
+    engine = create_orchestration_engine(message_bus=bus)
+    engine.add_node("A", lambda s, _: s)
+
+    await engine.run_async(GraphState(), thread_id="t")
+
+    assert "complete" in received
+    assert bus.attempts >= 2
+


### PR DESCRIPTION
## Summary
- introduce a NATS-style message bus service with in-memory fallback
- hook orchestration engine into the message bus for start/end events
- add optional message bus parameter to factory function
- expose message bus utilities from services package
- add unit tests for event delivery and retry logic
- pin `nats-py` dependency

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685368e4a2bc832a8b795fe02d23086e