### PR TITLE
Enable parallel vector search

### DIFF
--- a/benchmarks/performance/vector_search_benchmark.py
+++ b/benchmarks/performance/vector_search_benchmark.py
@@ -9,14 +9,13 @@ from services.ltm_service.vector_store import WeaviateVectorStore
 
 def benchmark(workers: int, store_size: int = 2000, queries: int = 500) -> float:
     random.seed(0)
-    store = WeaviateVectorStore()
+    store = WeaviateVectorStore(workers=workers)
     for i in range(store_size):
         vec = [random.random() for _ in range(5)]
         store.add(vec, {"id": str(i)})
     qvecs = [[random.random() for _ in range(5)] for _ in range(queries)]
     start = time.perf_counter()
-    for q in qvecs:
-        store.query(q, limit=5)
+    store.query_many(qvecs, limit=5)
     qps = queries / (time.perf_counter() - start)
     store.close()
     return qps

--- a/services/ltm_service/vector_store.py
+++ b/services/ltm_service/vector_store.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 """Persistent vector store implementations for episodic memory."""
 
+import concurrent.futures
+import os
 import uuid
-from typing import Dict, List
+from typing import Dict, Iterable, List
 
 try:  # pragma: no cover - optional dependency
     import weaviate
@@ -32,7 +34,12 @@ class VectorStore:
 class WeaviateVectorStore(VectorStore):
     """Persistent vector store backed by a local Weaviate instance."""
 
-    def __init__(self, *, persistence_path: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        persistence_path: str | None = None,
+        workers: int | None = None,
+    ) -> None:
         if weaviate is None:  # pragma: no cover - dependency missing
             raise RuntimeError("weaviate-client not installed")
 
@@ -46,6 +53,9 @@ class WeaviateVectorStore(VectorStore):
             },
         )
         self._client = weaviate.connect_to_embedded(options=options)
+        self._pool = concurrent.futures.ThreadPoolExecutor(
+            max_workers=workers or int(os.getenv("VECTOR_STORE_WORKERS", "4"))
+        )
 
         if "Memory" not in self._client.collections.list():
             self._client.collections.create(
@@ -58,6 +68,8 @@ class WeaviateVectorStore(VectorStore):
         if self._client:
             self._client.close()
             self._client = None
+        if hasattr(self, "_pool"):
+            self._pool.shutdown(wait=True)
 
     def add(self, vector: List[float], metadata: Dict) -> str:
         vec_id = metadata.get("id", str(uuid.uuid4()))
@@ -66,7 +78,7 @@ class WeaviateVectorStore(VectorStore):
         self._collection.data.insert(properties=meta, vector=vector, uuid=vec_id)
         return vec_id
 
-    def query(self, vector: List[float], limit: int = 5) -> List[Dict]:
+    def _query_sync(self, vector: List[float], limit: int = 5) -> List[Dict]:
         results = (
             self._collection.query.near_vector(vector)
             .with_additional(["distance"])
@@ -81,6 +93,21 @@ class WeaviateVectorStore(VectorStore):
             records.append(meta)
         records.sort(key=lambda r: r["similarity"], reverse=True)
         return records
+
+    def query(self, vector: List[float], limit: int = 5) -> List[Dict]:
+        if getattr(self, "_pool", None):
+            return self._pool.submit(self._query_sync, vector, limit).result()
+        return self._query_sync(vector, limit)
+
+    def query_many(
+        self, vectors: Iterable[List[float]], *, limit: int = 5
+    ) -> List[List[Dict]]:
+        if not vectors:
+            return []
+        if getattr(self, "_pool", None):
+            futures = [self._pool.submit(self._query_sync, v, limit) for v in vectors]
+            return [f.result() for f in futures]
+        return [self._query_sync(v, limit) for v in vectors]
 
     def delete(self, vec_id: str) -> None:
         try:


### PR DESCRIPTION
## Summary
- add a worker pool in `WeaviateVectorStore`
- run queries in parallel via new `query_many`
- test that parallel querying is faster
- update vector search benchmark for multiple workers

## Testing
- `pre-commit run --files services/ltm_service/vector_store.py tests/test_vector_store_parallel.py benchmarks/performance/vector_search_benchmark.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685389f5f5f8832a930967510749e169