### PR TITLE
Implement simple orchestrator prototype

### DIFF
--- a/engine/orchestrator.py
+++ b/engine/orchestrator.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+"""Simplified orchestrator with state machine and tool adapters."""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from importlib import import_module
+from typing import Any, Dict, List
+
+import yaml
+from opentelemetry import trace
+
+
+@dataclass
+class ToolCall:
+    name: str
+    args: Dict[str, Any]
+
+
+def _dispatch(call: ToolCall):
+    adapters = import_module("tools.adapters")
+    return adapters.execute(call)
+
+
+tracer = trace.get_tracer(__name__)
+
+
+class Stage(str, Enum):
+    IDLE = "IDLE"
+    PLAN = "PLAN"
+    EXECUTE = "EXECUTE"
+    REFLECT = "REFLECT"
+    COMPLETE = "COMPLETE"
+
+
+class Planner:
+    """Very small planning stub generating a fixed DAG."""
+
+    template = """- id: search\n  tool: web.search\n- id: read\n  tool: pdf.reader\n  depends: [search]\n"""
+
+    def plan(self, prompt: str) -> str:
+        del prompt
+        return self.template
+
+
+class Reflector:
+    """Stub reflection module."""
+
+    def reflect(self, result: Dict[str, Any]) -> str:
+        _ = result
+        return "ok"
+
+
+@dataclass
+class Orchestrator:
+    planner: Planner
+    reflector: Reflector
+    history: List[Stage] = field(default_factory=list)
+
+    def run_task(self, prompt: str) -> Dict[str, Any]:
+        self.history.append(Stage.IDLE)
+        with tracer.start_as_current_span("plan"):
+            self.history.append(Stage.PLAN)
+            plan_yaml = self.planner.plan(prompt)
+        with tracer.start_as_current_span("execute"):
+            self.history.append(Stage.EXECUTE)
+            result = self._execute_plan(plan_yaml)
+        with tracer.start_as_current_span("reflect"):
+            self.history.append(Stage.REFLECT)
+            feedback = self.reflector.reflect(result)
+            result["feedback"] = feedback
+        with tracer.start_as_current_span("complete"):
+            self.history.append(Stage.COMPLETE)
+        return result
+
+    def _execute_plan(self, plan_yaml: str) -> Dict[str, Any]:
+        plan = yaml.safe_load(plan_yaml)
+        outputs = {}
+        for node in plan:
+            tool = node["tool"]
+            name = node["id"]
+            deps = node.get("depends", [])
+            args = (
+                {"query": "test"}
+                if tool == "web.search"
+                else {"path_or_url": "http://example.com/dummy.pdf"}
+            )
+            for dep in deps:
+                outputs.setdefault(name, []).append(outputs.get(dep))
+            call = ToolCall(name=tool, args=args)
+            outputs[name] = _dispatch(call)
+        return outputs

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Command line and REST entry point for the research orchestrator."""
+
+import argparse
+from typing import Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from engine.orchestrator import Orchestrator, Planner, Reflector
+
+app = FastAPI(title="Research Orchestrator")
+
+orc = Orchestrator(Planner(), Reflector())
+
+
+class RunRequest(BaseModel):
+    prompt: str
+
+
+@app.post("/run")
+async def run_endpoint(req: RunRequest):
+    result = orc.run_task(req.prompt)
+    return {"result": result}
+
+
+def run_cli(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Run orchestrator task")
+    parser.add_argument("prompt", help="Task prompt")
+    args = parser.parse_args(argv)
+    result = orc.run_task(args.prompt)
+    print(result)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    run_cli()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,35 @@
+import yaml
+
+from engine.orchestrator import Orchestrator, Planner, Reflector, Stage
+from tools.adapters import ToolCall
+
+
+def test_lifecycle_transitions(monkeypatch):
+    planner = Planner()
+    reflector = Reflector()
+    orch = Orchestrator(planner, reflector)
+
+    def fake_execute(call: ToolCall):
+        return {"tool": call.name, "args": call.args}
+
+    monkeypatch.setattr("tools.adapters.execute", fake_execute)
+
+    result = orch.run_task("find info")
+
+    assert orch.history == [
+        Stage.IDLE,
+        Stage.PLAN,
+        Stage.EXECUTE,
+        Stage.REFLECT,
+        Stage.COMPLETE,
+    ]
+    assert "search" in result
+    assert "read" in result
+
+
+def test_planner_outputs_yaml():
+    planner = Planner()
+    plan = planner.plan("research quantum")
+    data = yaml.safe_load(plan)
+    assert isinstance(data, list)
+    assert any(n.get("depends") for n in data)

--- a/tests/test_tool_adapters.py
+++ b/tests/test_tool_adapters.py
@@ -1,0 +1,12 @@
+from unittest import mock
+
+from tools import adapters
+
+
+def test_execute_dispatches():
+    call = adapters.ToolCall(name="web.search", args={"query": "ai"})
+    fake = mock.Mock(return_value=[{"url": "x"}])
+    adapters._REGISTRY["web.search"] = fake
+    result = adapters.execute(call)
+    fake.assert_called_once_with(query="ai")
+    assert result == [{"url": "x"}]

--- a/tools/adapters.py
+++ b/tools/adapters.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Lightweight tool adapter interface."""
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Callable, Dict
+
+
+@dataclass
+class ToolCall:
+    name: str
+    args: Dict[str, Any]
+
+
+def _load(name: str) -> Callable[..., Any]:
+    module_name, func_name = name.rsplit(".", 1)
+    module = import_module(f"tools.{module_name}")
+    return getattr(module, func_name)
+
+
+_REGISTRY: dict[str, Callable[..., Any]] = {
+    "web.search": _load("web_search.web_search"),
+    "pdf.reader": _load("pdf_reader.pdf_extract"),
+    "python.exec": _load("code_interpreter.code_interpreter"),
+}
+
+
+def execute(call: ToolCall) -> Any:
+    func = _REGISTRY.get(call.name)
+    if func is None:
+        raise ValueError(f"Unknown tool {call.name}")
+    return func(**call.args)


### PR DESCRIPTION
## Summary
- provide a minimal `orchestrator.py` entry point exposing CLI and FastAPI app
- add `engine/orchestrator.py` implementing a small state machine
- include simple planner and reflector stubs
- add dynamic tool adapter interface
- test lifecycle transitions and adapter dispatch

## Testing
- `pre-commit run --files engine/orchestrator.py orchestrator.py tests/test_orchestrator.py tests/test_tool_adapters.py tools/adapters.py`
- `pytest -q`
- `bash scripts/agent-setup.sh` *(fails: dependency conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_6853988caab0832a81bb2685f806f1fb