### PR TITLE
Add task schema doc

### DIFF
--- a/docs/task_schema_definition.md
+++ b/docs/task_schema_definition.md
@@ -1,0 +1,19 @@
+# Task Schema Definition
+
+This schema is designed to provide a clear and actionable description of each task, making it suitable for use in project management tools or by an automated agent.
+
+```yaml
+- task_id: (A unique identifier for the task, e.g., FEAT-001)
+  title: (A concise and descriptive title for the task)
+  description: (A more detailed explanation of the task and its purpose)
+  area: (The functional area of the project the task belongs to, e.g., "Data Analysis", "System Architecture", "Frontend")
+  actionable_steps:
+    - (A list of specific, actionable steps required to complete the task)
+  dependencies:
+    - (A list of other task_ids that must be completed before this task can be started)
+  acceptance_criteria:
+    - (A list of criteria that must be met for the task to be considered complete)
+  status: (The current status of the task, e.g., "To Do", "In Progress", "Done")
+  assigned_to: (The person or agent responsible for the task)
+  epic: (A larger user story or feature that this task is a part of)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Agentic Research Engine Docs
 nav:
   - Home: docs/index.md
   - Contributing Agents: docs/contributing_agents.md
+  - Task Schema Definition: docs/task_schema_definition.md
   - Research:
       - Reward Shaping Proposal: docs/research/2025-score-reward-shaping.md
       - Emergent Communication: docs/research/2025-emergent-communication-report.md


### PR DESCRIPTION
## Summary
- document task schema definition
- link new doc in mkdocs navigation

## Testing
- `bash scripts/agent-setup.sh` *(fails: dependency resolution conflict)*
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_686a55d1ecf8832a892f73862d7dcc5b