### PR TITLE
Implement dynamic auction mechanism selection

### DIFF
--- a/docs/usage/auction_mechanisms.md
+++ b/docs/usage/auction_mechanisms.md
@@ -1,0 +1,26 @@
+# Dynamic Auction Mechanism Configuration
+
+The Market Maker service selects an auction format based on the workload
+characteristics. Configuration thresholds control how that decision is made.
+
+## Default Heuristics
+
+```yaml
+auction:
+  high_complexity: 0.7  # threshold for SSI/VCG
+  high_budget: 0.7      # budget required to trigger VCG
+  many_tasks: 10        # task count to consider PSI/GCAA
+```
+
+These values map to the following strategies:
+
+- **VCG** – chosen when both workload complexity and available budget exceed
+  `high_complexity` and `high_budget`.
+- **PSI** – used for large batches of simple tasks where `num_tasks >= many_tasks`
+  and complexity is low (`<= 0.4`).
+- **GCAA** – preferred for moderately complex workloads with several tasks.
+- **SSI** – selected for complex tasks when the budget is limited.
+- **Combinatorial** – the default when no other rule matches.
+
+Adjust the thresholds in your configuration file or environment variables to
+adapt selection behavior to your deployment.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - Architecture:
       - Decision Records: docs/architecture/decision_records.md
       - Communication Guidelines: docs/architecture/llm_grounded_guided_evolution.md
+      - Auction Mechanisms: docs/usage/auction_mechanisms.md
 
   - Epics:
       - Interactive Agent Cockpit: docs/epics/interactive_agent_cockpit_epic.md

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -15,6 +15,15 @@ def __getattr__(name: str):
         from . import message_bus as _mb
 
         return getattr(_mb, name)
+    if name in {
+        "AuctionMechanism",
+        "AuctionConfig",
+        "Workload",
+        "select_auction_mechanism",
+    }:
+        from . import auction as _auc
+
+        return getattr(_auc, name)
     raise AttributeError(name)
 
 
@@ -26,4 +35,8 @@ __all__ = [
     "MessageBus",
     "InMemoryMessageBus",
     "NATSMessageBus",
+    "AuctionMechanism",
+    "AuctionConfig",
+    "Workload",
+    "select_auction_mechanism",
 ]

--- a/services/auction.py
+++ b/services/auction.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class AuctionMechanism(str, Enum):
+    """Available auction mechanisms."""
+
+    SSI = "sequential_single_item"
+    PSI = "parallel_single_item"
+    GCAA = "greedy_coalition"
+    COMBINATORIAL = "combinatorial"
+    VCG = "vcg"
+
+
+@dataclass
+class Workload:
+    """Characteristics of the upcoming workload."""
+
+    complexity: float  # 0.0-1.0 subjective measure
+    num_tasks: int
+    budget: float  # normalized 0-1 scale
+
+
+@dataclass
+class AuctionConfig:
+    """Configuration thresholds for mechanism selection."""
+
+    high_complexity: float = 0.7
+    high_budget: float = 0.7
+    many_tasks: int = 10
+
+
+def select_auction_mechanism(
+    workload: Workload, config: AuctionConfig | None = None
+) -> AuctionMechanism:
+    """Select the best auction mechanism based on workload parameters."""
+
+    cfg = config or AuctionConfig()
+
+    if (
+        workload.complexity >= cfg.high_complexity
+        and workload.budget >= cfg.high_budget
+    ):
+        return AuctionMechanism.VCG
+    if workload.num_tasks >= cfg.many_tasks:
+        if workload.complexity <= 0.4:
+            return AuctionMechanism.PSI
+        return AuctionMechanism.GCAA
+    if (
+        workload.num_tasks >= cfg.many_tasks // 2
+        and workload.complexity <= cfg.high_complexity
+    ):
+        return AuctionMechanism.GCAA
+    if workload.complexity >= cfg.high_complexity:
+        return AuctionMechanism.SSI
+    return AuctionMechanism.COMBINATORIAL
+
+
+__all__ = [
+    "AuctionMechanism",
+    "Workload",
+    "AuctionConfig",
+    "select_auction_mechanism",
+]

--- a/tests/services/test_auction_service.py
+++ b/tests/services/test_auction_service.py
@@ -1,0 +1,26 @@
+import pytest
+
+from services import AuctionConfig, AuctionMechanism, Workload, select_auction_mechanism
+
+
+@pytest.mark.parametrize(
+    "workload,expected",
+    [
+        (Workload(complexity=0.9, num_tasks=5, budget=0.9), AuctionMechanism.VCG),
+        (Workload(complexity=0.3, num_tasks=15, budget=0.3), AuctionMechanism.PSI),
+        (Workload(complexity=0.5, num_tasks=8, budget=0.5), AuctionMechanism.GCAA),
+        (Workload(complexity=0.8, num_tasks=3, budget=0.5), AuctionMechanism.SSI),
+        (
+            Workload(complexity=0.6, num_tasks=2, budget=0.4),
+            AuctionMechanism.COMBINATORIAL,
+        ),
+    ],
+)
+def test_select_mechanism(workload, expected):
+    assert select_auction_mechanism(workload) == expected
+
+
+def test_custom_config():
+    cfg = AuctionConfig(high_complexity=0.5, many_tasks=5)
+    wl = Workload(complexity=0.6, num_tasks=6, budget=0.4)
+    assert select_auction_mechanism(wl, cfg) == AuctionMechanism.GCAA


### PR DESCRIPTION
## Summary
- implement `services/auction.py` with basic heuristic selection
- expose auction utilities from services package
- document configuration options
- add unit tests for auction mechanism selection
- include doc page in mkdocs navigation

## Testing
- `pre-commit run --files services/auction.py services/__init__.py tests/services/test_auction_service.py docs/usage/auction_mechanisms.md mkdocs.yml`
- `pytest -q tests/services/test_auction_service.py`

------
https://chatgpt.com/codex/tasks/task_e_686e0e7bc18c832aaee3a5693af4056a