### PR TITLE
Add dev setup helper script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ Each agent resides in a folder under `agents/`. Every folder contains:
 - Execute `pre-commit run --all-files` to run linters and formatters.
 
 ## Setup
-- Run `bash scripts/agent-setup.sh` to install Python dependencies and pre-commit hooks.
-- Ensure the `tenacity` package is installed (via the setup script) before running tests.
+- Run `bash scripts/setup_dev_env.sh` to install Python dependencies and pre-commit hooks.
+- Ensure the `tenacity` package is installed (the setup script handles this) before running tests.
 
 ## PR Guidelines
 - Summarize changes in the PR description.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This is a mono-repo containing all services, agent definitions, and infrastructu
 
 2. **Install dependencies and tools:**
    ```bash
-   bash scripts/agent-setup.sh
+   bash scripts/setup_dev_env.sh
    ```
   The setup script installs from `requirements.txt` using a
   pinned `constraints.txt` file to avoid dependency resolution loops.
@@ -113,16 +113,25 @@ This is a mono-repo containing all services, agent definitions, and infrastructu
    ENVIRONMENT=dev SERVICE_VERSION=0.2.3 docker-compose up -d
    ```
 
-## **6. Running Tests**
+## **6. Development Setup**
+
+Run the helper script to install Python packages (including `tenacity`) and set
+up pre-commit hooks:
+
+```bash
+bash scripts/setup_dev_env.sh
+```
+
+## **7. Running Tests**
 
 A comprehensive test suite is crucial for maintaining system quality.
 
 Before running tests, make sure all Python dependencies are installed. The
-`agent-setup.sh` helper installs packages from `requirements.txt` (including the
-`tenacity` library required by several pipelines) and sets up pre-commit hooks:
+`setup_dev_env.sh` helper installs packages from `requirements.txt` (including
+the `tenacity` library required by several pipelines) and sets up pre-commit hooks:
 
 ```bash
-bash scripts/agent-setup.sh
+bash scripts/setup_dev_env.sh
 ```
 
 For a quick subset run only the core tests:
@@ -164,7 +173,7 @@ If the pages contain only images, the function can perform OCR using
 ``PDF_READER_ENABLE_OCR`` environment variable to ``true``. OCR requires the
 Tesseract binary to be installed and accessible on the system.
 
-## **7. Secrets Management**
+## **8. Secrets Management**
 
 Store API keys and credentials in a dedicated secrets manager such as
 **HashiCorp Vault** or **AWS Secrets Manager**. For local testing, export the
@@ -173,7 +182,7 @@ running the tools. In CI, add the keys as repository secrets and reference them
 in workflow steps. See [docs/security.md](docs/security.md) for detailed
 guidance.
 
-## **8. Error Logging Middleware**
+## **9. Error Logging Middleware**
 
 The orchestration engine supports optional structured error logging. Enable it
 by attaching an `ErrorLoggingMiddleware` instance to the engine:
@@ -187,7 +196,7 @@ engine.error_logger = ErrorLoggingMiddleware()
 Set `engine.error_logger = None` to disable logging. The middleware records the
 node name, exception, and serialized state for easier debugging.
 
-## **9. Continuous Deployment**
+## **10. Continuous Deployment**
 
 All services are deployed via an automated CD pipeline defined in `.github/workflows/cd.yml`.
 The pipeline uses Terraform and Helm configurations under `infra/` to perform
@@ -203,7 +212,7 @@ environment automatically. After verification, an operator can trigger the
 `promote-production` job to roll out the same release to production. In case of
 issues, `scripts/rollback.sh` reverts the selector to the previous color.
 
-## **10. Project Roadmap**
+## **11. Project Roadmap**
 
 This project is being executed in a phased approach to manage complexity and deliver value incrementally. For a complete list of all change requests, see [docs/change_request_ledger.md](docs/change_request_ledger.md).
 
@@ -220,7 +229,7 @@ This project is being executed in a phased approach to manage complexity and del
   * **Objective**: Refine the system for production use, focusing on efficiency and robustness.
   * **Key Deliverables**: Procedural Memory, multi-agent fine-tuning pipeline, mandatory CitationAgent, MAST-based failure testing.[1]
 
-## **11. Contributing**
+## **12. Contributing**
 
 Contributions are welcome and encouraged! Please follow these steps to contribute:
 
@@ -236,6 +245,6 @@ All pull requests will be automatically validated by the CI pipeline (P1-02), wh
 Branch protection rules on `main` enforce these checks so direct pushes are rejected. You can verify the policy by running `scripts/check_branch_protection.py` with a GitHub token.
 For instructions on running the pipeline locally and the required 80% coverage threshold, see [docs/ci.md](docs/ci.md).
 
-## **12. License**
+## **13. License**
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Setup development environment
+
+echo "[dev setup] Installing Python dependencies..."
+python -m pip install --upgrade pip >/dev/null
+pip install -q -r requirements.txt -c constraints.txt
+pip install -q tenacity
+
+if ! command -v pre-commit >/dev/null; then
+  echo "[dev setup] Installing pre-commit..."
+  pip install -q pre-commit==4.2.0
+fi
+
+echo "[dev setup] Installing git hooks..."
+pre-commit install
+
+echo "[dev setup] Done."


### PR DESCRIPTION
## Summary
- add `setup_dev_env.sh` for installing dependencies and hooks
- document the helper in README with a new "Development Setup" section
- reference the script in `AGENTS.md`

## Testing
- `pre-commit run --files AGENTS.md README.md scripts/setup_dev_env.sh` *(fails: ModuleNotFoundError: No module named 'tenacity')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_686e1ac8fdb4832a8dd669ba3ceed015