### PR TITLE
Add concurrency order test for chat scratchpad

### DIFF
--- a/tests/test_group_chat_concurrency.py
+++ b/tests/test_group_chat_concurrency.py
@@ -23,3 +23,19 @@ async def test_concurrent_scratchpad_updates():
 
     assert chat.read_scratchpad("count") == 200
     assert state.scratchpad["count"] == 200
+
+
+@pytest.mark.asyncio
+async def test_concurrent_message_order():
+    state = State()
+    chat = DynamicGroupChat({}, enable_lock=True)
+    chat.bind_state(state)
+
+    async def worker(i: int) -> None:
+        await asyncio.sleep(i * 0.001)
+        chat.update_scratchpad("log", lambda v, idx=i: (v or []) + [f"msg {idx}"])
+
+    await asyncio.gather(*(worker(i) for i in range(50)))
+
+    assert chat.read_scratchpad("log") == [f"msg {i}" for i in range(50)]
+    assert state.scratchpad["log"] == [f"msg {i}" for i in range(50)]


### PR DESCRIPTION
## Summary
- add test covering concurrent scratchpad updates with ordered writes

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687911efc3c8832a92d259c3a45b0d0a