### PR TITLE
Add markdown link checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
         run: bash scripts/agent-setup.sh
       - name: Run pre-commit
         run: pre-commit run --all-files
+      - name: Check Markdown links
+        run: python scripts/link_check.py
 
   api-spec:
     needs: changes

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Run linters and formatters
         run: pre-commit run --all-files
+      - name: Check Markdown links
+        run: python scripts/link_check.py
 
       - name: Run tests
         run: pytest --cov=./ --cov-report=xml --cov-report=html --cov-fail-under=80 -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,9 @@ repos:
         entry: bash scripts/run_core_tests.sh
         language: system
         pass_filenames: false
+      - id: link-check
+        name: check documentation links
+        entry: python scripts/link_check.py
+        language: python
+        pass_filenames: false
+        types: [markdown]

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -25,6 +25,14 @@ The script installs the core dependencies while respecting environment variables
 like `HTTP_PROXY`, `HTTPS_PROXY`, and `CUDA_VISIBLE_DEVICES` for proxy routing
 and GPU selection. Use this when you don't need the full toolchain.
 
+## Link Checker
+Validate links in Markdown files with the link checker script:
+
+```bash
+python scripts/link_check.py
+```
+Run this before submitting a pull request to catch any broken documentation links.
+
 ## Troubleshooting
 
 ### pip network timeouts

--- a/scripts/link_check.py
+++ b/scripts/link_check.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Run markdown-link-check on all markdown files.
+
+This script is a thin wrapper around `markdown-link-check` executed via `npx`.
+It scans provided paths (files or directories) for `.md` files and checks each
+with `markdown-link-check`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_check(file: Path) -> int:
+    """Run markdown-link-check on a single file."""
+    print(f"Checking {file}")
+    result = subprocess.run(
+        ["npx", "--yes", "markdown-link-check", "--quiet", str(file)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    print(result.stdout)
+    return result.returncode
+
+
+def gather_files(paths: list[str]) -> list[Path]:
+    files: list[Path] = []
+    for p in paths:
+        path = Path(p)
+        if path.is_dir():
+            files.extend(path.rglob("*.md"))
+        elif path.suffix == ".md":
+            files.append(path)
+    return files
+
+
+def main(paths: list[str]) -> int:
+    files = gather_files(paths)
+    rc = 0
+    for f in files:
+        rc |= run_check(f)
+    return rc
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check Markdown links with markdown-link-check"
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["README.md", "docs"],
+        help="Files or directories to scan",
+    )
+    args = parser.parse_args()
+    sys.exit(main(args.paths))


### PR DESCRIPTION
## Summary
- create `scripts/link_check.py` for validating Markdown links via `markdown-link-check`
- invoke new script in pre-commit and CI workflows
- document how to run the link checker

## Testing
- `pre-commit run --files scripts/link_check.py .github/workflows/ci.yml .github/workflows/minimal-ci.yml .pre-commit-config.yaml docs/onboarding.md` *(fails: ModuleNotFoundError: No module named 'tenacity')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_687ad61ae894832a8dea525ff4fc524d