### PR TITLE
Add RBAC docs and update LTM service tests

### DIFF
--- a/docs/ltm_service.md
+++ b/docs/ltm_service.md
@@ -1,0 +1,22 @@
+# LTM Service RBAC
+
+The LTM service exposes multiple HTTP endpoints. Access is controlled using the `X-Role` header. Requests are allowed only if the caller's role matches the endpoint requirements.
+
+| Endpoint | Method | Allowed Roles |
+|----------|-------|---------------|
+| `/memory` | POST | `editor` |
+| `/memory` | GET | `viewer`, `editor` |
+| `/semantic_consolidate` | POST | `editor` |
+| `/temporal_consolidate` | POST | `editor` |
+| `/propagate_subgraph` | POST | `editor` |
+| `/spatial_query` | GET | `viewer`, `editor` |
+| `/skill` | POST | `editor` |
+| `/skill_vector_query` | POST | `viewer`, `editor` |
+| `/skill_metadata_query` | POST | `viewer`, `editor` |
+| `/evaluator_memory` | POST | `editor` |
+| `/evaluator_memory` | GET | `viewer`, `editor` |
+| `/forget` | DELETE | `editor` |
+| `/forget_evaluator` | DELETE | `editor` |
+| `/provenance` | GET | `viewer`, `editor` |
+
+If a request is made with an unauthorized role, the service returns `403 Forbidden`.

--- a/services/ltm_service/api.py
+++ b/services/ltm_service/api.py
@@ -461,7 +461,9 @@ class LTMServiceServer:
 
             def _check_role(self, method: str, path: str) -> bool:
                 role = self.headers.get("X-Role", "")
-                allowed = ROLE_PERMISSIONS.get((method, path), set())
+                allowed = ROLE_PERMISSIONS.get((method, path))
+                if allowed is None:
+                    return False
                 return role in allowed
 
             @staticmethod


### PR DESCRIPTION
## Summary
- enforce explicit RBAC check in LTM API server
- document LTM service role requirements
- update LTM API tests to send roles and work without external deps

## Testing
- `pre-commit run --files services/ltm_service/api.py docs/api/ltm_service.md tests/test_ltm_service_api.py tests/test_ltm_contract.py`
- `pytest tests/test_ltm_service_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad89f1ab8832a912b3290a54cf3e7