### PR TITLE
Add lychee link checker script

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -26,12 +26,19 @@ like `HTTP_PROXY`, `HTTPS_PROXY`, and `CUDA_VISIBLE_DEVICES` for proxy routing
 and GPU selection. Use this when you don't need the full toolchain.
 
 ## Link Checker
-Validate links in Markdown files with the link checker script:
+Validate links in Markdown files with the link checker script, which wraps the
+[`lychee`](https://github.com/lycheeverse/lychee) link checker:
 
 ```bash
 python scripts/link_check.py
 ```
-Run this before submitting a pull request to catch any broken documentation links.
+Run this before submitting a pull request to catch any broken documentation
+links. The setup script installs `lychee` automatically using `cargo`. If you
+need to install it manually, run:
+
+```bash
+cargo install lychee --locked --version 0.13.0
+```
 
 ## Troubleshooting
 

--- a/scripts/agent-setup.sh
+++ b/scripts/agent-setup.sh
@@ -12,6 +12,11 @@ if ! command -v pre-commit >/dev/null; then
   pip install -q pre-commit==4.2.0
 fi
 
+if ! command -v lychee >/dev/null; then
+  echo "[setup] installing lychee..."
+  cargo install lychee --locked --version 0.13.0 >/dev/null
+fi
+
 echo "[setup] installing git hooks..."
 pre-commit install
 


### PR DESCRIPTION
## Summary
- use `lychee` for Markdown link checking
- install `lychee` in `agent-setup.sh`
- document usage of the link checker in `docs/onboarding.md`

## Testing
- `pre-commit run --all-files` *(fails: broken links detected)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_687ce97d322c832a81dc6e43b8ed76a4