### PR TITLE
Enhance memory_type validation and RBAC checks

### DIFF
--- a/docs/ltm_service.md
+++ b/docs/ltm_service.md
@@ -20,3 +20,7 @@ The LTM service exposes multiple HTTP endpoints. Access is controlled using the 
 | `/provenance` | GET | `viewer`, `editor` |
 
 If a request is made with an unauthorized role, the service returns `403 Forbidden`.
+
+The `memory_type` field or query parameter accepted by several endpoints must be
+one of `episodic`, `semantic`, `procedural` or `evaluator`. Using any other
+value results in a `400 Bad Request` response.

--- a/tests/test_ltm_service_api.py
+++ b/tests/test_ltm_service_api.py
@@ -97,6 +97,13 @@ def test_semantic_consolidate_endpoint():
         headers={"X-Role": "editor"},
     )
     assert resp.status_code == 201
+
+    resp = requests.post(
+        f"{endpoint}/semantic_consolidate",
+        json={"payload": triple},
+        headers={"X-Role": "viewer"},
+    )
+    assert resp.status_code == 403
     semantic_consolidate(triple, endpoint=endpoint)
     resp = requests.get(
         f"{endpoint}/memory",
@@ -191,6 +198,13 @@ def test_propagate_subgraph_endpoint():
         headers={"X-Role": "editor"},
     )
     assert resp.status_code == 200
+
+    resp = requests.post(
+        f"{endpoint}/propagate_subgraph",
+        json=subgraph,
+        headers={"X-Role": "viewer"},
+    )
+    assert resp.status_code == 403
     stored = server.service.retrieve(
         "semantic",
         {"subject": "E1", "predicate": "LINKS_TO", "object": "E2"},
@@ -221,6 +235,12 @@ def test_provenance_endpoint():
     )
     assert resp.status_code == 200
     assert resp.json()["provenance"]["source"] == "tester"
+
+    resp = requests.get(
+        f"{endpoint}/provenance/episodic/{rid}",
+        headers={"X-Role": "guest"},
+    )
+    assert resp.status_code == 403
     server.httpd.shutdown()
 
 


### PR DESCRIPTION
## Summary
- validate memory types centrally and reuse across handlers
- add role enforcement tests for LTM HTTP API
- note allowed memory types in docs

## Testing
- `SKIP=link-check pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cecbe4650832a9a41ac2837418ad3