### PR TITLE
Add LTM service API edge case tests

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -512,3 +512,16 @@
   status: open
   assigned_to: ''
   epic: ''
+- task_id: CR-TEST-016
+  title: Expand LTM service API tests
+  description: Add edge case and error path tests for LTM service API
+  area: tests
+  actionable_steps:
+  - Write additional tests
+  - Run pytest -k ltm_service
+  dependencies: []
+  acceptance_criteria:
+  - New tests pass
+  status: done
+  assigned_to: ''
+  epic: ''


### PR DESCRIPTION
## Summary
- cover LTM service API edge cases including redirects, sanitization and provenance errors
- mark new work in `tasks.yml`

## Testing
- `pre-commit run --files tests/test_ltm_service_api.py`
- `pytest -k ltm_service tests/test_ltm_service_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2c754c34832a8a387759efb5d9ee