### PR TITLE
Add external vector db client

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ The versioned OpenAPI schema for the LTM service is stored at
 
 Copy `.env.example` to `.env` and update the values for your environment. Common
 variables include `OPENAI_API_KEY`, proxy settings and optional integrations
-such as LangSmith. Refer to
+such as LangSmith. Configure the vector database connection via
+`WEAVIATE_URL` and `WEAVIATE_API_KEY` when using an external instance. Refer to
 [docs/onboarding.md#environment-variables](docs/onboarding.md#environment-variables)
 for a full list and guidance.
 

--- a/docs/semantic_memory_neo4j.md
+++ b/docs/semantic_memory_neo4j.md
@@ -68,3 +68,10 @@ curl -X POST http://localhost:8081/semantic_consolidate \
      -H 'Content-Type: application/json' \
      -d '{"payload": {"subject": "Transformer", "predicate": "IS_A", "object": "Model"}}'
 ```
+
+## Migration Notes
+
+Earlier releases bundled a local Weaviate instance for episodic memory. The
+service now expects an external vector database. Configure the endpoint via
+`WEAVIATE_URL` (and optional `WEAVIATE_API_KEY`). The Neo4j setup described
+above is unaffected.

--- a/infra/episodic_vector_db/README.md
+++ b/infra/episodic_vector_db/README.md
@@ -18,3 +18,8 @@ terraform apply \
 ```
 
 The service endpoint will be output after apply as `episodic-vector-db.<namespace>.svc.cluster.local:8080`.
+
+Configure the LTM service to connect by setting the following environment variables:
+
+- `WEAVIATE_URL` – endpoint of the Weaviate instance.
+- `WEAVIATE_API_KEY` – API key if authentication is enabled (optional).


### PR DESCRIPTION
## Summary
- connect to remote Weaviate instance when available
- document vector DB environment variables
- add connection instructions for the vector database
- document migration notes for Semantic Memory

## Testing
- `pre-commit run --files services/ltm_service/vector_store.py README.md infra/episodic_vector_db/README.md docs/semantic_memory_neo4j.md` *(fails: lychee not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d35ccb3d4832aaabd3d0aeee75af2