### PR TITLE
Add evaluator finetuning pipeline

### DIFF
--- a/docs/pipelines/evaluator_finetuning.md
+++ b/docs/pipelines/evaluator_finetuning.md
@@ -3,11 +3,11 @@
 This pipeline fine-tunes the Evaluator agent on a synthetic dataset of errors and corrections.
 The data lives at `data/synthetic_self_correction/self_correction_dataset.json`.
 
-Run the helper script:
+Run the training script:
 
 ```bash
-python scripts/finetune_evaluator.py --model hf-internal-testing/tiny-random-T5 --epochs 1
+python scripts/train_evaluator.py --model hf-internal-testing/tiny-random-T5 --epochs 1
 ```
 
-Artifacts are saved under `models/evaluator/<timestamp>/` alongside a `metrics.json` file recording baseline and
-fine-tuned accuracy.
+Artifacts are saved under `models/evaluator_finetuned/<version>/` alongside a `metrics.json` file recording the
+baseline and fine-tuned accuracy.

--- a/scripts/train_evaluator.py
+++ b/scripts/train_evaluator.py
@@ -120,7 +120,12 @@ def main() -> None:
     parser.add_argument("--epochs", type=int, default=3)
     parser.add_argument("--version", default=None)
     parser.add_argument("--test-split", type=float, default=0.1)
-    parser.add_argument("--out-root", type=Path, default=Path("models/evaluator"))
+    parser.add_argument(
+        "--out-root",
+        type=Path,
+        default=Path("models/evaluator_finetuned"),
+        help="Directory to store fine-tuned model artifacts",
+    )
     args = parser.parse_args()
 
     version = (


### PR DESCRIPTION
## Summary
- update default output directory for evaluator training
- document how to run the evaluator fine-tuning pipeline

## Testing
- `pre-commit run --files scripts/train_evaluator.py docs/pipelines/evaluator_finetuning.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d928e6c08832aac3fd2a249da923c