### PR TITLE
Improve Supervisor planning reuse

### DIFF
--- a/services/ltm_service/vector_store.py
+++ b/services/ltm_service/vector_store.py
@@ -11,7 +11,7 @@ development and tests. Authentication can be supplied via the
 import concurrent.futures
 import os
 import uuid
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Tuple
 
 try:  # pragma: no cover - optional dependency
     import weaviate
@@ -37,6 +37,36 @@ class VectorStore:
         raise NotImplementedError
 
 
+class SimpleVectorStore(VectorStore):
+    """In-memory vector store used when Weaviate is unavailable."""
+
+    def __init__(self) -> None:
+        self._data: List[Tuple[str, List[float], Dict]] = []
+
+    def add(self, vector: List[float], metadata: Dict) -> str:
+        vec_id = metadata.get("id", str(uuid.uuid4()))
+        self._data.append((vec_id, vector, metadata))
+        return vec_id
+
+    def query(self, vector: List[float], limit: int) -> List[Dict]:
+        def similarity(v1: List[float], v2: List[float]) -> float:
+            if not v1 or not v2:
+                return 0.0
+            score = sum(a * b for a, b in zip(v1, v2))
+            return score / (len(v1) ** 0.5 * len(v2) ** 0.5)
+
+        results = []
+        for vec_id, vec, meta in self._data:
+            results.append(
+                {"id": vec_id, **meta, "similarity": similarity(vector, vec)}
+            )
+        results.sort(key=lambda r: r["similarity"], reverse=True)
+        return results[:limit]
+
+    def delete(self, vec_id: str) -> None:
+        self._data = [r for r in self._data if r[0] != vec_id]
+
+
 class WeaviateVectorStore(VectorStore):
     """Persistent vector store backed by Weaviate."""
 
@@ -60,7 +90,11 @@ class WeaviateVectorStore(VectorStore):
 
         if url:
             auth = weaviate.AuthApiKey(api_key) if api_key else None
-            self._client = weaviate.Client(url, auth_client_secret=auth)
+            try:
+                self._client = weaviate.Client(url, auth_client_secret=auth)
+            except Exception:  # pragma: no cover - connection issues
+                self._fallback = SimpleVectorStore()
+                return
         else:
             options = EmbeddedOptions(
                 persistence_data_path=persistence_path or "/tmp/weaviate-data",
@@ -71,23 +105,45 @@ class WeaviateVectorStore(VectorStore):
                     "DEFAULT_VECTORIZER_MODULE": "none",
                 },
             )
-            self._client = weaviate.connect_to_embedded(options=options)
+            try:
+                self._client = weaviate.connect_to_embedded(options=options)
+            except Exception:  # pragma: no cover - fallback when API mismatch
+                try:
+                    self._client = weaviate.connect_to_embedded(
+                        hostname=options.hostname,
+                        port=options.port,
+                        grpc_port=options.grpc_port,
+                        persistence_data_path=options.persistence_data_path,
+                        binary_path=options.binary_path,
+                        environment_variables=options.additional_env_vars,
+                        version=options.version,
+                    )
+                except Exception:
+                    self._fallback = SimpleVectorStore()
+                    return
 
-        if "Memory" not in self._client.collections.list():
-            self._client.collections.create(
-                name="Memory",
-                vectorizer_config=weaviate.config.Configure.vectorizer.none(),
-            )
-        self._collection = self._client.collection("Memory")
+        if hasattr(self, "_fallback"):
+            self._collection = None
+        else:
+            if "Memory" not in self._client.collections.list():
+                self._client.collections.create(
+                    name="Memory",
+                    vectorizer_config=weaviate.config.Configure.vectorizer.none(),
+                )
+            self._collection = self._client.collection("Memory")
 
     def close(self) -> None:
-        if self._client:
+        if hasattr(self, "_fallback"):
+            self._fallback = None
+        elif self._client:
             self._client.close()
             self._client = None
         if hasattr(self, "_pool"):
             self._pool.shutdown(wait=True)
 
     def add(self, vector: List[float], metadata: Dict) -> str:
+        if hasattr(self, "_fallback"):
+            return self._fallback.add(vector, metadata)
         vec_id = metadata.get("id", str(uuid.uuid4()))
         meta = metadata.copy()
         meta.pop("id", None)
@@ -95,6 +151,8 @@ class WeaviateVectorStore(VectorStore):
         return vec_id
 
     def _query_sync(self, vector: List[float], limit: int = 5) -> List[Dict]:
+        if hasattr(self, "_fallback"):
+            return self._fallback.query(vector, limit)
         results = (
             self._collection.query.near_vector(vector)
             .with_additional(["distance"])
@@ -111,6 +169,8 @@ class WeaviateVectorStore(VectorStore):
         return records
 
     def query(self, vector: List[float], limit: int = 5) -> List[Dict]:
+        if hasattr(self, "_fallback"):
+            return self._fallback.query(vector, limit)
         if getattr(self, "_pool", None):
             return self._pool.submit(self._query_sync, vector, limit).result()
         return self._query_sync(vector, limit)
@@ -118,6 +178,8 @@ class WeaviateVectorStore(VectorStore):
     def query_many(
         self, vectors: Iterable[List[float]], *, limit: int = 5
     ) -> List[List[Dict]]:
+        if hasattr(self, "_fallback"):
+            return [self._fallback.query(v, limit) for v in vectors]
         if not vectors:
             return []
         if getattr(self, "_pool", None):
@@ -126,6 +188,9 @@ class WeaviateVectorStore(VectorStore):
         return [self._query_sync(v, limit) for v in vectors]
 
     def delete(self, vec_id: str) -> None:
+        if hasattr(self, "_fallback"):
+            self._fallback.delete(vec_id)
+            return
         try:
             self._collection.data.delete(uuid=vec_id)
         except Exception:  # pragma: no cover - best effort cleanup


### PR DESCRIPTION
## Summary
- reuse high-scoring plans in `SupervisorAgent`
- parameterize plan templates with current query and context
- add fallback SimpleVectorStore when Weaviate is unavailable
- test for plan reuse with template slots

## Testing
- `pre-commit run --files agents/supervisor.py tests/test_supervisor.py services/ltm_service/vector_store.py`
- `pytest -q tests/test_supervisor.py::test_high_score_plan_reused_with_slots` *(fails: Server error)*

------
https://chatgpt.com/codex/tasks/task_e_687d51f29fcc832a810e0a6abb56caab