### PR TITLE
Add action monitoring service

### DIFF
--- a/services/monitoring/__init__.py
+++ b/services/monitoring/__init__.py
@@ -1,0 +1,4 @@
+from .system_monitor import SystemMonitor
+from .action_monitor import ActionMonitor
+
+__all__ = ["SystemMonitor", "ActionMonitor"]

--- a/services/monitoring/action_monitor.py
+++ b/services/monitoring/action_monitor.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import List
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import MetricReader, PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter
+
+
+@dataclass
+class AuditLogRecord:
+    timestamp: datetime
+    agent_id: str
+    action: str
+    outcome: str
+
+
+class ActionMonitor:
+    """Collect agent actions and tool call metrics."""
+
+    def __init__(
+        self, metrics_reader: MetricReader, span_exporter: SpanExporter
+    ) -> None:
+        resource = Resource.create(
+            {
+                "service.name": "action-monitor",
+                "environment": os.getenv("ENVIRONMENT", "dev"),
+                "service.version": os.getenv("SERVICE_VERSION", "0.1.0"),
+            }
+        )
+        meter_provider = MeterProvider(
+            metric_readers=[metrics_reader], resource=resource
+        )
+        metrics.set_meter_provider(meter_provider)
+        self._meter = metrics.get_meter(__name__)
+
+        tracer_provider = TracerProvider(resource=resource)
+        tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+        trace.set_tracer_provider(tracer_provider)
+        self._tracer = trace.get_tracer(__name__)
+
+        self._action_counter = self._meter.create_counter(
+            "agent.actions", description="Count of agent actions"
+        )
+        self._tool_counter = self._meter.create_counter(
+            "agent.tool_calls", description="Count of tool calls"
+        )
+        self.logs: List[AuditLogRecord] = []
+
+    @classmethod
+    def from_otlp(cls, endpoint: str = "http://localhost:4317") -> "ActionMonitor":
+        metric_exporter = OTLPMetricExporter(endpoint=endpoint, insecure=True)
+        reader = PeriodicExportingMetricReader(metric_exporter)
+        span_exporter = OTLPSpanExporter(endpoint=endpoint, insecure=True)
+        return cls(reader, span_exporter)
+
+    def record_action(self, agent_id: str, action: str, outcome: str) -> None:
+        timestamp = datetime.now(UTC)
+        self.logs.append(AuditLogRecord(timestamp, agent_id, action, outcome))
+        attrs = {"agent_id": agent_id, "action": action, "outcome": outcome}
+        self._action_counter.add(1, attrs)
+        with self._tracer.start_as_current_span("agent_action", attributes=attrs):
+            pass
+
+    def record_tool_call(self, agent_id: str, tool_name: str, outcome: str) -> None:
+        timestamp = datetime.now(UTC)
+        self.logs.append(AuditLogRecord(timestamp, agent_id, tool_name, outcome))
+        attrs = {"agent_id": agent_id, "tool_name": tool_name, "outcome": outcome}
+        self._tool_counter.add(1, attrs)
+        with self._tracer.start_as_current_span("tool_call_audit", attributes=attrs):
+            pass

--- a/tests/services/test_action_monitor.py
+++ b/tests/services/test_action_monitor.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+from services.monitoring.action_monitor import ActionMonitor
+
+
+class InMemorySpanExporter(SpanExporter):
+    def __init__(self) -> None:
+        self.spans = []
+
+    def export(self, spans):  # type: ignore[override]
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:  # pragma: no cover - not needed
+        pass
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:  # pragma: no cover
+        return True
+
+
+def test_record_action_and_tool_call():
+    metric_reader = InMemoryMetricReader()
+    span_exporter = InMemorySpanExporter()
+    monitor = ActionMonitor(metric_reader, span_exporter)
+
+    monitor.record_action("agent1", "plan", "success")
+    monitor.record_tool_call("agent1", "web_search", "success")
+
+    assert len(monitor.logs) == 2
+
+    data = metric_reader.get_metrics_data()
+    names = {
+        m.name
+        for rm in data.resource_metrics
+        for sm in rm.scope_metrics
+        for m in sm.metrics
+    }
+    assert "agent.actions" in names
+    assert "agent.tool_calls" in names
+    assert span_exporter.spans


### PR DESCRIPTION
## Summary
- add ActionMonitor service to collect agent actions and tool calls
- export ActionMonitor from monitoring package
- test ActionMonitor metrics and logs

## Testing
- `pre-commit run --files services/monitoring/action_monitor.py tests/services/test_action_monitor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687de54938d0832a91be7ace551195aa