### PR TITLE
Add async tool registry client

### DIFF
--- a/services/tool_registry/__init__.py
+++ b/services/tool_registry/__init__.py
@@ -35,6 +35,8 @@ from tools import (
 )
 from tools.validation import validate_path_or_url
 
+from .async_client import ToolRegistryAsyncClient
+
 logger = logging.getLogger(__name__)
 
 
@@ -224,4 +226,9 @@ def create_default_registry(config_path: str | None = None) -> ToolRegistry:
     return registry
 
 
-__all__ = ["AccessDeniedError", "ToolRegistry", "create_default_registry"]
+__all__ = [
+    "AccessDeniedError",
+    "ToolRegistry",
+    "create_default_registry",
+    "ToolRegistryAsyncClient",
+]

--- a/services/tool_registry/async_client.py
+++ b/services/tool_registry/async_client.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Asynchronous HTTP client for the Tool Registry servers."""
+
+from typing import Any, Dict, Optional
+
+import httpx
+
+from . import AccessDeniedError
+
+
+class ToolRegistryAsyncClient:
+    """HTTP client using :class:`httpx.AsyncClient` to access the registry."""
+
+    def __init__(
+        self, base_url: str, *, client: Optional[httpx.AsyncClient] = None
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._client = client or httpx.AsyncClient()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def get_tool(self, role: str, name: str) -> str:
+        resp = await self._client.get(
+            f"{self.base_url}/tool", params={"agent": role, "name": name}
+        )
+        if resp.status_code == 404:
+            raise KeyError(name)
+        if resp.status_code == 403:
+            raise AccessDeniedError(resp.json().get("error", "forbidden"))
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("tool", "")
+
+    async def invoke(
+        self,
+        role: str,
+        tool: str,
+        *args: Any,
+        intent: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        payload: Dict[str, Any] = {
+            "agent": role,
+            "tool": tool,
+            "args": list(args),
+            "kwargs": kwargs,
+            "intent": intent or "",
+        }
+        resp = await self._client.post(f"{self.base_url}/invoke", json=payload)
+        if resp.status_code == 404:
+            raise KeyError(tool)
+        if resp.status_code == 403:
+            raise AccessDeniedError(resp.json().get("error", "forbidden"))
+        resp.raise_for_status()
+        return resp.json().get("result")
+
+    async def __aenter__(self) -> "ToolRegistryAsyncClient":
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        await self._client.__aexit__(*exc_info)


### PR DESCRIPTION
## Summary
- provide ToolRegistryAsyncClient for async HTTP access
- support async client in BaseAgent and core agents
- test async client behavior

## Testing
- `pre-commit run --files services/tool_registry/async_client.py agents/base.py agents/code_researcher.py agents/evaluator.py agents/memory_manager.py agents/supervisor.py agents/web_researcher.py services/tool_registry/__init__.py tests/test_tool_registry.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e70948738832a95ca8fda66943578