### PR TITLE
Enable async e2e tests

### DIFF
--- a/services/tool_registry/async_client.py
+++ b/services/tool_registry/async_client.py
@@ -6,8 +6,6 @@ from typing import Any, Dict, Optional
 
 import httpx
 
-from . import AccessDeniedError
-
 
 class ToolRegistryAsyncClient:
     """HTTP client using :class:`httpx.AsyncClient` to access the registry."""
@@ -22,6 +20,8 @@ class ToolRegistryAsyncClient:
         await self._client.aclose()
 
     async def get_tool(self, role: str, name: str) -> str:
+        from . import AccessDeniedError
+
         resp = await self._client.get(
             f"{self.base_url}/tool", params={"agent": role, "name": name}
         )
@@ -48,6 +48,8 @@ class ToolRegistryAsyncClient:
             "kwargs": kwargs,
             "intent": intent or "",
         }
+        from . import AccessDeniedError
+
         resp = await self._client.post(f"{self.base_url}/invoke", json=payload)
         if resp.status_code == 404:
             raise KeyError(tool)

--- a/tests/test_e2e_system.py
+++ b/tests/test_e2e_system.py
@@ -1,4 +1,3 @@
-import asyncio
 import importlib
 import json
 import os
@@ -47,8 +46,8 @@ def _make_registry(search_results: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-@pytest.mark.skip(reason="Flaky: triggers event loop deadlock in CI")
-def test_full_request_to_execution_trace():
+@pytest.mark.asyncio
+async def test_full_request_to_execution_trace():
     importlib.reload(trace)
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
@@ -67,7 +66,7 @@ def test_full_request_to_execution_trace():
     engine.add_node("WebResearcher", researcher)
     engine.add_edge("Supervisor", "WebResearcher")
 
-    result = asyncio.run(engine.run_async(GraphState()))
+    result = await engine.run_async(GraphState())
     assert result.data["research_result"]["sources"]
 
     span_names = [s.name for s in exporter.spans]
@@ -96,8 +95,8 @@ def test_foundational_benchmark_run():
     assert report["average_time"] >= 0
 
 
-@pytest.mark.skip(reason="Flaky: triggers event loop deadlock in CI")
-def test_dynamic_workflow_routing():
+@pytest.mark.asyncio
+async def test_dynamic_workflow_routing():
     registry_hits = _make_registry([{"url": "http://example.com", "title": "Ex"}])
     registry_empty = _make_registry([])
 
@@ -118,8 +117,8 @@ def test_dynamic_workflow_routing():
     eng.add_router("Research", router)
     eng.add_edge("Summarize", "End")
 
-    result = asyncio.run(
-        eng.run_async(GraphState(data={"sub_task": "topic"}), start_at="Research")
+    result = await eng.run_async(
+        GraphState(data={"sub_task": "topic"}), start_at="Research"
     )
     assert result.data.get("summary") is True
 
@@ -131,7 +130,7 @@ def test_dynamic_workflow_routing():
     eng2.add_router("Research", router)
     eng2.add_edge("Summarize", "End")
 
-    result2 = asyncio.run(
-        eng2.run_async(GraphState(data={"sub_task": "topic"}), start_at="Research")
+    result2 = await eng2.run_async(
+        GraphState(data={"sub_task": "topic"}), start_at="Research"
     )
     assert "summary" not in result2.data


### PR DESCRIPTION
## Summary
- enable E2E system tests by switching to `pytest.mark.asyncio`
- avoid circular import in async tool registry client

## Testing
- `pre-commit run --files tests/test_e2e_system.py services/tool_registry/async_client.py`
- `pytest tests/test_e2e_system.py::test_foundational_benchmark_run -q`
- `pytest tests/test_e2e_system.py::test_full_request_to_execution_trace -q` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_687ed88315f0832a808940e4a7459e6f