### PR TITLE
Enhance RBAC logging with user identity

### DIFF
--- a/docs/audit/security.md
+++ b/docs/audit/security.md
@@ -36,7 +36,7 @@ This guide describes how to monitor RBAC failures in the Tool Registry.
 Example log entry:
 
 ```json
-{"timestamp": "2024-01-01T12:00:00Z", "role": "Supervisor", "tool": "dummy", "client_ip": "127.0.0.1", "path": "/tool?agent=Supervisor&name=dummy", "error": "Role 'Supervisor' cannot access tool 'dummy'"}
+{"timestamp": "2024-01-01T12:00:00Z", "role": "Supervisor", "tool": "dummy", "user": "alice", "client_ip": "127.0.0.1", "path": "/tool?agent=Supervisor&name=dummy", "error": "Role 'Supervisor' cannot access tool 'dummy'"}
 ```
 
 Fields:
@@ -44,6 +44,7 @@ Fields:
 - `timestamp` – UTC time of the request
 - `role` – agent role making the request
 - `tool` – requested tool name
+- `user` – identity of the caller if provided
 - `client_ip` – IP address of the client
 - `path` – HTTP path and query
 - `error` – reason access was denied

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,7 +10,7 @@ This guide describes how to monitor RBAC failures in the Tool Registry.
 Example log entry:
 
 ```json
-{"timestamp": "2024-01-01T12:00:00Z", "role": "Supervisor", "tool": "dummy", "client_ip": "127.0.0.1", "path": "/tool?agent=Supervisor&name=dummy", "error": "Role 'Supervisor' cannot access tool 'dummy'"}
+{"timestamp": "2024-01-01T12:00:00Z", "role": "Supervisor", "tool": "dummy", "user": "alice", "client_ip": "127.0.0.1", "path": "/tool?agent=Supervisor&name=dummy", "error": "Role 'Supervisor' cannot access tool 'dummy'"}
 ```
 
 Fields:
@@ -18,6 +18,7 @@ Fields:
 - `timestamp` – UTC time of the request
 - `role` – agent role making the request
 - `tool` – requested tool name
+- `user` – identity of the caller if provided
 - `client_ip` – IP address of the client
 - `path` – HTTP path and query
 - `error` – reason access was denied

--- a/services/tool_registry/registry.py
+++ b/services/tool_registry/registry.py
@@ -40,6 +40,7 @@ class ToolRegistryServer:
                 params = parse_qs(parsed.query)
                 role = params.get("agent", [""])[0]
                 name = params.get("name", [""])[0]
+                user = self.headers.get("X-User", "")
                 try:
                     registry.get_tool(role, name)
                 except AccessDeniedError as e:
@@ -51,6 +52,7 @@ class ToolRegistryServer:
                                 ).isoformat(),
                                 "role": role,
                                 "tool": name,
+                                "user": user,
                                 "client_ip": self.client_address[0],
                                 "path": self.path,
                                 "error": str(e),

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -93,10 +93,13 @@ def test_registry_server_logs_denied_access(tmp_path, caplog):
     try:
         caplog.set_level("WARNING")
         requests.get(
-            f"{endpoint}/tool", params={"agent": "Supervisor", "name": "dummy"}
+            f"{endpoint}/tool",
+            params={"agent": "Supervisor", "name": "dummy"},
+            headers={"X-User": "alice"},
         )
         assert any(
             json.loads(record.message).get("role") == "Supervisor"
+            and json.loads(record.message).get("user") == "alice"
             for record in caplog.records
         )
     finally:


### PR DESCRIPTION
## Summary
- log `X-User` value when access to a tool is denied
- document new `user` field in RBAC log examples
- expect user info in registry server log test

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f20ab7db4832a823324d9de040b5b