### PR TITLE
Add config support for dataset curation

### DIFF
--- a/tests/test_dataset_curation.py
+++ b/tests/test_dataset_curation.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import pytest
 
@@ -41,3 +42,10 @@ def test_versioning_creates_output(tmp_path):
     assert out_file.is_file()
     loaded = json.loads(out_file.read_text())
     assert loaded == records
+
+
+def test_version_id_format(tmp_path):
+    version = dataset_curation.save_version([], tmp_path)
+    assert re.match(r"^\d{8}_\d{6}$", version)
+    out_file = tmp_path / version / "dataset.json"
+    assert out_file.is_file()


### PR DESCRIPTION
## Summary
- extend dataset curation script to load optional YAML/JSON config
- keep required field validation flexible
- add test checking timestamp-based dataset version naming

## Testing
- `pre-commit run --files scripts/dataset_curation.py tests/test_dataset_curation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f279b9890832a852d4eb582535e50