### PR TITLE
Add schema validation workflow

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,0 +1,28 @@
+name: Schema Validation
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Setup environment
+        run: bash scripts/agent-setup.sh
+      - name: Install openapi-core
+        run: pip install openapi-core==0.19.5
+      - name: Run schema validation tests
+        run: pytest tests/schema -q

--- a/constraints.txt
+++ b/constraints.txt
@@ -41,4 +41,5 @@ scikit-learn==1.7.0
 nats-py==2.6.0
 mypy==1.16.1
 mypy_extensions==1.1.0
+openapi-core==0.19.5
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -52,12 +52,14 @@ identify==2.6.12
 idna==3.10
 importlib-metadata==7.0.0
 iniconfig==2.1.0
+isodate==0.7.2
 isort==6.0.1
 Jinja2==3.1.6
 joblib==1.5.1
 jsonpatch==1.33
 jsonpointer==3.0.0
 jsonschema==4.24.0
+jsonschema-path==0.3.4
 jsonschema-specifications==2025.4.1
 jusText==3.0.2
 langchain==0.3.25
@@ -73,6 +75,7 @@ lxml_html_clean==0.4.2
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
+more-itertools==10.7.0
 mpmath==1.3.0
 multidict==6.6.3
 multiprocess==0.70.16
@@ -84,6 +87,9 @@ networkx==3.5
 nodeenv==1.9.1
 numpy==2.3.1
 openai==1.3.5
+openapi-core==0.19.5
+openapi-schema-validator==0.6.3
+openapi-spec-validator==0.7.2
 opentelemetry-api==1.24.0
 opentelemetry-exporter-otlp==1.24.0
 opentelemetry-exporter-otlp-proto-common==1.24.0
@@ -96,6 +102,7 @@ orjson==3.10.18
 ormsgpack==1.10.0
 packaging==24.2
 pandas==2.2.2
+parse==1.20.2
 pathspec==0.12.1
 pdfminer.six==20221105
 pdfplumber==0.10.2
@@ -175,6 +182,7 @@ uvicorn==0.27.0
 validators==0.35.0
 virtualenv==20.31.2
 weaviate-client==3.26.7
+werkzeug==3.1.1
 wheel==0.45.1
 wrapt==1.17.2
 xxhash==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,5 @@ playwright==1.52.0
 pytest-playwright==0.4.4
 nats-py==2.6.0
 mypy==1.16.1
+openapi-core==0.19.5
 

--- a/scripts/link_check.py
+++ b/scripts/link_check.py
@@ -29,8 +29,6 @@ def run_check(files: list[Path]) -> int:
         "--no-progress",
         "--max-redirects",
         "5",
-        "--accept",
-        "200..=599",
         "--dump",
     ] + [str(f) for f in files]
     print("Running:", " ".join(cmd))

--- a/tests/schema/test_openapi_validation.py
+++ b/tests/schema/test_openapi_validation.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema_path import SchemaPath
+from openapi_core import OpenAPI
+from openapi_core.shortcuts import validate_request
+from openapi_core.testing.requests import MockRequest
+
+SPEC = OpenAPI(
+    SchemaPath.from_dict(yaml.safe_load(Path("docs/api/openapi.yaml").read_text()))
+).spec
+
+CASES = [
+    ("ltm_contract/consolidate_success.json", "post", "/memory", True),
+    ("ltm_contract/consolidate_missing_record.json", "post", "/memory", False),
+    ("ltm_contract/retrieve_success.json", "get", "/memory", True),
+    ("procedural_contract/procedure_store_success.json", "post", "/memory", True),
+    ("procedural_contract/procedure_retrieve_success.json", "get", "/memory", True),
+]
+
+
+def _build_request(case_file: str, method: str, path: str) -> MockRequest:
+    case_path = Path("tests/fixtures") / case_file
+    payload = json.loads(case_path.read_text())
+    req = payload.get("request", {})
+    headers = req.get("headers")
+    params = req.get("params")
+    body = req.get("json")
+    data = json.dumps(body).encode() if body is not None else b""
+    return MockRequest(
+        "http://test", method, path, args=params, headers=headers, data=data
+    )
+
+
+@pytest.mark.parametrize("case_file,method,path,is_valid", CASES)
+def test_case_schema(case_file: str, method: str, path: str, is_valid: bool) -> None:
+    request = _build_request(case_file, method, path)
+    if is_valid:
+        validate_request(request, SPEC)
+    else:
+        with pytest.raises(Exception):
+            validate_request(request, SPEC)


### PR DESCRIPTION
## Summary
- install `openapi-core` dependencies
- add GitHub Action to validate API schemas
- check sample requests against OpenAPI in tests
- update link checker to avoid invalid flag

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f314c83dc832a88fb2aecde82d272