### PR TITLE
Add SkillLibrary vector store Terraform module

### DIFF
--- a/docs/architecture/skill_library_vector_store.md
+++ b/docs/architecture/skill_library_vector_store.md
@@ -1,0 +1,16 @@
+# SkillLibrary Vector Store Deployment
+
+The SkillLibrary uses a Weaviate instance to persist skill embeddings and metadata.
+Terraform configuration is provided under `infra/skill_library_vector_db` to deploy this database via the Helm chart.
+
+## Key Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `storage_size` | Persistent volume size allocated to the database | `10Gi` |
+| `api_key` | Optional API key used to secure the Weaviate API | empty |
+
+After applying the Terraform module, the service is reachable at
+`skilllib-vector-db.<namespace>.svc.cluster.local:8080`.
+Configure `WEAVIATE_URL` and `WEAVIATE_API_KEY` in the SkillLibrary service
+to point to this endpoint.

--- a/infra/skill_library_vector_db/README.md
+++ b/infra/skill_library_vector_db/README.md
@@ -1,0 +1,30 @@
+# SkillLibrary Vector Store
+
+This directory contains Terraform configuration for deploying a Weaviate vector database to power the SkillLibrary. The setup relies on the Helm provider so that the database can be installed in any Kubernetes cluster using a single `terraform apply`.
+
+## Prerequisites
+- A reachable Kubernetes cluster
+- `terraform` (>= 1.0)
+- Access credentials and kubeconfig path supplied via variables
+
+## Usage
+Run the following commands, supplying sensitive values via environment variables or `-var` flags:
+
+```bash
+terraform init
+terraform apply \
+  -var="kubeconfig=$KUBECONFIG" \
+  -var="namespace=ltm"
+```
+
+The service endpoint will be output after apply as `skilllib-vector-db.<namespace>.svc.cluster.local:8080`.
+
+Configure the LTM service to connect by setting the following environment variables:
+
+- `WEAVIATE_URL` – endpoint of the Weaviate instance.
+- `WEAVIATE_API_KEY` – API key if authentication is enabled (optional).
+
+### Configuration Variables
+- `storage_size` - Persistent volume size for data (default `10Gi`).
+- `api_key` - Optional admin API key for Weaviate.
+

--- a/infra/skill_library_vector_db/main.tf
+++ b/infra/skill_library_vector_db/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_version = ">= 1.0.0"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig
+  }
+}
+
+resource "helm_release" "skilllib_vector_db" {
+  name       = "skilllib-vector-db"
+  namespace  = var.namespace
+  repository = "https://weaviate.github.io/weaviate-helm"
+  chart      = "weaviate"
+  version    = var.weaviate_version
+
+  values = [
+    yamlencode({
+      persistence = {
+        enabled = true
+        size    = var.storage_size
+      }
+      env = merge({
+        QUERY_DEFAULTS_LIMIT = 20
+        DEFAULT_VECTORIZER_MODULE = "none"
+        DISABLE_TELEMETRY = "true"
+      }, var.api_key != "" ? {
+        AUTHENTICATION_APIKEY_ENABLED      = "true"
+        AUTHENTICATION_APIKEY_ALLOWED_KEYS = var.api_key
+        AUTHENTICATION_APIKEY_USERS        = "skilllib"
+      } : {})
+    })
+  ]
+}
+
+output "endpoint" {
+  value = "http://skilllib-vector-db.${var.namespace}.svc.cluster.local:8080"
+}

--- a/infra/skill_library_vector_db/variables.tf
+++ b/infra/skill_library_vector_db/variables.tf
@@ -1,0 +1,28 @@
+variable "kubeconfig" {
+  description = "Path to kubeconfig"
+  type        = string
+}
+
+variable "namespace" {
+  description = "Target namespace for the vector database"
+  type        = string
+  default     = "ltm"
+}
+
+variable "weaviate_version" {
+  description = "Helm chart version to deploy"
+  type        = string
+  default     = "17.4.5"
+}
+
+variable "storage_size" {
+  description = "Persistent volume size"
+  type        = string
+  default     = "10Gi"
+}
+
+variable "api_key" {
+  description = "Optional admin API key"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- add `infra/skill_library_vector_db` terraform module for Weaviate
- document key variables and usage

## Testing
- `pre-commit run --files infra/skill_library_vector_db/main.tf infra/skill_library_vector_db/variables.tf infra/skill_library_vector_db/README.md docs/architecture/skill_library_vector_store.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f47780eec832a8524862cf16b462d