### PR TITLE
Implement LTM snapshot query

### DIFF
--- a/agents/memory_manager.py
+++ b/agents/memory_manager.py
@@ -70,6 +70,19 @@ class MemoryManagerAgent:
         return []
 
     def _snapshot_query(self, valid_at: float, tx_at: float) -> List[Dict[str, Any]]:
+        if self.endpoint:
+            try:
+                resp = requests.get(
+                    f"{self.endpoint}/snapshot",
+                    params={"valid_at": valid_at, "tx_at": tx_at},
+                    headers={"X-Role": "viewer"},
+                    timeout=10,
+                )
+                resp.raise_for_status()
+                return resp.json().get("results", [])
+            except Exception:  # pragma: no cover - log only
+                logger.exception("snapshot query failed")
+                return []
         if self.ltm_service:
             try:
                 module = self.ltm_service._modules.get("semantic")

--- a/services/ltm_service/openapi_app.py
+++ b/services/ltm_service/openapi_app.py
@@ -19,6 +19,7 @@ except Exception:  # pragma: no cover - fallback for spec generation
         ("POST", "/temporal_consolidate"): {"editor"},
         ("POST", "/propagate_subgraph"): {"editor"},
         ("GET", "/memory"): {"viewer", "editor"},
+        ("GET", "/snapshot"): {"viewer", "editor"},
         # Deprecated paths kept for one release cycle
         ("POST", "/consolidate"): {"editor"},
         ("GET", "/retrieve"): {"viewer", "editor"},
@@ -235,6 +236,22 @@ def create_app(service: LTMService) -> FastAPI:
             coords,
             valid_from,
             valid_to,
+        )
+        return RetrieveResponse(results=results)
+
+    @app.get("/snapshot", summary="Retrieve spatio-temporal snapshot")
+    async def snapshot(
+        valid_at: float = Query(..., description="Valid time"),
+        tx_at: float = Query(..., description="Transaction time"),
+        x_role: str | None = Header(None),
+    ) -> RetrieveResponse:
+        role = x_role or ""
+        if not _check_role("GET", "/snapshot", role):
+            raise HTTPException(status_code=403, detail="forbidden")
+        results = await asyncio.to_thread(
+            service.get_snapshot,
+            valid_at,
+            tx_at,
         )
         return RetrieveResponse(results=results)
 

--- a/tests/services/test_api.py
+++ b/tests/services/test_api.py
@@ -122,6 +122,46 @@ def test_spatial_query_endpoint():
     assert results[0]["value"] == "v2"
 
 
+def test_snapshot_endpoint():
+    client, _ = _create_client()
+
+    data1 = {
+        "subject": "S",
+        "predicate": "P",
+        "object": "O",
+        "value": "v1",
+        "valid_from": 0,
+        "valid_to": 50,
+        "location": {"lat": 1, "lon": 1},
+    }
+    client.post("/temporal_consolidate", json=data1, headers={"X-Role": "editor"})
+
+    import time
+
+    time.sleep(0.05)
+
+    data2 = {
+        "subject": "S",
+        "predicate": "P",
+        "object": "O",
+        "value": "v2",
+        "valid_from": 50,
+        "valid_to": None,
+        "location": {"lat": 1.5, "lon": 1.5},
+    }
+    client.post("/temporal_consolidate", json=data2, headers={"X-Role": "editor"})
+
+    tx_at = time.time() - 0.025
+    resp = client.get(
+        "/snapshot",
+        params={"valid_at": 25, "tx_at": tx_at},
+        headers={"X-Role": "viewer"},
+    )
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert results and results[0]["value"] == "v1"
+
+
 def test_skill_endpoints():
     client, _ = _create_client()
 


### PR DESCRIPTION
## Summary
- add snapshot query method to LTM service
- expose `/snapshot` endpoint in the FastAPI and HTTP services
- extend MemoryManagerAgent to call the new endpoint
- cover snapshot retrieval in unit tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f533cd570832aa5a364f2c8c60f58