### PR TITLE
Enhance policy logging with hashes

### DIFF
--- a/tests/test_e2e_validation_suite.py
+++ b/tests/test_e2e_validation_suite.py
@@ -1,3 +1,6 @@
+import hashlib
+import json
+
 import pytest
 
 from agents.citation_agent import CitationAgent
@@ -86,6 +89,16 @@ def test_e2e_tool_governance_enforcement(caplog):
         registry.invoke("Researcher", "shell.exec", "rm -rf /")
 
     assert any(e["type"] == "tool" and not e["allowed"] for e in monitor.events)
+    event = monitor.events[0]
+    payload = {
+        "prev_hash": "0",
+        "type": "tool",
+        "role": "Researcher",
+        "tool": "shell.exec",
+        "allowed": False,
+    }
+    expected = hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+    assert event["hash"] == expected
 
     result = "task complete"
     assert result == "task complete"


### PR DESCRIPTION
## Summary
- ensure `PolicyMonitor` logs each decision with a SHA‑256 chain
- verify hashed records in safeguard integration tests
- test hashed denial events in e2e validation suite

## Testing
- `pre-commit run --files services/policy_monitor.py tests/test_safeguard_monitor.py tests/test_e2e_validation_suite.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa5f27be4832abfd039eeb9d026b5