### PR TITLE
Add pipeline overview doc

### DIFF
--- a/docs/pipelines_overview.md
+++ b/docs/pipelines_overview.md
@@ -1,0 +1,14 @@
+# Pipeline Overview
+
+This repository includes several small pipelines that generate training data, evaluate model outputs, and update agent policies. They are implemented under the `pipelines/` package and can be invoked via scripts in `scripts/`.
+
+1. **Teacher Data Generation** – `TeacherDataPipeline` prompts a large model to create self‑correction examples and saves them under `data/teacher_dataset/`.
+2. **Back Translation Augmentation** – `BackTranslationPipeline` introduces linguistic noise by translating the teacher data to another language and back.
+3. **Evaluator Fine‑Tuning** – `train_evaluator.py` fine‑tunes the Evaluator model on the synthetic error/correction pairs.
+4. **Judge Evaluation** – `JudgePipeline` scores research reports against `schemas/judge_rubric.json` and persists the results.
+5. **Reward Model Training** – `RewardModelTrainer` fits a simple linear model using the judged scores (and optional constitution labels).
+6. **Supervisor Policy Training** – `SupervisorPolicyTrainer` runs RLAIF with the reward model to refine the Supervisor's planning policy.
+7. **Multi‑Agent Fine‑Tuning** – `MultiAgentFinetunePipeline` fine‑tunes multiple agent policies in parallel using the same reward model.
+
+Each stage consumes artifacts from the previous steps and writes versioned outputs under `data/` or `models/`. Individual pipelines can also be composed in higher‑level workflows.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,9 @@ nav:
       - Communication Guidelines: docs/architecture/llm_grounded_guided_evolution.md
       - Auction Mechanisms: docs/usage/auction_mechanisms.md
 
+  - Pipelines:
+      - Overview: docs/pipelines_overview.md
+
   - Epics:
       - Interactive Agent Cockpit: docs/epics/interactive_agent_cockpit_epic.md
       - P4-12R – Address Outstanding Phase 3 Gaps: docs/epics/p4_12r_phase3_gap_closure_epic.md


### PR DESCRIPTION
## Summary
- document overall pipeline flow
- add the overview page to docs navigation
- build MkDocs site locally

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_688079fc96d4832a9af7ccbab6212e63