### PR TITLE
Implement dataset loader and tests

### DIFF
--- a/tests/unit/test_dataset_loader_util.py
+++ b/tests/unit/test_dataset_loader_util.py
@@ -1,0 +1,31 @@
+import json
+
+import pytest
+
+from tests.utils.dataset_loader import load_dataset
+
+
+def test_load_json_dataset(tmp_path):
+    data = [{"a": 1}, {"a": 2}]
+    f = tmp_path / "d.json"
+    f.write_text(json.dumps(data), encoding="utf-8")
+    loaded = load_dataset(f)
+    assert loaded == data
+
+
+def test_load_csv_dataset(tmp_path):
+    csv_text = "a,b\n1,2\n3,4\n"
+    f = tmp_path / "d.csv"
+    f.write_text(csv_text, encoding="utf-8")
+    loaded = load_dataset(f)
+    assert loaded == [
+        {"a": "1", "b": "2"},
+        {"a": "3", "b": "4"},
+    ]
+
+
+def test_unsupported_extension(tmp_path):
+    f = tmp_path / "d.txt"
+    f.write_text("hi", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_dataset(f)

--- a/tests/utils/dataset_loader.py
+++ b/tests/utils/dataset_loader.py
@@ -1,0 +1,24 @@
+import csv
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def load_dataset(path: str | Path) -> List[Dict[str, Any]]:
+    """Load evaluation dataset from ``path``.
+
+    Supports JSON and CSV files. Returns a list of dict records.
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise FileNotFoundError(p)
+    if p.suffix == ".json":
+        text = p.read_text(encoding="utf-8")
+        data = json.loads(text or "[]")
+        if not isinstance(data, list):
+            raise ValueError("JSON dataset must be a list of objects")
+        return data
+    if p.suffix == ".csv":
+        with p.open(newline="", encoding="utf-8") as f:
+            return [dict(row) for row in csv.DictReader(f)]
+    raise ValueError(f"Unsupported dataset format: {p.suffix}")


### PR DESCRIPTION
## Summary
- add a dataset loader utility under tests/utils
- unit test dataset loader for JSON and CSV

## Testing
- `pre-commit run --files tests/utils/dataset_loader.py tests/unit/test_dataset_loader_util.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880992e6a00832a94de3804800f6999