### PR TITLE
Add automatic tool plugin discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,10 @@ mytool = "my_package.tools:mytool"
 ```
 
 After installing the package, `create_default_registry()` auto-discovers the
-plugin and registers it. Configure permissions for the new tool in
-`services/tool_registry/config.yml` just like the built-in tools.
+plugin and registers it. The lightweight orchestrator adapters also scan this
+entry point group at startup so plugins become immediately available.
+Configure permissions for the new tool in `services/tool_registry/config.yml`
+just like the built-in tools.
 
 ## **8. Secrets Management**
 

--- a/tests/test_tool_adapters.py
+++ b/tests/test_tool_adapters.py
@@ -1,3 +1,4 @@
+from importlib import metadata, reload
 from unittest import mock
 
 from tools import adapters
@@ -10,3 +11,24 @@ def test_execute_dispatches():
     result = adapters.execute(call)
     fake.assert_called_once_with(query="ai")
     assert result == [{"url": "x"}]
+
+
+def dummy_plugin_tool():
+    return "plugin"
+
+
+def test_entrypoint_plugins_loaded(monkeypatch):
+    ep = metadata.EntryPoint(
+        name="dummy_plugin",
+        value="tests.test_tool_adapters:dummy_plugin_tool",
+        group="agentic_research_engine.tools",
+    )
+
+    def fake_entry_points(*args, **kwargs):  # pragma: no cover - deterministic
+        return [ep] if kwargs.get("group") == ep.group else []
+
+    monkeypatch.setattr(metadata, "entry_points", fake_entry_points)
+    reload(adapters)
+
+    call = adapters.ToolCall(name="dummy_plugin", args={})
+    assert adapters.execute(call) == "plugin"

--- a/tools/adapters.py
+++ b/tools/adapters.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 """Lightweight tool adapter interface."""
 
+import logging
 from dataclasses import dataclass
-from importlib import import_module
+from importlib import import_module, metadata
 from typing import Any, Callable, Dict
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_ENTRYPOINT_GROUP = "agentic_research_engine.tools"
 
 
 @dataclass
@@ -19,11 +24,29 @@ def _load(name: str) -> Callable[..., Any]:
     return getattr(module, func_name)
 
 
+def _discover_plugins() -> Dict[str, Callable[..., Any]]:
+    """Return callables exposed via the plugin entry point group."""
+    try:
+        eps = metadata.entry_points(group=PLUGIN_ENTRYPOINT_GROUP)
+    except TypeError:  # pragma: no cover - py < 3.10
+        eps = metadata.entry_points().get(PLUGIN_ENTRYPOINT_GROUP, [])  # type: ignore[attr-defined]
+
+    plugins: Dict[str, Callable[..., Any]] = {}
+    for ep in eps:
+        try:
+            plugins[ep.name] = ep.load()
+        except Exception:  # pragma: no cover - defensive
+            logger.warning("Failed to load plugin %s", ep.name, exc_info=True)
+    return plugins
+
+
 _REGISTRY: dict[str, Callable[..., Any]] = {
     "web.search": _load("web_search.web_search"),
     "pdf.reader": _load("pdf_reader.pdf_extract"),
     "python.exec": _load("code_interpreter.code_interpreter"),
 }
+
+_REGISTRY.update(_discover_plugins())
 
 
 def execute(call: ToolCall) -> Any:


### PR DESCRIPTION
## Summary
- load tool plugins from Python entry points when importing the adapter registry
- document automatic plugin loading in README
- test adapter plugin discovery

## Testing
- `pre-commit run --files tools/adapters.py tests/test_tool_adapters.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a3a35798832a8599efecea837128