### PR TITLE
Add mocked web research test

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -51,6 +51,7 @@ class BaseAgent:
         input_tokens: int | None = None,
         output_tokens: int | None = None,
         latency_ms: float | None = None,
+        tool_input: Any | None = None,
     ) -> None:
         """Record a tool invocation in the procedure and emit a trace span."""
         self._procedure.append({"action": name, "args": args, "kwargs": kwargs})
@@ -58,7 +59,9 @@ class BaseAgent:
             agent_id=agent_id,
             agent_role=self.role,
             tool_name=name,
-            tool_input={"args": args, "kwargs": kwargs},
+            tool_input=tool_input
+            if tool_input is not None
+            else {"args": args, "kwargs": kwargs},
             tool_output=result,
             input_tokens=input_tokens,
             output_tokens=output_tokens,


### PR DESCRIPTION
## Summary
- update `BaseAgent._log_tool` to accept a `tool_input` argument
- mock HTML/PDF HTTP requests in WebResearcher tests
- ensure the node invocation passes scratchpad

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880aca62f44832ab7ebf992d0a42d16