### PR TITLE
Add additional unit tests to core suite

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = tests/test_smoke.py
+addopts = tests/test_smoke.py tests/unit/test_dataset_loader_util.py tests/unit/test_edge_metadata.py
 markers =
     core: lightweight core tests for local development
     integration: heavier integration tests

--- a/scripts/run_core_tests.sh
+++ b/scripts/run_core_tests.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-# Run a minimal smoke test
-pytest tests/test_smoke.py -q "${@}"
+# Run the lightweight core test suite
+pytest -q


### PR DESCRIPTION
## Summary
- expand pytest default addopts to include unit tests
- run core tests via script without file args

## Testing
- `pre-commit run --files pytest.ini tests/unit/test_dataset_loader_util.py tests/unit/test_edge_metadata.py tests/test_smoke.py scripts/run_core_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688210035314832a8b33f620721bd418